### PR TITLE
chore(teamcity): finalize CI runtime parameters

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -9,7 +9,17 @@ project {
 
     params {
         param("android.sdk.path", "C:\\Users\\mmate\\AppData\\Local\\Android\\Sdk")
+        param("teamcity.activeBuildBranch.age.hours", "0")
         password("figma.file.content.access.token", "credentialsJSON:56b32d27-92ba-4f95-8a34-f4e24067105a")
+    }
+
+    cleanup {
+        baseRule {
+            artifacts(days = 7)
+            history(days = 14)
+            all(days = 30)
+            preventDependencyCleanup = false
+        }
     }
 
     pipeline(WaterMyPlantsCi)

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -5,6 +5,8 @@ import jetbrains.buildServer.configs.kotlin.pipelines.PipelineCompatible
 version = "2026.1"
 
 project {
+    vcsRoot(WaterMyPlantsRepository)
+
     params {
         param("android.sdk.path", "C:\\Users\\mmate\\AppData\\Local\\Android\\Sdk")
         password("figma.file.content.access.token", "credentialsJSON:56b32d27-92ba-4f95-8a34-f4e24067105a")
@@ -18,7 +20,7 @@ object WaterMyPlantsCi : Pipeline({
     name = "CI"
 
     repositories {
-        repository(DslContext.settingsRoot)
+        repository(WaterMyPlantsRepository)
     }
 
     triggers {
@@ -77,6 +79,22 @@ object WaterMyPlantsCi : Pipeline({
 
         dependency("generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
     }
+})
+
+object WaterMyPlantsRepository : VcsRoot({
+    id("WaterMyPlantsRepository")
+    name = "water-my-plants GitHub repository"
+    type = "jetbrains.git"
+
+    param("url", "https://github.com/marmatsan/water-my-plants.git")
+    param("branch", "refs/heads/main")
+    param(
+        "branchSpec",
+        """
+        +:refs/heads/*
+        +:refs/pull/*/head
+        """.trimIndent()
+    )
 })
 
 open class PipelineScriptStep(init: PipelineScriptStep.() -> Unit = {}) : BuildStep(), PipelineCompatible {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -5,6 +5,10 @@ import jetbrains.buildServer.configs.kotlin.pipelines.PipelineCompatible
 version = "2026.1"
 
 project {
+    params {
+        password("figma.file.content.access.token", "credentialsJSON:56b32d27-92ba-4f95-8a34-f4e24067105a")
+    }
+
     pipeline(WaterMyPlantsCi)
 }
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -6,6 +6,7 @@ version = "2026.1"
 
 project {
     params {
+        param("android.sdk.path", "C:\\Users\\mmate\\AppData\\Local\\Android\\Sdk")
         password("figma.file.content.access.token", "credentialsJSON:56b32d27-92ba-4f95-8a34-f4e24067105a")
     }
 
@@ -27,6 +28,8 @@ object WaterMyPlantsCi : Pipeline({
     }
 
     params {
+        param("env.ANDROID_HOME", "%android.sdk.path%")
+        param("env.ANDROID_SDK_ROOT", "%android.sdk.path%")
         param("env.FIGMA_FILE_CONTENT_ACCESS_TOKEN", "%figma.file.content.access.token%")
     }
 


### PR DESCRIPTION
## What changed

- Declares `figma.file.content.access.token` as a TeamCity secure password parameter in `.teamcity/settings.kts`.
- Exposes the local Android SDK path as `ANDROID_HOME` and `ANDROID_SDK_ROOT` for CI jobs.

## Why

The TeamCity pipeline needs all runtime parameters declared in versioned settings so PR builds can run on the local Windows agent from a clean checkout.

## Validation

- `./mvnw.cmd -f .teamcity/pom.xml teamcity-configs:generate`
- `./gradlew.bat check` with `ANDROID_HOME` and `ANDROID_SDK_ROOT` set to the same SDK path used by TeamCity