### PR TITLE
docs(teamcity): document versioned settings workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp
 
 # TeamCity DSL local generation output
 .teamcity/target/
+teamcity.toml
 
 # Cucumber+ IDE plugin generated files
 **/.cucumber+/

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -85,16 +85,19 @@ In TeamCity 2026.1.2, the virtual jobs generated from this Kotlin DSL pipeline
 did not materialize that default checkout in our setup: job logs showed a fresh
 checkout directory followed immediately by the script step, and `gradlew.bat`
 was missing. Until the native checkout behavior is reliable, each Gradle step
-uses a shared script helper that fetches the exact TeamCity-selected revision:
+uses a shared script helper that fetches the selected TeamCity branch:
 
 ```kotlin
-set "WMP_REVISION=%build.vcs.number.WaterMyPlants_GitHub%"
+set "WMP_BRANCH=%teamcity.build.branch%"
+if "%WMP_BRANCH%"=="<default>" set "WMP_BRANCH=main"
 git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*"
-git checkout --force "%WMP_REVISION%"
+git checkout --force "origin/%WMP_BRANCH%" || git checkout --force "origin/pull/%WMP_BRANCH%"
 ```
 
-This keeps the job on the same commit that TeamCity selected for the pipeline
-branch while avoiding a manual branch-name reconstruction in the script.
+Do not use `%build.vcs.number.WaterMyPlants_GitHub%` inside job script content.
+The virtual jobs do not have that VCS root attached, so TeamCity treats the
+parameter as unresolved during agent compatibility checks and reports `No
+compatible agent`.
 
 Avoid job-level repository blocks unless a job needs a different checkout
 layout. TeamCity can generate pipeline YAML that references `WaterMyPlants_GitHub`

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -88,16 +88,21 @@ was missing. Until the native checkout behavior is reliable, each Gradle step
 uses a shared script helper that fetches the selected TeamCity branch:
 
 ```kotlin
+setlocal EnableExtensions EnableDelayedExpansion
 set "WMP_BRANCH=%teamcity.build.branch%"
-if "%WMP_BRANCH%"=="<default>" set "WMP_BRANCH=main"
+if "!WMP_BRANCH!"=="<default>" set "WMP_BRANCH=main"
 git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*"
-git checkout --force "origin/%WMP_BRANCH%" || git checkout --force "origin/pull/%WMP_BRANCH%"
+git checkout --force "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!"
 ```
 
 Do not use `%build.vcs.number.WaterMyPlants_GitHub%` inside job script content.
 The virtual jobs do not have that VCS root attached, so TeamCity treats the
 parameter as unresolved during agent compatibility checks and reports `No
 compatible agent`.
+
+For local Windows batch variables, use delayed expansion (`!WMP_BRANCH!`) rather
+than `%WMP_BRANCH%`. TeamCity treats `%...%` as a TeamCity parameter reference
+before the job starts, so `%WMP_BRANCH%` also makes the job incompatible.
 
 Avoid job-level repository blocks unless a job needs a different checkout
 layout. TeamCity can generate pipeline YAML that references `WaterMyPlants_GitHub`

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -42,17 +42,19 @@ the fix belongs in `.teamcity/settings.kts`, not in the pipeline editor.
 
 ## Pipeline Repository
 
-Use the versioned settings root as the pipeline repository:
+Use the existing project VCS root as the pipeline repository by absolute id:
 
 ```kotlin
 repositories {
-    repository(DslContext.settingsRoot)
+    repository(AbsoluteId("WaterMyPlants_GitHub"))
 }
 ```
 
-The project settings and source code live in the same GitHub repository, and TeamCity binds the Pipeline UI branch selector to the settings root. A duplicate Git VCS root with the same URL can make the pipeline show a feature/chore branch while individual jobs still checkout that duplicate root from `main`.
+The project settings and source code live in the same GitHub repository. The repository configured in TeamCity as `water-my-plants` is the root that the Pipeline UI resolves to the selected branch.
 
-Do not add a second VCS root for this repository unless the build intentionally needs a separate checkout.
+Do not create a second Git VCS root with the same URL. A duplicate root can make the pipeline show a feature/chore branch while individual jobs still checkout `main`.
+
+Do not use `DslContext.settingsRoot` as the job checkout repository. It is the settings root, and TeamCity can apply settings-path checkout rules such as `.teamcity`; jobs need the full repository to run `gradlew.bat`.
 
 ## Pipeline Job Reuse
 
@@ -94,7 +96,7 @@ Generated files are written to:
 .teamcity/target/generated-configs
 ```
 
-The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For this project, the pipeline should point to `SettingsRootId` so branch builds checkout the same repository branch selected in the Pipeline UI.
+The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For this project, the pipeline head should reference `WaterMyPlants_GitHub` and should not emit a duplicate VCS root for `https://github.com/marmatsan/water-my-plants.git`.
 
 ## Clean-up Rules
 

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -64,11 +64,12 @@ object GitHub : VcsRoot({
 })
 ```
 
-Then reference that same object from the pipeline and every job:
+Then reference that same object once from the pipeline and keep it enabled by
+default:
 
 ```kotlin
 repositories {
-    repository(GitHub)
+    repository(GitHub, enabledByDefault = true)
 }
 ```
 
@@ -77,14 +78,13 @@ TeamCity, the local DSL id `GitHub` is materialized under the project id as
 `WaterMyPlants_GitHub`, which is the root that the Pipeline UI resolves to the
 selected branch.
 
-Without a job-level repository, the top-level Pipeline Head can resolve the
-branch correctly while virtual jobs start with an empty checkout directory and
-fail because `gradlew.bat` is missing.
+This is the repository that TeamCity should automatically checkout for every
+job.
 
-Do not reference `AbsoluteId("WaterMyPlants_GitHub")` directly from job
-repository blocks. TeamCity can generate pipeline YAML that references
-`WaterMyPlants_GitHub` without registering that repository in the pipeline
-model, which fails at runtime with:
+Avoid job-level repository blocks unless a job needs a different checkout
+layout. TeamCity can generate pipeline YAML that references `WaterMyPlants_GitHub`
+from a job without making that repository available to the pipeline generator,
+which fails at runtime with:
 
 ```text
 Repository referenced by WaterMyPlants_GitHub not found

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -42,7 +42,7 @@ the fix belongs in `.teamcity/settings.kts`, not in the pipeline editor.
 
 ## Pipeline Repository
 
-Do not use the versioned settings root as the pipeline repository:
+Use the versioned settings root as the pipeline repository:
 
 ```kotlin
 repositories {
@@ -50,34 +50,9 @@ repositories {
 }
 ```
 
-That makes TeamCity generate the pipeline against `SettingsRootId`.
+The project settings and source code live in the same GitHub repository, and TeamCity binds the Pipeline UI branch selector to the settings root. A duplicate Git VCS root with the same URL can make the pipeline show a feature/chore branch while individual jobs still checkout that duplicate root from `main`.
 
-Use an explicit Git VCS root for the project repository instead:
-
-```kotlin
-vcsRoot(WaterMyPlantsRepository)
-
-repositories {
-    repository(WaterMyPlantsRepository)
-}
-```
-
-This makes the generated pipeline settings point to the project repository VCS root, which is required before repository status publication can work correctly.
-
-The repository branch specification must not silently fall back to `main` for branch builds:
-
-```kotlin
-param(
-    "branchSpec",
-    """
-    #! fallbackToDefault: false
-    +:refs/heads/(*)
-    +:refs/pull/(*/head)
-    """.trimIndent()
-)
-```
-
-The explicit logical branch name keeps this VCS root aligned with the branch selected in the Pipeline UI. The fallback guard turns a branch-resolution mistake into an obvious configuration failure instead of running the Figma gate against `main`.
+Do not add a second VCS root for this repository unless the build intentionally needs a separate checkout.
 
 ## Pipeline Job Reuse
 
@@ -119,7 +94,7 @@ Generated files are written to:
 .teamcity/target/generated-configs
 ```
 
-The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For example, it can confirm whether the pipeline still points to `SettingsRootId` or to the intended repository VCS root.
+The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For this project, the pipeline should point to `SettingsRootId` so branch builds checkout the same repository branch selected in the Pipeline UI.
 
 ## Clean-up Rules
 

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -42,25 +42,53 @@ the fix belongs in `.teamcity/settings.kts`, not in the pipeline editor.
 
 ## Pipeline Repository
 
-Use the existing project VCS root as the pipeline repository by absolute id:
+Declare the project VCS root in `.teamcity/settings.kts` with the local id
+`GitHub`:
+
+```kotlin
+object GitHub : VcsRoot({
+    id("GitHub")
+    name = "water-my-plants"
+    type = "jetbrains.git"
+
+    param("url", "https://github.com/marmatsan/water-my-plants.git")
+    param("branch", "refs/heads/main")
+    param(
+        "branchSpec",
+        """
+        #! fallbackToDefault: false
+        +:refs/heads/(*)
+        +:refs/pull/(*/head)
+        """.trimIndent()
+    )
+})
+```
+
+Then reference that same object from the pipeline and every job:
 
 ```kotlin
 repositories {
-    repository(AbsoluteId("WaterMyPlants_GitHub"))
+    repository(GitHub)
 }
 ```
 
-The project settings and source code live in the same GitHub repository. The repository configured in TeamCity as `water-my-plants` is the root that the Pipeline UI resolves to the selected branch.
+The project settings and source code live in the same GitHub repository. In
+TeamCity, the local DSL id `GitHub` is materialized under the project id as
+`WaterMyPlants_GitHub`, which is the root that the Pipeline UI resolves to the
+selected branch.
 
-Declare the same repository explicitly in every job:
+Without a job-level repository, the top-level Pipeline Head can resolve the
+branch correctly while virtual jobs start with an empty checkout directory and
+fail because `gradlew.bat` is missing.
 
-```kotlin
-repositories {
-    repository(AbsoluteId("WaterMyPlants_GitHub"))
-}
+Do not reference `AbsoluteId("WaterMyPlants_GitHub")` directly from job
+repository blocks. TeamCity can generate pipeline YAML that references
+`WaterMyPlants_GitHub` without registering that repository in the pipeline
+model, which fails at runtime with:
+
+```text
+Repository referenced by WaterMyPlants_GitHub not found
 ```
-
-Without this, the top-level Pipeline Head can resolve the branch correctly while virtual jobs start with an empty checkout directory and fail because `gradlew.bat` is missing.
 
 Do not create a second Git VCS root with the same URL. A duplicate root can make the pipeline show a feature/chore branch while individual jobs still checkout `main`.
 

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -64,6 +64,21 @@ repositories {
 
 This makes the generated pipeline settings point to the project repository VCS root, which is required before repository status publication can work correctly.
 
+The repository branch specification must not silently fall back to `main` for branch builds:
+
+```kotlin
+param(
+    "branchSpec",
+    """
+    #! fallbackToDefault: false
+    +:refs/heads/(*)
+    +:refs/pull/(*/head)
+    """.trimIndent()
+)
+```
+
+The explicit logical branch name keeps this VCS root aligned with the branch selected in the Pipeline UI. The fallback guard turns a branch-resolution mistake into an obvious configuration failure instead of running the Figma gate against `main`.
+
 ## Pipeline Job Reuse
 
 Pipeline jobs must keep reuse disabled:

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -52,6 +52,16 @@ repositories {
 
 The project settings and source code live in the same GitHub repository. The repository configured in TeamCity as `water-my-plants` is the root that the Pipeline UI resolves to the selected branch.
 
+Declare the same repository explicitly in every job:
+
+```kotlin
+repositories {
+    repository(AbsoluteId("WaterMyPlants_GitHub"))
+}
+```
+
+Without this, the top-level Pipeline Head can resolve the branch correctly while virtual jobs start with an empty checkout directory and fail because `gradlew.bat` is missing.
+
 Do not create a second Git VCS root with the same URL. A duplicate root can make the pipeline show a feature/chore branch while individual jobs still checkout `main`.
 
 Do not use `DslContext.settingsRoot` as the job checkout repository. It is the settings root, and TeamCity can apply settings-path checkout rules such as `.teamcity`; jobs need the full repository to run `gradlew.bat`.

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -56,6 +56,44 @@ Do not create a second Git VCS root with the same URL. A duplicate root can make
 
 Do not use `DslContext.settingsRoot` as the job checkout repository. It is the settings root, and TeamCity can apply settings-path checkout rules such as `.teamcity`; jobs need the full repository to run `gradlew.bat`.
 
+When this is working, the generated Pipeline Head contains:
+
+```xml
+<vcs-entry-ref root-id="WaterMyPlants_GitHub" />
+```
+
+and the pipeline run log for a branch build reports:
+
+```text
+VCS revisions: 'WaterMyPlants_GitHub' ... refs/heads/chore/teamcity-settings
+```
+
+If the log reports `WaterMyPlants_WaterMyPlantsRepository` or a revision from `refs/heads/main` while the Pipeline UI shows a chore/feature branch, TeamCity is using the wrong checkout root.
+
+## Pipeline Runs and Job Logs
+
+The top-level Pipeline build is composite. It aggregates job results and may fail with:
+
+```text
+Build chain finished (failed: 3)
+```
+
+That log does not show the actual Gradle failure. Debug the child jobs instead:
+
+```text
+Verify
+Generate design model
+Check Figma trunk sync
+```
+
+The expected Figma gate failure for an unsynchronized branch mentions that branch name:
+
+```text
+Figma is out of sync with chore/teamcity-settings
+```
+
+If it says `Figma is out of sync with main`, the job checked out `main` and the pipeline checkout configuration is wrong.
+
 ## Pipeline Job Reuse
 
 Pipeline jobs must keep reuse disabled:

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -64,6 +64,16 @@ repositories {
 
 This makes the generated pipeline settings point to the project repository VCS root, which is required before repository status publication can work correctly.
 
+## Pipeline Job Reuse
+
+Pipeline jobs must keep reuse disabled:
+
+```kotlin
+allowReuse = false
+```
+
+This prevents TeamCity from satisfying a branch or pull request pipeline with a previously successful job from `main`. The Figma gate depends on the exact `design-model.json` generated for the same branch revision, so `verify`, `generate_design_model`, and `check_figma_trunk_sync` must all run in the same pipeline chain for the selected branch.
+
 ## Secure Parameters
 
 Secrets are declared in DSL only by TeamCity credential references, never by raw secret values.

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -92,7 +92,7 @@ setlocal EnableExtensions EnableDelayedExpansion
 set "WMP_BRANCH=%teamcity.build.branch%"
 if "!WMP_BRANCH!"=="<default>" set "WMP_BRANCH=main"
 git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*"
-git checkout --force "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!"
+git checkout --force -B "!WMP_BRANCH!" "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!"
 ```
 
 Do not use `%build.vcs.number.WaterMyPlants_GitHub%` inside job script content.
@@ -196,6 +196,94 @@ Generated files are written to:
 ```
 
 The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For this project, the pipeline head should reference `WaterMyPlants_GitHub` and should not emit a duplicate VCS root for `https://github.com/marmatsan/water-my-plants.git`.
+
+## TeamCity CLI
+
+Use the TeamCity CLI for local diagnostics and repeatable pipeline runs. It does
+not replace `.teamcity/settings.kts`; it is a client for validating settings,
+querying TeamCity, and starting builds.
+
+The CLI is configured locally through `teamcity.toml` at the repository root:
+
+```toml
+[[server]]
+url = 'http://localhost:8111'
+project = 'WaterMyPlants'
+job = 'WaterMyPlants_WaterMyPlantsCi'
+```
+
+Keep `teamcity.toml` out of Git. It points to a developer-local TeamCity server
+and is ignored by `.gitignore`.
+
+Authenticate the CLI with a TeamCity access token:
+
+```powershell
+teamcity auth login --server http://localhost:8111 --token <token>
+teamcity auth status
+```
+
+The local TeamCity server currently uses HTTP, so the CLI prints an insecure
+connection warning. That is expected for the localhost setup. Do not paste the
+token into source files, shell scripts, or docs.
+
+Bind the current checkout to the TeamCity project and default pipeline if the
+local `teamcity.toml` is missing:
+
+```powershell
+teamcity link --server http://localhost:8111 --project WaterMyPlants --job WaterMyPlants_WaterMyPlantsCi --scope=
+```
+
+Validate versioned settings from the CLI when `mvn` is available on `PATH`:
+
+```powershell
+teamcity project settings validate .teamcity --verbose
+```
+
+On Windows with TeamCity CLI 1.2.1, the CLI does not use the Maven Wrapper from
+the repository root for a `.teamcity` DSL directory. Keep a single Maven Wrapper
+at the repository root and expose its downloaded Maven 3.9.16 distribution for
+CLI validation:
+
+```powershell
+$mavenBin = Get-ChildItem "$env:USERPROFILE\.m2\wrapper\dists\apache-maven-3.9.16-bin" -Recurse -Filter mvn.cmd | Select-Object -First 1 -ExpandProperty DirectoryName
+$env:PATH = "$mavenBin;$env:PATH"
+teamcity project settings validate .teamcity --verbose
+```
+
+Check versioned settings synchronization:
+
+```powershell
+teamcity project settings status WaterMyPlants
+```
+
+Run the linked CI pipeline for the current Git branch:
+
+```powershell
+teamcity run start --branch '@this' --revision '@head' --watch
+```
+
+Quote `@this` and `@head` in PowerShell. Without quotes, PowerShell can treat
+`@...` as syntax instead of passing the literal value to the CLI.
+
+Useful diagnostics after a run:
+
+```powershell
+teamcity run tree <run-id>
+teamcity run view <run-id>
+teamcity run changes <run-id>
+teamcity run log <job-run-id> --tail 120 --raw
+teamcity run log <job-run-id> --failed --raw
+teamcity run artifacts <job-run-id>
+```
+
+The top-level pipeline run is composite. Use `teamcity run tree <run-id>` to get
+the child job run ids for `Verify`, `Generate design model`, and `Check Figma
+trunk sync`, then inspect the failing child job log.
+
+Do not rely on `--local-changes` unless the access token has the TeamCity
+permission `Change build source code with a custom patch`. The normal workflow
+is to commit and push the branch, then run the pipeline against that branch
+revision.
 
 ## Clean-up Rules
 

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -1,0 +1,122 @@
+# TeamCity Versioned Settings
+
+This directory is the source of truth for TeamCity project settings.
+
+## Branching Workflow
+
+Every change to `.teamcity/settings.kts` must be made on the short-lived branch:
+
+```text
+chore/teamcity-settings
+```
+
+Create or recreate the branch from the latest `main`, keep the change focused on TeamCity settings, open a pull request back to `main`, and delete the branch after the merge.
+
+Do not push TeamCity settings changes directly to `main`.
+
+## How TeamCity Processes These Settings
+
+TeamCity loads the current project configuration from the default branch of the versioned settings VCS root. For this repository, that branch is `main`.
+
+Branch builds can use branch-local settings when the project is configured with:
+
+```text
+When build starts: use settings from VCS
+```
+
+That setting allows a build in a feature or chore branch to run with the `.teamcity/settings.kts` from that branch. It does not mean the TeamCity project UI immediately switches to that branch configuration. The stable project configuration shown in the UI is updated after the settings are merged to `main` and TeamCity reloads versioned settings.
+
+`Load project settings from VCS` is a manual resync tool. It should not be required for every change once polling or webhooks detect new commits, but it is useful while bootstrapping the setup or recovering from a stopped synchronization.
+
+## UI Editing
+
+Project editing through the TeamCity UI is disabled because settings are stored in VCS.
+
+TeamCity Pipelines defined in Kotlin DSL are also read-only in the UI. If TeamCity reports:
+
+```text
+pipelines cannot be edited in UI, edit Kotlin DSL files instead
+```
+
+the fix belongs in `.teamcity/settings.kts`, not in the pipeline editor.
+
+## Pipeline Repository
+
+Do not use the versioned settings root as the pipeline repository:
+
+```kotlin
+repositories {
+    repository(DslContext.settingsRoot)
+}
+```
+
+That makes TeamCity generate the pipeline against `SettingsRootId`.
+
+Use an explicit Git VCS root for the project repository instead:
+
+```kotlin
+vcsRoot(WaterMyPlantsRepository)
+
+repositories {
+    repository(WaterMyPlantsRepository)
+}
+```
+
+This makes the generated pipeline settings point to the project repository VCS root, which is required before repository status publication can work correctly.
+
+## Secure Parameters
+
+Secrets are declared in DSL only by TeamCity credential references, never by raw secret values.
+
+Example:
+
+```kotlin
+password("figma.file.content.access.token", "credentialsJSON:...")
+```
+
+The pipeline maps the secure project parameter to the build environment:
+
+```kotlin
+param("env.FIGMA_FILE_CONTENT_ACCESS_TOKEN", "%figma.file.content.access.token%")
+```
+
+## Local Validation
+
+Validate TeamCity settings before pushing:
+
+```powershell
+.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate
+```
+
+Generated files are written to:
+
+```text
+.teamcity/target/generated-configs
+```
+
+The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For example, it can confirm whether the pipeline still points to `SettingsRootId` or to the intended repository VCS root.
+
+## Clean-up Rules
+
+Clean-up rules are also project settings and must be changed in `.teamcity/settings.kts`.
+
+The current project cleanup policy is:
+
+```kotlin
+cleanup {
+    baseRule {
+        artifacts(days = 7)
+        history(days = 14)
+        all(days = 30)
+        preventDependencyCleanup = false
+    }
+}
+```
+
+The project also sets:
+
+```kotlin
+param("teamcity.activeBuildBranch.age.hours", "0")
+```
+
+This prevents closed branches with old builds from staying visible as active branches for the default 24-hour window.

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -81,6 +81,21 @@ selected branch.
 This is the repository that TeamCity should automatically checkout for every
 job.
 
+In TeamCity 2026.1.2, the virtual jobs generated from this Kotlin DSL pipeline
+did not materialize that default checkout in our setup: job logs showed a fresh
+checkout directory followed immediately by the script step, and `gradlew.bat`
+was missing. Until the native checkout behavior is reliable, each Gradle step
+uses a shared script helper that fetches the exact TeamCity-selected revision:
+
+```kotlin
+set "WMP_REVISION=%build.vcs.number.WaterMyPlants_GitHub%"
+git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*"
+git checkout --force "%WMP_REVISION%"
+```
+
+This keeps the job on the same commit that TeamCity selected for the pipeline
+branch while avoiding a manual branch-name reconstruction in the script.
+
 Avoid job-level repository blocks unless a job needs a different checkout
 layout. TeamCity can generate pipeline YAML that references `WaterMyPlants_GitHub`
 from a job without making that repository available to the pipeline generator,

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -97,15 +97,16 @@ object WaterMyPlantsCi : Pipeline({
 object GradleScripts {
     fun gradle(tasks: String): String =
         """
+        setlocal EnableExtensions EnableDelayedExpansion
         set "WMP_BRANCH=%teamcity.build.branch%"
-        if "%WMP_BRANCH%"=="<default>" set "WMP_BRANCH=main"
-        if "%WMP_BRANCH%"=="" set "WMP_BRANCH=main"
+        if "!WMP_BRANCH!"=="<default>" set "WMP_BRANCH=main"
+        if "!WMP_BRANCH!"=="" set "WMP_BRANCH=main"
 
         if not exist ".git" git init || exit /b 1
         git remote remove origin 2>NUL
         git remote add origin https://github.com/marmatsan/water-my-plants.git || exit /b 1
         git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*" || exit /b 1
-        git checkout --force "origin/%WMP_BRANCH%" || git checkout --force "origin/pull/%WMP_BRANCH%" || exit /b 1
+        git checkout --force "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!" || exit /b 1
 
         .\gradlew.bat $tasks
         """.trimIndent()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -5,8 +5,6 @@ import jetbrains.buildServer.configs.kotlin.pipelines.PipelineCompatible
 version = "2026.1"
 
 project {
-    vcsRoot(WaterMyPlantsRepository)
-
     params {
         param("android.sdk.path", "C:\\Users\\mmate\\AppData\\Local\\Android\\Sdk")
         param("teamcity.activeBuildBranch.age.hours", "0")
@@ -30,7 +28,7 @@ object WaterMyPlantsCi : Pipeline({
     name = "CI"
 
     repositories {
-        repository(WaterMyPlantsRepository)
+        repository(DslContext.settingsRoot)
     }
 
     triggers {
@@ -92,23 +90,6 @@ object WaterMyPlantsCi : Pipeline({
 
         dependency("generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
     }
-})
-
-object WaterMyPlantsRepository : VcsRoot({
-    id("WaterMyPlantsRepository")
-    name = "water-my-plants GitHub repository"
-    type = "jetbrains.git"
-
-    param("url", "https://github.com/marmatsan/water-my-plants.git")
-    param("branch", "refs/heads/main")
-    param(
-        "branchSpec",
-        """
-        #! fallbackToDefault: false
-        +:refs/heads/(*)
-        +:refs/pull/(*/head)
-        """.trimIndent()
-    )
 })
 
 open class PipelineScriptStep(init: PipelineScriptStep.() -> Unit = {}) : BuildStep(), PipelineCompatible {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -97,13 +97,15 @@ object WaterMyPlantsCi : Pipeline({
 object GradleScripts {
     fun gradle(tasks: String): String =
         """
-        set "WMP_REVISION=%build.vcs.number.WaterMyPlants_GitHub%"
+        set "WMP_BRANCH=%teamcity.build.branch%"
+        if "%WMP_BRANCH%"=="<default>" set "WMP_BRANCH=main"
+        if "%WMP_BRANCH%"=="" set "WMP_BRANCH=main"
 
         if not exist ".git" git init || exit /b 1
         git remote remove origin 2>NUL
         git remote add origin https://github.com/marmatsan/water-my-plants.git || exit /b 1
         git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*" || exit /b 1
-        git checkout --force "%WMP_REVISION%" || exit /b 1
+        git checkout --force "origin/%WMP_BRANCH%" || git checkout --force "origin/pull/%WMP_BRANCH%" || exit /b 1
 
         .\gradlew.bat $tasks
         """.trimIndent()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -5,6 +5,8 @@ import jetbrains.buildServer.configs.kotlin.pipelines.PipelineCompatible
 version = "2026.1"
 
 project {
+    vcsRoot(GitHub)
+
     params {
         param("android.sdk.path", "C:\\Users\\mmate\\AppData\\Local\\Android\\Sdk")
         param("teamcity.activeBuildBranch.age.hours", "0")
@@ -28,7 +30,7 @@ object WaterMyPlantsCi : Pipeline({
     name = "CI"
 
     repositories {
-        repository(AbsoluteId("WaterMyPlants_GitHub"))
+        repository(GitHub)
     }
 
     triggers {
@@ -49,7 +51,7 @@ object WaterMyPlantsCi : Pipeline({
         allowReuse = false
 
         repositories {
-            repository(AbsoluteId("WaterMyPlants_GitHub"))
+            repository(GitHub)
         }
 
         steps {
@@ -66,7 +68,7 @@ object WaterMyPlantsCi : Pipeline({
         allowReuse = false
 
         repositories {
-            repository(AbsoluteId("WaterMyPlants_GitHub"))
+            repository(GitHub)
         }
 
         steps {
@@ -90,7 +92,7 @@ object WaterMyPlantsCi : Pipeline({
         allowReuse = false
 
         repositories {
-            repository(AbsoluteId("WaterMyPlants_GitHub"))
+            repository(GitHub)
         }
 
         steps {
@@ -102,6 +104,23 @@ object WaterMyPlantsCi : Pipeline({
 
         dependency("generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
     }
+})
+
+object GitHub : VcsRoot({
+    id("GitHub")
+    name = "water-my-plants"
+    type = "jetbrains.git"
+
+    param("url", "https://github.com/marmatsan/water-my-plants.git")
+    param("branch", "refs/heads/main")
+    param(
+        "branchSpec",
+        """
+        #! fallbackToDefault: false
+        +:refs/heads/(*)
+        +:refs/pull/(*/head)
+        """.trimIndent()
+    )
 })
 
 open class PipelineScriptStep(init: PipelineScriptStep.() -> Unit = {}) : BuildStep(), PipelineCompatible {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -104,8 +104,9 @@ object WaterMyPlantsRepository : VcsRoot({
     param(
         "branchSpec",
         """
-        +:refs/heads/*
-        +:refs/pull/*/head
+        #! fallbackToDefault: false
+        +:refs/heads/(*)
+        +:refs/pull/(*/head)
         """.trimIndent()
     )
 })

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,7 +53,7 @@ object WaterMyPlantsCi : Pipeline({
         steps {
             step(PipelineScriptStep {
                 name = "Run Gradle check"
-                scriptContent = ".\\gradlew.bat check"
+                scriptContent = GradleScripts.gradle("check")
             })
         }
     }
@@ -66,7 +66,7 @@ object WaterMyPlantsCi : Pipeline({
         steps {
             step(PipelineScriptStep {
                 name = "Generate Figma design model"
-                scriptContent = ".\\gradlew.bat generateFigmaDesignModel"
+                scriptContent = GradleScripts.gradle("generateFigmaDesignModel")
             })
         }
 
@@ -86,13 +86,28 @@ object WaterMyPlantsCi : Pipeline({
         steps {
             step(PipelineScriptStep {
                 name = "Verify Figma sync metadata"
-                scriptContent = ".\\gradlew.bat checkFigmaTrunkSync"
+                scriptContent = GradleScripts.gradle("checkFigmaTrunkSync")
             })
         }
 
         dependency("generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
     }
 })
+
+object GradleScripts {
+    fun gradle(tasks: String): String =
+        """
+        set "WMP_REVISION=%build.vcs.number.WaterMyPlants_GitHub%"
+
+        if not exist ".git" git init || exit /b 1
+        git remote remove origin 2>NUL
+        git remote add origin https://github.com/marmatsan/water-my-plants.git || exit /b 1
+        git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*" || exit /b 1
+        git checkout --force "%WMP_REVISION%" || exit /b 1
+
+        .\gradlew.bat $tasks
+        """.trimIndent()
+}
 
 object GitHub : VcsRoot({
     id("GitHub")

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -48,6 +48,7 @@ object WaterMyPlantsCi : Pipeline({
     job {
         id("verify")
         name = "Verify"
+        allowReuse = false
 
         steps {
             step(PipelineScriptStep {
@@ -60,6 +61,7 @@ object WaterMyPlantsCi : Pipeline({
     job {
         id("generate_design_model")
         name = "Generate design model"
+        allowReuse = false
 
         steps {
             step(PipelineScriptStep {
@@ -79,6 +81,7 @@ object WaterMyPlantsCi : Pipeline({
     job {
         id("check_figma_trunk_sync")
         name = "Check Figma trunk sync"
+        allowReuse = false
 
         steps {
             step(PipelineScriptStep {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -28,7 +28,7 @@ object WaterMyPlantsCi : Pipeline({
     name = "CI"
 
     repositories {
-        repository(DslContext.settingsRoot)
+        repository(AbsoluteId("WaterMyPlants_GitHub"))
     }
 
     triggers {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -106,7 +106,7 @@ object GradleScripts {
         git remote remove origin 2>NUL
         git remote add origin https://github.com/marmatsan/water-my-plants.git || exit /b 1
         git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*" || exit /b 1
-        git checkout --force "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!" || exit /b 1
+        git checkout --force -B "!WMP_BRANCH!" "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!" || exit /b 1
 
         .\gradlew.bat $tasks
         """.trimIndent()

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -30,7 +30,7 @@ object WaterMyPlantsCi : Pipeline({
     name = "CI"
 
     repositories {
-        repository(GitHub)
+        repository(GitHub, enabledByDefault = true)
     }
 
     triggers {
@@ -50,10 +50,6 @@ object WaterMyPlantsCi : Pipeline({
         name = "Verify"
         allowReuse = false
 
-        repositories {
-            repository(GitHub)
-        }
-
         steps {
             step(PipelineScriptStep {
                 name = "Run Gradle check"
@@ -66,10 +62,6 @@ object WaterMyPlantsCi : Pipeline({
         id("generate_design_model")
         name = "Generate design model"
         allowReuse = false
-
-        repositories {
-            repository(GitHub)
-        }
 
         steps {
             step(PipelineScriptStep {
@@ -90,10 +82,6 @@ object WaterMyPlantsCi : Pipeline({
         id("check_figma_trunk_sync")
         name = "Check Figma trunk sync"
         allowReuse = false
-
-        repositories {
-            repository(GitHub)
-        }
 
         steps {
             step(PipelineScriptStep {

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -48,6 +48,10 @@ object WaterMyPlantsCi : Pipeline({
         name = "Verify"
         allowReuse = false
 
+        repositories {
+            repository(AbsoluteId("WaterMyPlants_GitHub"))
+        }
+
         steps {
             step(PipelineScriptStep {
                 name = "Run Gradle check"
@@ -60,6 +64,10 @@ object WaterMyPlantsCi : Pipeline({
         id("generate_design_model")
         name = "Generate design model"
         allowReuse = false
+
+        repositories {
+            repository(AbsoluteId("WaterMyPlants_GitHub"))
+        }
 
         steps {
             step(PipelineScriptStep {
@@ -80,6 +88,10 @@ object WaterMyPlantsCi : Pipeline({
         id("check_figma_trunk_sync")
         name = "Check Figma trunk sync"
         allowReuse = false
+
+        repositories {
+            repository(AbsoluteId("WaterMyPlants_GitHub"))
+        }
 
         steps {
             step(PipelineScriptStep {


### PR DESCRIPTION
Document the TeamCity versioned settings workflow, including the dedicated `chore/teamcity-settings` branch, how TeamCity loads `.teamcity/settings.kts`, and how to validate generated configs locally before merging.