### PR TITLE
fix(teamcity): split Figma sync from PR CI

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -81,18 +81,27 @@ selected branch.
 This is the repository that TeamCity should automatically checkout for every
 job.
 
-In TeamCity 2026.1.2, the virtual jobs generated from this Kotlin DSL pipeline
-did not materialize that default checkout in our setup: job logs showed a fresh
-checkout directory followed immediately by the script step, and `gradlew.bat`
-was missing. Until the native checkout behavior is reliable, each Gradle step
-uses a shared script helper that fetches the selected TeamCity branch:
+In TeamCity 2026.1.2, pipeline-level `enabledByDefault = true` did not
+materialize the repository checkout inside our virtual jobs. Job logs showed a
+fresh checkout directory followed immediately by the script step, and
+`gradlew.bat` was missing.
+
+Declare the repository explicitly in each job instead of performing a manual
+`git fetch` from the build script:
 
 ```kotlin
-setlocal EnableExtensions EnableDelayedExpansion
-set "WMP_BRANCH=%teamcity.build.branch%"
-if "!WMP_BRANCH!"=="<default>" set "WMP_BRANCH=main"
-git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*"
-git checkout --force -B "!WMP_BRANCH!" "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!"
+repositories {
+    repository(GitHub)
+}
+```
+
+The generated Pipeline YAML then contains a native job repository entry:
+
+```yaml
+repositories:
+- RootProjectId_GitHub:
+    enabled: true
+    path: ""
 ```
 
 Do not use `%build.vcs.number.WaterMyPlants_GitHub%` inside job script content.
@@ -102,12 +111,15 @@ compatible agent`.
 
 For local Windows batch variables, use delayed expansion (`!WMP_BRANCH!`) rather
 than `%WMP_BRANCH%`. TeamCity treats `%...%` as a TeamCity parameter reference
-before the job starts, so `%WMP_BRANCH%` also makes the job incompatible.
+before the job starts, so `%WMP_BRANCH%` also makes the job incompatible. The
+current pipeline does not need local batch variables because repository checkout
+is configured through the Pipeline DSL.
 
-Avoid job-level repository blocks unless a job needs a different checkout
-layout. TeamCity can generate pipeline YAML that references `WaterMyPlants_GitHub`
-from a job without making that repository available to the pipeline generator,
-which fails at runtime with:
+Do not reference generated project-prefixed ids such as `WaterMyPlants_GitHub`
+directly from job repository blocks. Use the local DSL object `GitHub`. TeamCity
+can generate pipeline YAML that references a generated id from a job without
+making that repository available to the pipeline generator, which fails at
+runtime with:
 
 ```text
 Repository referenced by WaterMyPlants_GitHub not found

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -51,19 +51,45 @@ pipelines cannot be edited in UI, edit Kotlin DSL files instead
 
 the fix belongs in `.teamcity/settings.kts`, not in the pipeline editor.
 
-## Pipeline Definition
+## Pipeline Definitions
 
-The CI pipeline is defined with TeamCity Pipelines Kotlin DSL.
+The TeamCity pipelines are defined with TeamCity Pipelines Kotlin DSL.
+
+### CI
+
+`CI` is the pull request and branch validation pipeline. It is the only TeamCity
+status required by GitHub branch protection.
 
 The pipeline:
 
 - monitors all branches;
-- maps secure TeamCity parameters to build environment variables;
 - runs `Verify`;
 - runs `Generate design model` after `Verify`;
 - publishes `build/reports/figma-sync/design-model.json`;
-- runs `Check Figma trunk sync` after the design model is generated;
 - publishes the final GitHub status check from the final job.
+
+`CI` does not run `checkFigmaTrunkSync`. Figma represents the stable `main`
+state, so short-lived branch builds should prove that the model can be generated
+without requiring Figma to already match that temporary branch.
+
+### Figma Sync
+
+`Figma Sync` is the post-merge Figma verification pipeline. It is scoped to the
+default branch and should not be required by GitHub before merging pull
+requests.
+
+The pipeline:
+
+- triggers only for `<default>`;
+- generates `build/reports/figma-sync/design-model.json` from `main`;
+- publishes the generated model as an artifact;
+- runs `Check Figma trunk sync` against the metadata currently stored in Figma.
+
+The visual write step is still MCP-operated outside TeamCity. Until that write
+step is automated, `Figma Sync` is expected to fail after a model-affecting
+merge if Figma has not been synchronized yet. That failure is a post-merge
+documentation signal, not a pull request merge gate. After the MCP sync writes
+the latest metadata, rerun `Figma Sync` on `main` to verify the result.
 
 Keep job reuse disabled:
 
@@ -72,9 +98,8 @@ allowReuse = false
 ```
 
 This prevents TeamCity from satisfying a branch or pull request pipeline with a
-previously successful job from another branch. The Figma gate depends on the
-exact `design-model.json` generated for the same branch revision, so all jobs
-must run in the same pipeline chain for the selected branch.
+previously successful job from another branch. The generated design model must
+belong to the same branch revision as the pipeline chain being validated.
 
 ## Repository Checkout
 
@@ -182,9 +207,12 @@ param("github_authentication_type", "vcsRoot")
 param("build_custom_name", statusCheckName)
 ```
 
-GitHub branch protection should require the `TeamCity CI` status check. The
-status is published by the final pipeline job, which depends on the earlier
-jobs, so it represents the full pipeline chain.
+GitHub branch protection should require only the `TeamCity CI` status check.
+The status is published by the final `CI` pipeline job, which depends on the
+earlier job, so it represents the pull request validation chain.
+
+Do not require the `Figma Sync` pipeline in GitHub branch protection. That
+pipeline runs after changes reach `main`.
 
 Do not add a raw GitHub token to the repository. The VCS root credentials or a
 TeamCity-managed GitHub App token must provide permission to write commit
@@ -233,7 +261,8 @@ For this project, the generated pipeline should:
 - reference only one Git VCS root for the GitHub repository;
 - emit job-level `repositories` entries;
 - emit direct Gradle script content;
-- emit `commit-status-publisher` on the final job.
+- emit `commit-status-publisher` only on the final `CI` job;
+- keep `Figma Sync` as a separate default-branch pipeline.
 
 ## TeamCity CLI
 
@@ -331,9 +360,10 @@ object instead.
 If GitHub receives no status check, inspect `teamcity-commit-status.log` and
 confirm that the status publisher feature is attached to the final job.
 
-If the Figma gate fails on an unsynchronized branch, the failure message should
-mention the selected branch. If it mentions `main` while running another branch,
-fix repository checkout before investigating Figma sync.
+If `Figma Sync` fails on `main`, check whether the Figma MCP visual sync has
+been run with the latest `design-model.json`. If the failure mentions a branch
+other than the selected branch, fix repository checkout before investigating
+Figma sync.
 
 ## Clean-up Rules
 

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -4,19 +4,22 @@ This directory is the source of truth for TeamCity project settings.
 
 ## Branching Workflow
 
-Every change to `.teamcity/settings.kts` must be made on the short-lived branch:
+Change `.teamcity/settings.kts` on the short-lived branch:
 
 ```text
 chore/teamcity-settings
 ```
 
-Create or recreate the branch from the latest `main`, keep the change focused on TeamCity settings, open a pull request back to `main`, and delete the branch after the merge.
+Create or recreate the branch from the latest `main`, keep the change focused on
+TeamCity settings, open a pull request back to `main`, and delete the branch
+after the merge.
 
 Do not push TeamCity settings changes directly to `main`.
 
-## How TeamCity Processes These Settings
+## Versioned Settings
 
-TeamCity loads the current project configuration from the default branch of the versioned settings VCS root. For this repository, that branch is `main`.
+TeamCity loads the stable project configuration from the default branch of the
+versioned settings VCS root. For this repository, that branch is `main`.
 
 Branch builds can use branch-local settings when the project is configured with:
 
@@ -24,15 +27,23 @@ Branch builds can use branch-local settings when the project is configured with:
 When build starts: use settings from VCS
 ```
 
-That setting allows a build in a feature or chore branch to run with the `.teamcity/settings.kts` from that branch. It does not mean the TeamCity project UI immediately switches to that branch configuration. The stable project configuration shown in the UI is updated after the settings are merged to `main` and TeamCity reloads versioned settings.
+That option allows a build in a feature or chore branch to run with the
+`.teamcity/settings.kts` from that branch. It does not mean the TeamCity project
+UI immediately switches to that branch configuration. The stable project
+configuration shown in the UI is updated after the settings are merged to
+`main` and TeamCity reloads versioned settings.
 
-`Load project settings from VCS` is a manual resync tool. It should not be required for every change once polling or webhooks detect new commits, but it is useful while bootstrapping the setup or recovering from a stopped synchronization.
+`Load project settings from VCS` is a manual resync tool. It should not be
+required for every change once polling or webhooks detect new commits, but it is
+useful while bootstrapping the setup or recovering from stopped synchronization.
 
 ## UI Editing
 
-Project editing through the TeamCity UI is disabled because settings are stored in VCS.
+Project editing through the TeamCity UI is disabled because settings are stored
+in VCS.
 
-TeamCity Pipelines defined in Kotlin DSL are also read-only in the UI. If TeamCity reports:
+TeamCity Pipelines defined in Kotlin DSL are also read-only in the UI. If
+TeamCity reports:
 
 ```text
 pipelines cannot be edited in UI, edit Kotlin DSL files instead
@@ -40,10 +51,35 @@ pipelines cannot be edited in UI, edit Kotlin DSL files instead
 
 the fix belongs in `.teamcity/settings.kts`, not in the pipeline editor.
 
-## Pipeline Repository
+## Pipeline Definition
 
-Declare the project VCS root in `.teamcity/settings.kts` with the local id
-`GitHub`:
+The CI pipeline is defined with TeamCity Pipelines Kotlin DSL.
+
+The pipeline:
+
+- monitors all branches;
+- maps secure TeamCity parameters to build environment variables;
+- runs `Verify`;
+- runs `Generate design model` after `Verify`;
+- publishes `build/reports/figma-sync/design-model.json`;
+- runs `Check Figma trunk sync` after the design model is generated;
+- publishes the final GitHub status check from the final job.
+
+Keep job reuse disabled:
+
+```kotlin
+allowReuse = false
+```
+
+This prevents TeamCity from satisfying a branch or pull request pipeline with a
+previously successful job from another branch. The Figma gate depends on the
+exact `design-model.json` generated for the same branch revision, so all jobs
+must run in the same pipeline chain for the selected branch.
+
+## Repository Checkout
+
+Declare the project VCS root in `.teamcity/settings.kts` with a local DSL object
+and use that object everywhere inside the DSL:
 
 ```kotlin
 object GitHub : VcsRoot({
@@ -64,8 +100,7 @@ object GitHub : VcsRoot({
 })
 ```
 
-Then reference that same object once from the pipeline and keep it enabled by
-default:
+Reference the same object from the pipeline:
 
 ```kotlin
 repositories {
@@ -73,21 +108,7 @@ repositories {
 }
 ```
 
-The project settings and source code live in the same GitHub repository. In
-TeamCity, the local DSL id `GitHub` is materialized under the project id as
-`WaterMyPlants_GitHub`, which is the root that the Pipeline UI resolves to the
-selected branch.
-
-This is the repository that TeamCity should automatically checkout for every
-job.
-
-In TeamCity 2026.1.2, pipeline-level `enabledByDefault = true` did not
-materialize the repository checkout inside our virtual jobs. Job logs showed a
-fresh checkout directory followed immediately by the script step, and
-`gradlew.bat` was missing.
-
-Declare the repository explicitly in each job instead of performing a manual
-`git fetch` from the build script:
+Also declare the repository explicitly in each job:
 
 ```kotlin
 repositories {
@@ -95,103 +116,48 @@ repositories {
 }
 ```
 
-The generated Pipeline YAML then contains a native job repository entry:
+The job-level repository block is intentional. It makes TeamCity perform a
+native checkout for every virtual pipeline job before the Gradle command runs.
+
+The generated Pipeline YAML should contain a native job repository entry:
 
 ```yaml
 repositories:
-- RootProjectId_GitHub:
+- <generated-github-vcs-root-id>:
     enabled: true
     path: ""
 ```
 
-Do not use `%build.vcs.number.WaterMyPlants_GitHub%` inside job script content.
-The virtual jobs do not have that VCS root attached, so TeamCity treats the
-parameter as unresolved during agent compatibility checks and reports `No
-compatible agent`.
+The generated script content should remain a direct Gradle call:
 
-For local Windows batch variables, use delayed expansion (`!WMP_BRANCH!`) rather
-than `%WMP_BRANCH%`. TeamCity treats `%...%` as a TeamCity parameter reference
-before the job starts, so `%WMP_BRANCH%` also makes the job incompatible. The
-current pipeline does not need local batch variables because repository checkout
-is configured through the Pipeline DSL.
-
-Do not reference generated project-prefixed ids such as `WaterMyPlants_GitHub`
-directly from job repository blocks. Use the local DSL object `GitHub`. TeamCity
-can generate pipeline YAML that references a generated id from a job without
-making that repository available to the pipeline generator, which fails at
-runtime with:
-
-```text
-Repository referenced by WaterMyPlants_GitHub not found
+```yaml
+script-content: .\gradlew.bat check
 ```
 
-Do not create a second Git VCS root with the same URL. A duplicate root can make the pipeline show a feature/chore branch while individual jobs still checkout `main`.
+Do not perform `git init`, `git fetch`, or `git checkout` from build script
+content. Repository checkout belongs in the Pipeline DSL through job
+repositories.
 
-Do not use `DslContext.settingsRoot` as the job checkout repository. It is the settings root, and TeamCity can apply settings-path checkout rules such as `.teamcity`; jobs need the full repository to run `gradlew.bat`.
+Do not reference TeamCity-generated project-prefixed VCS root ids directly from
+job repository blocks. Use the local DSL object, such as `GitHub`. Generated ids
+are implementation details and can make pipeline generation fail if they are not
+available in the current generation context.
 
-When this is working, the generated Pipeline Head contains:
+Do not create a second Git VCS root with the same URL. Duplicate roots can make
+the pipeline UI show one branch while individual jobs checkout another.
 
-```xml
-<vcs-entry-ref root-id="WaterMyPlants_GitHub" />
-```
-
-and the pipeline run log for a branch build reports:
-
-```text
-VCS revisions: 'WaterMyPlants_GitHub' ... refs/heads/chore/teamcity-settings
-```
-
-If the log reports `WaterMyPlants_WaterMyPlantsRepository` or a revision from `refs/heads/main` while the Pipeline UI shows a chore/feature branch, TeamCity is using the wrong checkout root.
-
-## Pipeline Runs and Job Logs
-
-The top-level Pipeline build is composite. It aggregates job results and may fail with:
-
-```text
-Build chain finished (failed: 3)
-```
-
-That log does not show the actual Gradle failure. Debug the child jobs instead:
-
-```text
-Verify
-Generate design model
-Check Figma trunk sync
-```
-
-The expected Figma gate failure for an unsynchronized branch mentions that branch name:
-
-```text
-Figma is out of sync with chore/teamcity-settings
-```
-
-If it says `Figma is out of sync with main`, the job checked out `main` and the pipeline checkout configuration is wrong.
-
-## Pipeline Job Reuse
-
-Pipeline jobs must keep reuse disabled:
-
-```kotlin
-allowReuse = false
-```
-
-This prevents TeamCity from satisfying a branch or pull request pipeline with a previously successful job from `main`. The Figma gate depends on the exact `design-model.json` generated for the same branch revision, so `verify`, `generate_design_model`, and `check_figma_trunk_sync` must all run in the same pipeline chain for the selected branch.
+Do not use `DslContext.settingsRoot` as the job checkout repository. It is the
+settings root, and TeamCity can apply settings-path checkout rules such as
+`.teamcity`. Jobs need the full repository to run `gradlew.bat`.
 
 ## GitHub Status Publishing
 
 GitHub status publishing is configured in DSL because Pipeline editing is
 read-only when versioned settings are enabled.
 
-TeamCity 2026.1.2 does not expose a typed `commitStatusPublisher` helper for
-Pipelines. The generated DSL documentation shows the official
-`CommitStatusPublisher` class as a `BuildFeature`, but not as
-`PipelineCompatible`, so it cannot be added to a Pipeline job through the typed
-helper.
-
-The Pipeline DSL does expose `Job.features`, and accepts build features that
-implement `PipelineCompatible`. This project therefore declares a small generic
-feature wrapper and attaches it to the final pipeline job,
-`check_figma_trunk_sync`:
+The Pipeline DSL exposes `Job.features` and accepts build features that
+implement `PipelineCompatible`. This project declares a small generic feature
+wrapper and attaches it to the final pipeline job:
 
 ```kotlin
 features {
@@ -202,10 +168,9 @@ features {
 That emits `commit-status-publisher` into the generated Pipeline YAML:
 
 ```yaml
-check_figma_trunk_sync:
-  features:
-  - type: commit-status-publisher
-    build_custom_name: TeamCity CI
+features:
+- type: commit-status-publisher
+  build_custom_name: TeamCity CI
 ```
 
 The feature uses GitHub with VCS root credentials:
@@ -218,8 +183,8 @@ param("build_custom_name", statusCheckName)
 ```
 
 GitHub branch protection should require the `TeamCity CI` status check. The
-status is published by the final pipeline job, which depends on `verify` and
-`generate_design_model`, so it represents the full pipeline chain.
+status is published by the final pipeline job, which depends on the earlier
+jobs, so it represents the full pipeline chain.
 
 Do not add a raw GitHub token to the repository. The VCS root credentials or a
 TeamCity-managed GitHub App token must provide permission to write commit
@@ -229,32 +194,18 @@ The feature intentionally omits `vcsRootId`. TeamCity's Commit Status Publisher
 then publishes for the Git VCS roots attached to the virtual job. If GitHub
 receives no statuses, inspect `teamcity-commit-status.log`.
 
-Important validation history:
-
-- With the duplicated repository root, TeamCity ran jobs against `main` while
-  the Pipeline UI showed the selected branch.
-- Before the pipeline root was corrected, job-level status publishing reported
-  `publisher github: no compatible revisions found`.
-- After the pipeline root was corrected, the final job exposed the selected
-  branch revision and published `TeamCity CI` successfully.
-
-The native Pipeline UI toggle `Publish status to repository` is not represented
-by a typed Kotlin DSL property for `PipelineRepositories` in 2026.1.2. JetBrains
-documentation describes that native toggle as available for pipelines created
-from provider connections; this project is configured from versioned Kotlin DSL
-and a VCS root.
-
 ## Secure Parameters
 
-Secrets are declared in DSL only by TeamCity credential references, never by raw secret values.
+Secrets are declared in DSL only by TeamCity credential references, never by raw
+secret values.
 
-Example:
+Use a TeamCity-generated secure value:
 
 ```kotlin
-password("figma.file.content.access.token", "credentialsJSON:...")
+password("figma.file.content.access.token", "<teamcity-secure-token-reference>")
 ```
 
-The pipeline maps the secure project parameter to the build environment:
+Map the secure project parameter to the build environment:
 
 ```kotlin
 param("env.FIGMA_FILE_CONTENT_ACCESS_TOKEN", "%figma.file.content.access.token%")
@@ -274,7 +225,15 @@ Generated files are written to:
 .teamcity/target/generated-configs
 ```
 
-The generated directory is ignored by Git, but it is useful for checking what XML/YAML TeamCity will receive. For this project, the pipeline head should reference `WaterMyPlants_GitHub` and should not emit a duplicate VCS root for `https://github.com/marmatsan/water-my-plants.git`.
+The generated directory is ignored by Git, but it is useful for checking what
+XML and YAML TeamCity will receive.
+
+For this project, the generated pipeline should:
+
+- reference only one Git VCS root for the GitHub repository;
+- emit job-level `repositories` entries;
+- emit direct Gradle script content;
+- emit `commit-status-publisher` on the final job.
 
 ## TeamCity CLI
 
@@ -282,34 +241,21 @@ Use the TeamCity CLI for local diagnostics and repeatable pipeline runs. It does
 not replace `.teamcity/settings.kts`; it is a client for validating settings,
 querying TeamCity, and starting builds.
 
-The CLI is configured locally through `teamcity.toml` at the repository root:
-
-```toml
-[[server]]
-url = 'http://localhost:8111'
-project = 'WaterMyPlants'
-job = 'WaterMyPlants_WaterMyPlantsCi'
-```
-
 Keep `teamcity.toml` out of Git. It points to a developer-local TeamCity server
 and is ignored by `.gitignore`.
 
 Authenticate the CLI with a TeamCity access token:
 
 ```powershell
-teamcity auth login --server http://localhost:8111 --token <token>
+teamcity auth login --server <teamcity-url> --token <token>
 teamcity auth status
 ```
-
-The local TeamCity server currently uses HTTP, so the CLI prints an insecure
-connection warning. That is expected for the localhost setup. Do not paste the
-token into source files, shell scripts, or docs.
 
 Bind the current checkout to the TeamCity project and default pipeline if the
 local `teamcity.toml` is missing:
 
 ```powershell
-teamcity link --server http://localhost:8111 --project WaterMyPlants --job WaterMyPlants_WaterMyPlantsCi --scope=
+teamcity link --server <teamcity-url> --project <project-id> --job <pipeline-id> --scope=
 ```
 
 Validate versioned settings from the CLI when `mvn` is available on `PATH`:
@@ -318,13 +264,13 @@ Validate versioned settings from the CLI when `mvn` is available on `PATH`:
 teamcity project settings validate .teamcity --verbose
 ```
 
-On Windows with TeamCity CLI 1.2.1, the CLI does not use the Maven Wrapper from
-the repository root for a `.teamcity` DSL directory. Keep a single Maven Wrapper
-at the repository root and expose its downloaded Maven 3.9.16 distribution for
-CLI validation:
+On Windows with TeamCity CLI, the CLI may not use the Maven Wrapper from the
+repository root for a `.teamcity` DSL directory. Keep a single Maven Wrapper at
+the repository root and expose the downloaded Maven distribution on `PATH` if
+CLI validation requires `mvn`:
 
 ```powershell
-$mavenBin = Get-ChildItem "$env:USERPROFILE\.m2\wrapper\dists\apache-maven-3.9.16-bin" -Recurse -Filter mvn.cmd | Select-Object -First 1 -ExpandProperty DirectoryName
+$mavenBin = Get-ChildItem "$env:USERPROFILE\.m2\wrapper\dists" -Recurse -Filter mvn.cmd | Select-Object -First 1 -ExpandProperty DirectoryName
 $env:PATH = "$mavenBin;$env:PATH"
 teamcity project settings validate .teamcity --verbose
 ```
@@ -332,17 +278,17 @@ teamcity project settings validate .teamcity --verbose
 Check versioned settings synchronization:
 
 ```powershell
-teamcity project settings status WaterMyPlants
+teamcity project settings status <project-id>
 ```
 
 Run the linked CI pipeline for the current Git branch:
 
 ```powershell
-teamcity run start --branch '@this' --revision '@head' --watch
+teamcity run start --branch '@this' --watch
 ```
 
-Quote `@this` and `@head` in PowerShell. Without quotes, PowerShell can treat
-`@...` as syntax instead of passing the literal value to the CLI.
+Quote `@this` in PowerShell. Without quotes, PowerShell can treat `@...` as
+syntax instead of passing the literal value to the CLI.
 
 Useful diagnostics after a run:
 
@@ -356,19 +302,45 @@ teamcity run artifacts <job-run-id>
 ```
 
 The top-level pipeline run is composite. Use `teamcity run tree <run-id>` to get
-the child job run ids for `Verify`, `Generate design model`, and `Check Figma
-trunk sync`, then inspect the failing child job log.
+the child job run ids, then inspect the failing child job log.
 
 Do not rely on `--local-changes` unless the access token has the TeamCity
 permission `Change build source code with a custom patch`. The normal workflow
-is to commit and push the branch, then run the pipeline against that branch
-revision.
+is to commit and push the branch, then run the pipeline against that branch.
+
+## Troubleshooting
+
+If a job cannot find `gradlew.bat`, check that the job declares the GitHub
+repository in its `repositories` block and that generated YAML contains a native
+repository entry for that job.
+
+If a branch build appears to run against `main`, check the child job log. The
+checkout log should mention the selected branch and revision. If it shows
+`refs/heads/main` for a non-main branch build, TeamCity is using the wrong VCS
+root or checkout configuration.
+
+If TeamCity reports `No compatible agent` with unresolved parameters, inspect
+the job script content for `%...%` references that are not TeamCity parameters.
+For Windows batch variables, use delayed expansion (`!VARIABLE!`) or avoid local
+batch variables in the TeamCity step.
+
+If pipeline generation reports that a repository is not found, check for direct
+references to generated VCS root ids in job repository blocks. Use the local DSL
+object instead.
+
+If GitHub receives no status check, inspect `teamcity-commit-status.log` and
+confirm that the status publisher feature is attached to the final job.
+
+If the Figma gate fails on an unsynchronized branch, the failure message should
+mention the selected branch. If it mentions `main` while running another branch,
+fix repository checkout before investigating Figma sync.
 
 ## Clean-up Rules
 
-Clean-up rules are also project settings and must be changed in `.teamcity/settings.kts`.
+Clean-up rules are also project settings and must be changed in
+`.teamcity/settings.kts`.
 
-The current project cleanup policy is:
+The project cleanup policy is:
 
 ```kotlin
 cleanup {
@@ -387,4 +359,5 @@ The project also sets:
 param("teamcity.activeBuildBranch.age.hours", "0")
 ```
 
-This prevents closed branches with old builds from staying visible as active branches for the default 24-hour window.
+This prevents closed branches with old builds from staying visible as active
+branches for the default 24-hour window.

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -23,15 +23,19 @@ project {
     }
 
     pipeline(WaterMyPlantsCi)
+    pipeline(WaterMyPlantsFigmaSync)
 }
 
 /**
- * CI pipeline for the repository.
+ * Pull request and branch CI pipeline for the repository.
  *
- * The pipeline runs the Gradle verification tasks, generates the Figma design
- * model, and finishes with the Figma trunk sync gate. Each job declares the
- * [GitHub] repository explicitly so TeamCity performs a native checkout before
- * executing Gradle.
+ * The pipeline runs Gradle verification tasks and checks that the Figma design
+ * model can be generated. It does not require Figma to already be synchronized
+ * with a temporary branch because Figma represents the stable `main` state.
+ *
+ * The final job publishes the `TeamCity CI` GitHub status required by branch
+ * protection. Each job declares the [GitHub] repository explicitly so TeamCity
+ * performs a native checkout before executing Gradle.
  */
 object WaterMyPlantsCi : Pipeline({
     id("WaterMyPlantsCi")
@@ -50,7 +54,6 @@ object WaterMyPlantsCi : Pipeline({
     params {
         param("env.ANDROID_HOME", "%android.sdk.path%")
         param("env.ANDROID_SDK_ROOT", "%android.sdk.path%")
-        param("env.FIGMA_FILE_CONTENT_ACCESS_TOKEN", "%figma.file.content.access.token%")
     }
 
     job {
@@ -91,20 +94,72 @@ object WaterMyPlantsCi : Pipeline({
             sharedWithJobs("build/reports/figma-sync/design-model.json")
         }
 
+        features {
+            feature(GitHubStatusPublisher("TeamCity CI"))
+        }
+
         dependency("verify")
+    }
+})
+
+/**
+ * Post-merge Figma synchronization verification pipeline.
+ *
+ * This pipeline is scoped to `main` because Figma is derived documentation for
+ * the trunk state, not for every short-lived branch. The MCP-operated visual
+ * sync still runs outside TeamCity; this pipeline generates the trunk model and
+ * either verifies the metadata after Figma has been updated or fails visibly
+ * until the MCP sync is run and the pipeline is rerun.
+ */
+object WaterMyPlantsFigmaSync : Pipeline({
+    id("WaterMyPlantsFigmaSync")
+    name = "Figma Sync"
+
+    repositories {
+        repository(GitHub, enabledByDefault = true)
+    }
+
+    triggers {
+        trigger(PipelineVcsTrigger {
+            branchFilter = "+:<default>"
+        })
+    }
+
+    params {
+        param("env.ANDROID_HOME", "%android.sdk.path%")
+        param("env.ANDROID_SDK_ROOT", "%android.sdk.path%")
+        param("env.FIGMA_FILE_CONTENT_ACCESS_TOKEN", "%figma.file.content.access.token%")
     }
 
     job {
-        id("check_figma_trunk_sync")
-        name = "Check Figma trunk sync"
+        id("figma_sync_generate_design_model")
+        name = "Generate main design model"
         allowReuse = false
 
         repositories {
             repository(GitHub)
         }
 
-        features {
-            feature(GitHubStatusPublisher("TeamCity CI"))
+        steps {
+            step(PipelineScriptStep {
+                name = "Generate Figma design model"
+                scriptContent = """.\gradlew.bat generateFigmaDesignModel"""
+            })
+        }
+
+        outputFiles {
+            pipelineArtifacts("build/reports/figma-sync/design-model.json")
+            sharedWithJobs("build/reports/figma-sync/design-model.json")
+        }
+    }
+
+    job {
+        id("figma_sync_check_trunk_sync")
+        name = "Check Figma trunk sync"
+        allowReuse = false
+
+        repositories {
+            repository(GitHub)
         }
 
         steps {
@@ -114,7 +169,7 @@ object WaterMyPlantsCi : Pipeline({
             })
         }
 
-        dependency("generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
+        dependency("figma_sync_generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
     }
 })
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -50,10 +50,14 @@ object WaterMyPlantsCi : Pipeline({
         name = "Verify"
         allowReuse = false
 
+        repositories {
+            repository(GitHub)
+        }
+
         steps {
             step(PipelineScriptStep {
                 name = "Run Gradle check"
-                scriptContent = GradleScripts.gradle("check")
+                scriptContent = """.\gradlew.bat check"""
             })
         }
     }
@@ -63,10 +67,14 @@ object WaterMyPlantsCi : Pipeline({
         name = "Generate design model"
         allowReuse = false
 
+        repositories {
+            repository(GitHub)
+        }
+
         steps {
             step(PipelineScriptStep {
                 name = "Generate Figma design model"
-                scriptContent = GradleScripts.gradle("generateFigmaDesignModel")
+                scriptContent = """.\gradlew.bat generateFigmaDesignModel"""
             })
         }
 
@@ -83,6 +91,10 @@ object WaterMyPlantsCi : Pipeline({
         name = "Check Figma trunk sync"
         allowReuse = false
 
+        repositories {
+            repository(GitHub)
+        }
+
         features {
             feature(GitHubStatusPublisher("TeamCity CI"))
         }
@@ -90,7 +102,7 @@ object WaterMyPlantsCi : Pipeline({
         steps {
             step(PipelineScriptStep {
                 name = "Verify Figma sync metadata"
-                scriptContent = GradleScripts.gradle("checkFigmaTrunkSync")
+                scriptContent = """.\gradlew.bat checkFigmaTrunkSync"""
             })
         }
 
@@ -108,24 +120,6 @@ class GitHubStatusPublisher(statusCheckName: String) : BuildFeature(), PipelineC
         param("github_authentication_type", "vcsRoot")
         param("build_custom_name", statusCheckName)
     }
-}
-
-object GradleScripts {
-    fun gradle(tasks: String): String =
-        """
-        setlocal EnableExtensions EnableDelayedExpansion
-        set "WMP_BRANCH=%teamcity.build.branch%"
-        if "!WMP_BRANCH!"=="<default>" set "WMP_BRANCH=main"
-        if "!WMP_BRANCH!"=="" set "WMP_BRANCH=main"
-
-        if not exist ".git" git init || exit /b 1
-        git remote remove origin 2>NUL
-        git remote add origin https://github.com/marmatsan/water-my-plants.git || exit /b 1
-        git fetch --depth=1 origin "+refs/heads/*:refs/remotes/origin/*" "+refs/pull/*/head:refs/remotes/origin/pull/*" || exit /b 1
-        git checkout --force -B "!WMP_BRANCH!" "origin/!WMP_BRANCH!" || git checkout --force "origin/pull/!WMP_BRANCH!" || exit /b 1
-
-        .\gradlew.bat $tasks
-        """.trimIndent()
 }
 
 object GitHub : VcsRoot({

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -25,6 +25,14 @@ project {
     pipeline(WaterMyPlantsCi)
 }
 
+/**
+ * CI pipeline for the repository.
+ *
+ * The pipeline runs the Gradle verification tasks, generates the Figma design
+ * model, and finishes with the Figma trunk sync gate. Each job declares the
+ * [GitHub] repository explicitly so TeamCity performs a native checkout before
+ * executing Gradle.
+ */
 object WaterMyPlantsCi : Pipeline({
     id("WaterMyPlantsCi")
     name = "CI"
@@ -110,6 +118,16 @@ object WaterMyPlantsCi : Pipeline({
     }
 })
 
+/**
+ * Pipeline-compatible Commit Status Publisher feature for GitHub.
+ *
+ * TeamCity Pipelines Kotlin DSL accepts build features that implement
+ * [PipelineCompatible]. This wrapper emits the `commit-status-publisher`
+ * feature into the generated Pipeline YAML and publishes the final pipeline
+ * status with [statusCheckName].
+ *
+ * @param statusCheckName GitHub status check name required by branch protection.
+ */
 class GitHubStatusPublisher(statusCheckName: String) : BuildFeature(), PipelineCompatible {
     init {
         type = "commit-status-publisher"
@@ -122,6 +140,13 @@ class GitHubStatusPublisher(statusCheckName: String) : BuildFeature(), PipelineC
     }
 }
 
+/**
+ * GitHub repository VCS root used by both versioned settings and pipeline jobs.
+ *
+ * The branch specification includes regular branches and pull request heads, and
+ * disables fallback to the default branch so branch resolution mistakes fail
+ * visibly instead of running jobs against `main`.
+ */
 object GitHub : VcsRoot({
     id("GitHub")
     name = "water-my-plants"
@@ -139,7 +164,17 @@ object GitHub : VcsRoot({
     )
 })
 
+/**
+ * Pipeline-compatible command line script step.
+ *
+ * The TeamCity Pipelines DSL serializes script steps with the `script-content`
+ * YAML property. This wrapper keeps the Kotlin DSL explicit while avoiding raw
+ * untyped build step declarations at call sites.
+ */
 open class PipelineScriptStep(init: PipelineScriptStep.() -> Unit = {}) : BuildStep(), PipelineCompatible {
+    /**
+     * Command content emitted as `script-content` in generated Pipeline YAML.
+     */
     var scriptContent: String
         get() = params.find { it.name == SCRIPT_CONTENT_PARAM }?.value.orEmpty()
         set(value) {
@@ -157,7 +192,17 @@ open class PipelineScriptStep(init: PipelineScriptStep.() -> Unit = {}) : BuildS
     }
 }
 
+/**
+ * Pipeline-compatible VCS trigger.
+ *
+ * The typed trigger helper used by classic build configurations is not accepted
+ * directly by Pipeline DSL blocks, so this wrapper emits the VCS trigger with
+ * the branch filter parameter expected by TeamCity Pipelines.
+ */
 open class PipelineVcsTrigger(init: PipelineVcsTrigger.() -> Unit = {}) : Trigger(), PipelineCompatible {
+    /**
+     * TeamCity branch filter used by the generated VCS trigger.
+     */
     var branchFilter: String
         get() = params.find { it.name == BRANCH_FILTER_PARAM }?.value.orEmpty()
         set(value) {

--- a/build-logic/figmaDesignSync/docs/figma-trunk-sync.md
+++ b/build-logic/figmaDesignSync/docs/figma-trunk-sync.md
@@ -2,15 +2,17 @@
 
 ## Purpose
 
-`main` is the source of truth for the dependency design model. Figma is considered synchronized only when the configured Figma page stores the same `modelHash` generated from the current branch.
+`main` is the source of truth for the dependency design model. Figma is considered synchronized only when the configured Figma page stores the same `modelHash` generated from `main`.
 
 This replaces field-by-field Figma checks. The repository generates a single JSON model, the Figma MCP sync step updates the Figma visualization, then writes sync metadata, and Gradle verifies that Figma points to the same model.
 
 ## CI Ownership
 
-`figmaDesignSync` is a CI-owned verification step. Developers may run it locally for diagnosis, but CI is the source of truth before changes are merged into `main`.
+`figmaDesignSync` is split between pull request validation and post-merge Figma verification. Developers may run it locally for diagnosis, but TeamCity is the source of truth for the repository workflow.
 
-In trunk-based development, pull requests target `main` and CI must verify that Figma reflects the model generated from the branch being validated. Local execution is useful when diagnosing a failed gate or checking credentials, but it is not a required manual step before every commit because it depends on external Figma state, access tokens, and the MCP-operated write flow.
+In trunk-based development, pull requests target `main` and CI must verify that the design model can be generated from the branch being validated. CI does not require Figma to already reflect a temporary branch. After the pull request is merged, the post-merge Figma pipeline generates the model from `main`, the MCP-operated sync updates Figma, and `checkFigmaTrunkSync` verifies the metadata.
+
+Local execution is useful when diagnosing a failed gate or checking credentials, but it is not a required manual step before every commit because Figma sync depends on external Figma state, access tokens, and the MCP-operated write flow.
 
 ## Sources
 
@@ -64,7 +66,7 @@ Module dependency extraction reads explicit `project(":...")` calls and type-saf
 
 Module dependency graphs are no longer rendered into Figma's deleted `dependency of modules` section. They are architecture documentation and must be represented in PlantUML diagrams under the repository UML convention, then published to the Figma UML documentation page.
 
-`modelHash` is calculated from the stable model content and excludes `generatedAt` and `modelHash` itself.
+`modelHash` is calculated from the stable model content and excludes `branch`, `gitSha`, `generatedAt`, and `modelHash` itself. `branch` and `gitSha` remain in the JSON as traceability metadata, but they do not force a Figma sync when the visual model content has not changed.
 
 ## Figma MCP Sync
 
@@ -212,7 +214,7 @@ Visual rendering rules:
 
 ## Verification
 
-The verification task reads Figma shared plugin data through the Figma REST API and compares it with a freshly generated model from the current branch:
+The verification task reads Figma shared plugin data through the Figma REST API and compares it with a freshly generated model from the current checkout. In TeamCity, this check belongs to the post-merge `main` workflow:
 
 ```powershell
 $line = Get-Content -Path .env | Where-Object { $_ -like 'FIGMA_FILE_CONTENT_ACCESS_TOKEN=*' } | Select-Object -First 1
@@ -226,24 +228,32 @@ The check fails when:
 
 - Figma does not expose shared plugin data for `water_my_plants_sync`.
 - Figma is missing `modelHash` or `gitSha`.
-- Figma's `modelHash` differs from the model generated from the current branch.
+- Figma's `modelHash` differs from the model generated from the current checkout.
 - The visual MCP sync step refused to write metadata because Figma was missing required visual variables, sections, instances, or connector templates.
 
 `checkFigmaTrunkSync` verifies the sync metadata hash, not every visual node. Manual edits in Figma can go undetected if they do not update or remove the shared plugin metadata. The visual MCP sync step is responsible for updating or recreating supported visual elements before writing the hash.
 
 ## TeamCity Integration
 
-TeamCity should generate `design-model.json` after a feature is merged into `main` and publish it as a build artifact.
+TeamCity uses two separate pipelines for this workflow.
 
-Recommended build steps for `main`:
+`CI` is the pull request gate required by GitHub branch protection:
 
 - Run normal verification: unit, integration, and end-to-end tests where available.
 - Run `generateFigmaDesignModel`.
 - Publish `build/reports/figma-sync/design-model.json`.
+
+`CI` does not run `checkFigmaTrunkSync`. Figma represents `main`, not every short-lived branch.
+
+`Figma Sync` is the post-merge pipeline for `main`:
+
+- Run `generateFigmaDesignModel` from `main`.
+- Publish `build/reports/figma-sync/design-model.json`.
+- Run `checkFigmaTrunkSync` against the metadata currently stored in Figma.
 - Verify every added or changed `.puml` diagram has been rendered and published
   to the Figma UML documentation page in its own locked section.
 
-The Figma write step is currently MCP-operated. After the MCP sync step writes the metadata into Figma, run:
+The Figma write step is currently MCP-operated. Until it is automated inside TeamCity, the first `Figma Sync` run after a model-affecting merge can identify that `main` is not yet reflected in Figma, but the actual write still happens through the MCP step. Use the published `design-model.json` artifact to run the Figma MCP visual sync. After the MCP sync step writes the metadata into Figma, rerun `Figma Sync` or run:
 
 ```powershell
 .\gradlew.bat checkFigmaTrunkSync
@@ -272,4 +282,4 @@ Only after that barrier is green:
 - Merge `release/<version>` into `main`.
 - Publish the stable version.
 
-After committing changes to this flow, regenerate the model and sync Figma again because `gitSha` changes with the commit.
+After merging changes that affect the generated model content, regenerate the model from `main` and sync Figma again. Commits that only change traceability metadata, CI settings, or unrelated files do not require a Figma sync if `modelHash` stays unchanged.

--- a/build-logic/figmaDesignSync/docs/uml/diagrams/figma-design-model-feature.puml
+++ b/build-logic/figmaDesignSync/docs/uml/diagrams/figma-design-model-feature.puml
@@ -45,10 +45,10 @@ fork again
   }
 fork again
   partition "@domain" {
-    :<b>Scenario</b>\ngitSha affects the model hash; <<scenario>>
+    :<b>Scenario</b>\ngitSha does not affect the model hash; <<scenario>>
     :When the design model is generated\nfor git sha abc123;
     :And the design model is generated again\nfor git sha def456;
-    :Then both generated model hashes\nare different;
+    :Then both generated model hashes\nare equal;
   }
 fork again
   partition "@gradle @integration" {

--- a/build-logic/figmaDesignSync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
+++ b/build-logic/figmaDesignSync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
@@ -35,16 +35,15 @@ internal class FigmaDesignModelGenerator(
     /**
      * Generates the complete model and stable model hash for [request].
      *
-     * The hash input contains schema version, branch, git SHA, and content.
-     * `generatedAt` is written to the model but excluded from the hash so the
-     * same repository snapshot remains comparable across runs.
+     * The hash input contains schema version and content. Git identity fields
+     * are written to the model as traceability metadata, but they are excluded
+     * from the hash so commits that do not affect the visual model do not force
+     * a Figma sync.
      */
     fun generate(request: FigmaDesignModelGenerationRequest): FigmaDesignModelGenerationResult {
         val content = buildContent(request)
         val hashInput = buildJsonObject {
             put("schemaVersion", SCHEMA_VERSION)
-            put("branch", request.branch)
-            put("gitSha", request.gitSha)
             put("content", content)
         }
         val modelHash = FigmaDesignModelHash.compute(hashInput)

--- a/build-logic/figmaDesignSync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelHash.kt
+++ b/build-logic/figmaDesignSync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelHash.kt
@@ -11,8 +11,8 @@ import kotlinx.serialization.json.JsonObject
  *
  * JSON object keys are sorted before hashing so equivalent model content
  * produces the same hash regardless of insertion order. The generator hashes
- * content plus Git identity, but intentionally excludes volatile metadata such
- * as `generatedAt`.
+ * visual model content and intentionally excludes traceability metadata such as
+ * `branch`, `gitSha`, and `generatedAt`.
  */
 internal object FigmaDesignModelHash {
     private val canonicalJson = Json {

--- a/build-logic/figmaDesignSync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
+++ b/build-logic/figmaDesignSync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
@@ -37,7 +37,7 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
 
         project.tasks.register<CheckFigmaTrunkSyncTask>("checkFigmaTrunkSync") {
             group = "verification"
-            description = "Checks that Figma sync metadata matches the design model generated from the current branch."
+            description = "Checks that Figma sync metadata matches the design model generated from the current checkout."
 
             metadataNodeUrl.set(extension.designModelMetadataNodeUrl)
             versionsFile.set(extension.versionsFile)

--- a/build-logic/figmaDesignSync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/build-logic/figmaDesignSync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -40,7 +40,7 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
         second.model["generatedAt"]?.jsonPrimitive?.content shouldBe "2026-06-19T10:16:30Z"
     }
 
-    test("generate changes the model hash when gitSha changes") {
+    test("generate keeps the same model hash when only gitSha changes") {
         // GIVEN
         val generator = generator()
 
@@ -51,7 +51,7 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
         // THEN
         first.modelHash shouldBe first.model["modelHash"]?.jsonPrimitive?.content
         second.modelHash shouldBe second.model["modelHash"]?.jsonPrimitive?.content
-        (first.modelHash == second.modelHash) shouldBe false
+        first.modelHash shouldBe second.modelHash
     }
 
     test("generate writes sorted top-level content") {

--- a/build-logic/figmaDesignSync/plugin/src/test/resources/com/marmatsan/figmaDesignSync/plugin/bdd/figma-design-model.feature
+++ b/build-logic/figmaDesignSync/plugin/src/test/resources/com/marmatsan/figmaDesignSync/plugin/bdd/figma-design-model.feature
@@ -31,10 +31,10 @@ Feature: Figma design model generation
     Then both generated model hashes are equal
 
   @domain
-  Scenario: gitSha affects the model hash
+  Scenario: gitSha does not affect the model hash
     When the design model is generated for git sha abc123
     And the design model is generated again for git sha def456
-    Then both generated model hashes are different
+    Then both generated model hashes are equal
 
   @gradle @integration
   Scenario: generateFigmaDesignModel writes the design model report


### PR DESCRIPTION
## Summary

- Move `checkFigmaTrunkSync` out of the required `CI` pipeline.
- Add a separate `Figma Sync` pipeline scoped to `main` for post-merge Figma verification.
- Make `modelHash` depend on visual model content instead of `branch` or `gitSha`.
- Update TeamCity/Figma documentation and the derived BDD UML diagram.

## Why

Figma is derived documentation for the stable `main` state. PR CI should verify that the repository builds and can generate the design model, but it should not require Figma to be synchronized with every short-lived branch.

## Validation

- `./mvnw.cmd -f .teamcity/pom.xml teamcity-configs:generate`
- `./gradlew.bat :build-logic:figmaDesignSync:plugin:test`
- `./gradlew.bat generateFigmaDesignModel`
- TeamCity `CI` run #37 on `chore/teamcity-settings`: success
- GitHub status `TeamCity CI`: success