### PR TITLE
fix(teamcity): trigger Figma Sync after CI

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -80,7 +80,7 @@ requests.
 
 The pipeline:
 
-- triggers only for `<default>`;
+- triggers after `CI` finishes successfully on `<default>`;
 - generates `build/reports/figma-sync/design-model.json` from `main`;
 - publishes the generated model as an artifact;
 - runs `Check Figma trunk sync` against the metadata currently stored in Figma.
@@ -90,6 +90,11 @@ step is automated, `Figma Sync` is expected to fail after a model-affecting
 merge if Figma has not been synchronized yet. That failure is a post-merge
 documentation signal, not a pull request merge gate. After the MCP sync writes
 the latest metadata, rerun `Figma Sync` on `main` to verify the result.
+
+Use a Finish Build Trigger for this chain, not a direct VCS trigger on
+`Figma Sync`. The trigger watches `CI`, requires a successful watched build, and
+uses `+:<default>` as its branch filter. This prevents the Figma verification
+pipeline from running before `main` has passed the normal CI pipeline.
 
 Keep job reuse disabled:
 
@@ -262,7 +267,9 @@ For this project, the generated pipeline should:
 - emit job-level `repositories` entries;
 - emit direct Gradle script content;
 - emit `commit-status-publisher` only on the final `CI` job;
-- keep `Figma Sync` as a separate default-branch pipeline.
+- keep `Figma Sync` as a separate default-branch pipeline;
+- emit `buildDependencyTrigger` for `Figma Sync`, pointing at `CI`, with
+  `afterSuccessfulBuildOnly=true`.
 
 ## TeamCity CLI
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -120,7 +120,9 @@ object WaterMyPlantsFigmaSync : Pipeline({
     }
 
     triggers {
-        trigger(PipelineVcsTrigger {
+        trigger(PipelineFinishBuildTrigger {
+            buildType = "${WaterMyPlantsCi.id}"
+            successfulOnly = true
             branchFilter = "+:<default>"
         })
     }
@@ -270,6 +272,55 @@ open class PipelineVcsTrigger(init: PipelineVcsTrigger.() -> Unit = {}) : Trigge
     }
 
     private companion object {
+        const val BRANCH_FILTER_PARAM = "branchFilter"
+    }
+}
+
+/**
+ * Pipeline-compatible finish build trigger.
+ *
+ * TeamCity's Finish Build Trigger uses the `buildDependencyTrigger` type. The
+ * Figma Sync pipeline uses it to run only after the CI pipeline has completed
+ * successfully on the default branch.
+ */
+open class PipelineFinishBuildTrigger(
+    init: PipelineFinishBuildTrigger.() -> Unit = {}
+) : Trigger(), PipelineCompatible {
+    /**
+     * External id of the build configuration or pipeline head to watch.
+     */
+    var buildType: String
+        get() = params.find { it.name == BUILD_TYPE_PARAM }?.value.orEmpty()
+        set(value) {
+            param(BUILD_TYPE_PARAM, value)
+        }
+
+    /**
+     * Whether this trigger should react only to successful watched builds.
+     */
+    var successfulOnly: Boolean
+        get() = params.find { it.name == SUCCESSFUL_ONLY_PARAM }?.value == "true"
+        set(value) {
+            param(SUCCESSFUL_ONLY_PARAM, if (value) "true" else "")
+        }
+
+    /**
+     * TeamCity branch filter used to limit watched CI builds.
+     */
+    var branchFilter: String
+        get() = params.find { it.name == BRANCH_FILTER_PARAM }?.value.orEmpty()
+        set(value) {
+            param(BRANCH_FILTER_PARAM, value)
+        }
+
+    init {
+        type = "buildDependencyTrigger"
+        init()
+    }
+
+    private companion object {
+        const val BUILD_TYPE_PARAM = "dependsOn"
+        const val SUCCESSFUL_ONLY_PARAM = "afterSuccessfulBuildOnly"
         const val BRANCH_FILTER_PARAM = "branchFilter"
     }
 }

--- a/build-logic/figmaDesignSync/docs/figma-trunk-sync.md
+++ b/build-logic/figmaDesignSync/docs/figma-trunk-sync.md
@@ -10,7 +10,7 @@ This replaces field-by-field Figma checks. The repository generates a single JSO
 
 `figmaDesignSync` is split between pull request validation and post-merge Figma verification. Developers may run it locally for diagnosis, but TeamCity is the source of truth for the repository workflow.
 
-In trunk-based development, pull requests target `main` and CI must verify that the design model can be generated from the branch being validated. CI does not require Figma to already reflect a temporary branch. After the pull request is merged, the post-merge Figma pipeline generates the model from `main`, the MCP-operated sync updates Figma, and `checkFigmaTrunkSync` verifies the metadata.
+In trunk-based development, pull requests target `main` and CI must verify that the design model can be generated from the branch being validated. CI does not require Figma to already reflect a temporary branch. After the pull request is merged, CI runs on `main`; once that `main` CI run succeeds, the post-merge Figma pipeline generates the model from `main`, the MCP-operated sync updates Figma, and `checkFigmaTrunkSync` verifies the metadata.
 
 Local execution is useful when diagnosing a failed gate or checking credentials, but it is not a required manual step before every commit because Figma sync depends on external Figma state, access tokens, and the MCP-operated write flow.
 
@@ -247,6 +247,7 @@ TeamCity uses two separate pipelines for this workflow.
 
 `Figma Sync` is the post-merge pipeline for `main`:
 
+- Trigger after the `CI` pipeline succeeds on `<default>`.
 - Run `generateFigmaDesignModel` from `main`.
 - Publish `build/reports/figma-sync/design-model.json`.
 - Run `checkFigmaTrunkSync` against the metadata currently stored in Figma.


### PR DESCRIPTION
## Summary

- Replace the direct VCS trigger on `Figma Sync` with a finish build trigger.
- Make `Figma Sync` run only after `CI` succeeds on `<default>`.
- Document the post-merge chain in TeamCity and Figma sync docs.

## Why

Figma verification should start after `main` has passed the normal CI pipeline, not independently from VCS changes. This keeps the post-merge flow ordered as `CI` -> `Figma Sync`.

## Validation

- `./mvnw.cmd -f .teamcity/pom.xml teamcity-configs:generate`
- `teamcity project settings validate .teamcity --verbose`
- TeamCity `CI` run #40 on `chore/teamcity-settings`: success
- GitHub status `TeamCity CI`: success