### PR TITLE
ci(teamcity): publish Figma sync GitHub status

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -86,7 +86,8 @@ The pipeline:
 - triggers after `CI` finishes successfully on `<default>`;
 - generates `build/reports/figma-sync/design-model.json` from `main`;
 - publishes the generated model as an artifact;
-- runs `Check Figma trunk sync` against the metadata currently stored in Figma.
+- runs `Check Figma trunk sync` against the metadata currently stored in Figma;
+- publishes the optional `TeamCity Figma Sync` GitHub status on `main`.
 
 The visual write step is still MCP-operated outside TeamCity. Until that write
 step is automated, `Figma Sync` is expected to fail after a model-affecting
@@ -216,11 +217,13 @@ param("build_custom_name", statusCheckName)
 ```
 
 GitHub branch protection should require only the `TeamCity CI` status check.
-The status is published by the final `CI` pipeline job, which depends on the
-earlier job, so it represents the pull request validation chain.
+The `TeamCity CI` status is published by the final `CI` pipeline job, which
+depends on the earlier job, so it represents the pull request validation chain.
 
-Do not require the `Figma Sync` pipeline in GitHub branch protection. That
-pipeline runs after changes reach `main`.
+`Figma Sync` publishes `TeamCity Figma Sync` from its final job so `main`
+commits show whether post-merge Figma documentation verification passed. Do not
+require that status in GitHub branch protection because the pipeline runs after
+changes reach `main`.
 
 Do not add a raw GitHub token to the repository. The VCS root credentials or a
 TeamCity-managed GitHub App token must provide permission to write commit
@@ -269,7 +272,8 @@ For this project, the generated pipeline should:
 - reference only one Git VCS root for the GitHub repository;
 - emit job-level `repositories` entries;
 - emit direct Gradle script content;
-- emit `commit-status-publisher` only on the final `CI` job;
+- emit `commit-status-publisher` on the final `CI` job and the final
+  `Figma Sync` job;
 - keep `Figma Sync` as a separate default-branch pipeline;
 - emit `buildDependencyTrigger` for `Figma Sync`, pointing at `CI`, with
   `afterSuccessfulBuildOnly=true`.

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -109,7 +109,9 @@ object WaterMyPlantsCi : Pipeline({
  * the trunk state, not for every short-lived branch. The MCP-operated visual
  * sync still runs outside TeamCity; this pipeline generates the trunk model and
  * either verifies the metadata after Figma has been updated or fails visibly
- * until the MCP sync is run and the pipeline is rerun.
+ * until the MCP sync is run and the pipeline is rerun. The final job publishes
+ * an optional GitHub status so the post-merge documentation state is visible on
+ * `main` commits without becoming a pull request merge gate.
  */
 object WaterMyPlantsFigmaSync : Pipeline({
     id("WaterMyPlantsFigmaSync")
@@ -169,6 +171,10 @@ object WaterMyPlantsFigmaSync : Pipeline({
                 name = "Verify Figma sync metadata"
                 scriptContent = """.\gradlew.bat checkFigmaTrunkSync"""
             })
+        }
+
+        features {
+            feature(GitHubStatusPublisher("TeamCity Figma Sync"))
         }
 
         dependency("figma_sync_generate_design_model", listOf("build/reports/figma-sync/design-model.json"))

--- a/docs/ci/main-branch-protection.md
+++ b/docs/ci/main-branch-protection.md
@@ -52,7 +52,8 @@ a GitHub Checks API run. The PR can therefore show `Checks (0)` while still
 showing `All checks have passed` for `TeamCity CI`.
 
 Do not require `Figma Sync` in the GitHub ruleset. `Figma Sync` runs after
-changes reach `main`.
+changes reach `main`. It may still appear on `main` commits as the optional
+`TeamCity Figma Sync` status.
 
 ## TeamCity CI
 
@@ -83,6 +84,10 @@ Finish Build Trigger.
 The Figma write step is currently MCP-operated. If `Figma Sync` fails because
 Figma is out of sync, run the MCP visual sync with the generated
 `design-model.json`, then rerun `Figma Sync`.
+
+The final `Figma Sync` job publishes the optional `TeamCity Figma Sync` commit
+status to GitHub so the post-merge documentation state is visible from the
+commit page.
 
 ## If CI Fails On Main
 


### PR DESCRIPTION
## Summary

- Publish the optional `TeamCity Figma Sync` GitHub status from the final Figma Sync verification job.
- Document that GitHub branch protection should keep requiring only `TeamCity CI`.
- Clarify that `TeamCity Figma Sync` is visible on `main` commits as post-merge documentation verification.

## Verification

- `./mvnw.cmd -f .teamcity/pom.xml teamcity-configs:generate`
- `teamcity project settings validate .teamcity --verbose`