### PR TITLE
chore(codex): ignore local project config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ teamcity.toml
 
 # Cucumber+ IDE plugin generated files
 **/.cucumber+/
+
+# Codex local project configuration
+.codex/config.toml


### PR DESCRIPTION
## What changed

- Ignore `.codex/config.toml` so project-local Codex settings such as Memories remain local.

## Why

Memories are useful for this checkout, but they should not become a versioned team-wide contract. Required agent behavior remains in `AGENTS.md` and repository documentation.

## Verification

- Inspected the diff: only `.gitignore` changes.
- TeamCity CI passed for `chore/ignore-codex-project-config`.