### PR TITLE
feat(figma-design-sync): render convention plugin dependency usage

### DIFF
--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/catalog/ProjectCatalogTreesDataSource.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/catalog/ProjectCatalogTreesDataSource.kt
@@ -42,7 +42,8 @@ class ProjectCatalogTreesDataSource(
         when (source) {
             is ProjectCatalogTreeSource.DependenciesDslVersionAliases ->
                 dependenciesCatalogTreesReader.readLibraryTreeWithVersionAliases(
-                    rootDir = File(source.rootDirPath)
+                    rootDir = File(source.rootDirPath),
+                    conventionPluginIncludedBuilds = source.conventionPluginIncludedBuilds
                 )
 
             is ProjectCatalogTreeSource.IncludedBuildSettings ->

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
@@ -9,10 +9,12 @@ import com.marmatsan.dependencies.Versions
 import com.marmatsan.figmaDesignSync.data.gradle.catalog.GradleCatalogUsageReader
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.port.gradle.IncludedBuildSource
 import java.io.File
 import me.tatarka.inject.annotations.Inject
 
@@ -48,11 +50,18 @@ class DependenciesCatalogTreesReader(
      * repository-owned version key that should be edited.
      */
     fun readLibraryTreeWithVersionAliases(
-        rootDir: File
+        rootDir: File,
+        conventionPluginIncludedBuilds: List<IncludedBuildSource> = emptyList()
     ): LibraryCatalogTree =
         readLibraryTree(versions = CatalogVersionAliases)
             .withLibraryUsages(
                 gradleCatalogUsageReader.readMainLibraryUsages(rootDir)
+            )
+            .withConventionPluginUsages(
+                readConventionPluginLibraryUsages(
+                    rootDir = rootDir,
+                    includedBuilds = conventionPluginIncludedBuilds
+                )
             )
 
     /**
@@ -89,6 +98,32 @@ class DependenciesCatalogTreesReader(
     ): PluginCatalogTree = PluginCatalogTree(
         roots = roots.map { root -> root.toPluginCatalogNode() }
     )
+
+    private fun readConventionPluginLibraryUsages(
+        rootDir: File,
+        includedBuilds: List<IncludedBuildSource>
+    ): ConventionPluginLibraryUsages {
+        val modulesByPluginId = gradleCatalogUsageReader.readMainAppliedLiteralPluginUsages(rootDir)
+
+        return includedBuilds
+            .filter(IncludedBuildSource::publishesConventionPlugins)
+            .fold(ConventionPluginLibraryUsages()) { usages, includedBuild ->
+                val includedBuildRootDir = File(includedBuild.rootDirPath)
+                val libraryUsages = gradleCatalogUsageReader.readConventionLibraryUsages(
+                    rootDir = includedBuildRootDir,
+                    modulePathPrefix = includedBuild.modulePathPrefix
+                )
+                val pluginIdsByModule = gradleCatalogUsageReader.readConventionPluginIdsByModule(
+                    rootDir = includedBuildRootDir,
+                    modulePathPrefix = includedBuild.modulePathPrefix
+                )
+
+                usages + libraryUsages.toConventionPluginLibraryUsages(
+                    pluginIdsByModule = pluginIdsByModule,
+                    modulesByPluginId = modulesByPluginId
+                )
+            }
+    }
 }
 
 private fun Node<DependencyNode.Library>.toLibraryCatalogNode(): LibraryCatalogNode {
@@ -160,6 +195,81 @@ private fun LibraryCatalogEntry.withLibraryUsages(
         )
     }
 
+private fun LibraryCatalogTree.withConventionPluginUsages(
+    usages: ConventionPluginLibraryUsages
+): LibraryCatalogTree =
+    copy(
+        roots = roots.map { node -> node.withConventionPluginUsages(usages) }
+    )
+
+private fun LibraryCatalogNode.withConventionPluginUsages(
+    usages: ConventionPluginLibraryUsages,
+    parentGroup: String = ""
+): LibraryCatalogNode {
+    val groupPath = listOf(parentGroup, group)
+        .filter(String::isNotBlank)
+        .joinToString(".")
+
+    return copy(
+        entries = entries.map { entry -> entry.withConventionPluginUsages(groupPath, usages) },
+        children = children.map { child -> child.withConventionPluginUsages(usages, groupPath) }
+    )
+}
+
+private fun LibraryCatalogEntry.withConventionPluginUsages(
+    group: String,
+    usages: ConventionPluginLibraryUsages
+): LibraryCatalogEntry =
+    when (this) {
+        is LibraryCatalogEntry.Artifact -> copy(
+            providedByConventionPlugins = usages.coordinates["$group:$artifact"].orEmpty()
+        )
+
+        is LibraryCatalogEntry.ArtifactsBundle -> copy(
+            providedByConventionPlugins = usages.bundles[alias].orEmpty()
+        )
+    }
+
+private fun GradleCatalogUsageReader.LibraryUsages.toConventionPluginLibraryUsages(
+    pluginIdsByModule: Map<String, Set<String>>,
+    modulesByPluginId: Map<String, Set<String>>
+): ConventionPluginLibraryUsages =
+    ConventionPluginLibraryUsages(
+        coordinates = coordinates.toConventionPluginUsageMap(
+            pluginIdsByModule = pluginIdsByModule,
+            modulesByPluginId = modulesByPluginId
+        ),
+        bundles = bundles.toConventionPluginUsageMap(
+            pluginIdsByModule = pluginIdsByModule,
+            modulesByPluginId = modulesByPluginId
+        )
+    )
+
+private fun Map<String, Set<String>>.toConventionPluginUsageMap(
+    pluginIdsByModule: Map<String, Set<String>>,
+    modulesByPluginId: Map<String, Set<String>>
+): Map<String, List<ConventionPluginUsage>> =
+    mapValues { (_, pluginModules) ->
+        pluginModules
+            .flatMap { pluginModule ->
+                pluginIdsByModule[pluginModule].orEmpty().mapNotNull { pluginId ->
+                    val requiredByModules = modulesByPluginId[pluginId].orEmpty().sorted()
+                    if (requiredByModules.isEmpty()) {
+                        null
+                    } else {
+                        ConventionPluginUsage(
+                            pluginId = pluginId,
+                            pluginModule = pluginModule,
+                            requiredByModules = requiredByModules
+                        )
+                    }
+                }
+            }
+            .distinct()
+            .sortedWith(compareBy(ConventionPluginUsage::pluginId, ConventionPluginUsage::pluginModule))
+    }
+        .filterValues(List<ConventionPluginUsage>::isNotEmpty)
+
 private fun PluginCatalogTree.withPluginUsages(
     usages: Map<String, Set<String>>
 ): PluginCatalogTree =
@@ -194,6 +304,28 @@ private operator fun GradleCatalogUsageReader.LibraryUsages.plus(
         bundles = bundles.merge(other.bundles),
         aliases = aliases.merge(other.aliases)
     )
+
+private data class ConventionPluginLibraryUsages(
+    val coordinates: Map<String, List<ConventionPluginUsage>> = emptyMap(),
+    val bundles: Map<String, List<ConventionPluginUsage>> = emptyMap()
+)
+
+private operator fun ConventionPluginLibraryUsages.plus(
+    other: ConventionPluginLibraryUsages
+): ConventionPluginLibraryUsages =
+    ConventionPluginLibraryUsages(
+        coordinates = coordinates.mergeConventionPluginUsages(other.coordinates),
+        bundles = bundles.mergeConventionPluginUsages(other.bundles)
+    )
+
+private fun Map<String, List<ConventionPluginUsage>>.mergeConventionPluginUsages(
+    other: Map<String, List<ConventionPluginUsage>>
+): Map<String, List<ConventionPluginUsage>> =
+    (keys + other.keys).associateWith { key ->
+        (this[key].orEmpty() + other[key].orEmpty())
+            .distinct()
+            .sortedWith(compareBy(ConventionPluginUsage::pluginId, ConventionPluginUsage::pluginModule))
+    }
 
 private fun libraryAlias(
     libraryGroup: String,

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReader.kt
@@ -59,6 +59,23 @@ class GradleCatalogUsageReader {
             }
     }
 
+    fun readConventionPluginIdsByModule(
+        rootDir: File,
+        modulePathPrefix: String
+    ): Map<String, Set<String>> =
+        rootDir
+            .conventionPluginModuleDirs()
+            .associate { moduleDir ->
+                val modulePath = moduleDir.toIncludedBuildModulePath(rootDir, modulePathPrefix)
+                val pluginIds = moduleDir
+                    .resolve(BUILD_FILE_NAME)
+                    .readText()
+                    .pluginIds()
+                    .toSet()
+
+                modulePath to pluginIds
+            }
+
     fun readIncludedBuildLibraryUsages(
         rootDir: File,
         modulePathPrefix: String
@@ -310,6 +327,11 @@ class GradleCatalogUsageReader {
     private fun String.hasGradleConventionPluginImplementation(): Boolean =
         GradleConventionPluginImplementationRegex.containsMatchIn(this)
 
+    private fun String.pluginIds(): Sequence<String> =
+        sequenceOf(pluginNameRegex, pluginIdRegex)
+            .flatMap { regex -> regex.findAll(this) }
+            .map { match -> match.groupValues[1] }
+
     /**
      * Usage index for libraries declared as direct coordinates or bundles.
      *
@@ -342,6 +364,8 @@ class GradleCatalogUsageReader {
         val mainPluginAliasRegex = Regex("""alias\s*\(\s*plugins\.plugins\.([A-Za-z0-9_.]+)\s*\)""")
         val literalPluginIdRegex = Regex("""\bid\s*\(\s*"([^"]+)"\s*\)""")
         val applyFalseRegex = Regex("""\bapply\s+false\b""")
+        val pluginNameRegex = Regex("val\\s+pluginName\\s*=\\s*\"([^\"]+)\"")
+        val pluginIdRegex = Regex("id\\s*=\\s*\"([^\"]+)\"")
         val GradleConventionPluginImplementationRegex = Regex(
             "implementationClass\\s*=\\s*\"[^\"]*GradleConventionPlugin\""
         )

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReaderTest.kt
@@ -5,10 +5,12 @@ import com.marmatsan.dependencies.tree.dsl.plugin.pluginTree
 import com.marmatsan.figmaDesignSync.data.gradle.catalog.GradleCatalogUsageReader
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.port.gradle.IncludedBuildSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.io.File
@@ -169,6 +171,119 @@ internal class DependenciesCatalogTreesReaderTest : FunSpec({
         actualTree.findArtifact("io.mockk", "mockk").requiredByModules shouldBe emptyList()
     }
 
+    test("readLibraryTreeWithVersionAliases maps convention plugin providers to main build modules") {
+        // GIVEN
+        val rootDir = Files.createTempDirectory("water-my-plants-convention-library-usages").toFile()
+        rootDir.writeBuildFile(
+            path = "app",
+            content = """
+            plugins {
+                id("com.marmatsan.compose")
+            }
+            """.trimIndent()
+        )
+        rootDir.writeBuildFile(
+            path = "core/ui",
+            content = """
+            plugins {
+                id("com.marmatsan.compose")
+            }
+            """.trimIndent()
+        )
+        rootDir.writeBuildFile(
+            path = "onboarding/ui",
+            content = """
+            plugins {
+                id("com.marmatsan.android")
+            }
+            """.trimIndent()
+        )
+        val includedBuildRootDir = rootDir.resolve("repo/gradle-plugins")
+        includedBuildRootDir.writeBuildFile(
+            path = "compose",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.compose"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.compose.plugin.ComposeGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeKotlinFile(
+            path = "compose/src/main/kotlin/com/marmatsan/compose/plugin",
+            fileName = "ComposeGradleConventionPlugin.kt",
+            content = """
+            package com.marmatsan.compose.plugin
+
+            fun configure() {
+                libs.implementation(
+                    libraryGroup = "androidx.activity",
+                    artifact = "activity-compose"
+                )
+                libs.implementationBundle(
+                    bundle = "composeBundle"
+                )
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeBuildFile(
+            path = "unit-test",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.unitTest"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.unitTest.plugin.UnitTestGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeKotlinFile(
+            path = "unit-test/src/main/kotlin/com/marmatsan/unitTest/plugin",
+            fileName = "UnitTestGradleConventionPlugin.kt",
+            content = """
+            package com.marmatsan.unitTest.plugin
+
+            fun configure() {
+                libs.implementation(
+                    libraryGroup = "io.mockk",
+                    artifact = "mockk"
+                )
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val actualTree = dependenciesCatalogTreesReader().readLibraryTreeWithVersionAliases(
+            rootDir = rootDir,
+            conventionPluginIncludedBuilds = listOf(
+                IncludedBuildSource(
+                    settingsFilePath = includedBuildRootDir.resolve("settings.gradle.kts").absolutePath,
+                    rootDirPath = includedBuildRootDir.absolutePath,
+                    modulePathPrefix = ":gradle-plugins",
+                    publishesConventionPlugins = true
+                )
+            )
+        )
+
+        // THEN
+        val expectedComposeUsage = listOf(
+            ConventionPluginUsage(
+                pluginId = "com.marmatsan.compose",
+                pluginModule = ":gradle-plugins:compose",
+                requiredByModules = listOf(":app", ":core:ui")
+            )
+        )
+        actualTree.findArtifact("androidx.activity", "activity-compose")
+            .providedByConventionPlugins shouldBe expectedComposeUsage
+        actualTree.findBundle("androidx.compose.ui", "composeBundle")
+            .providedByConventionPlugins shouldBe expectedComposeUsage
+        actualTree.findArtifact("io.mockk", "mockk")
+            .providedByConventionPlugins shouldBe emptyList()
+    }
+
     test("readPluginTreeWithVersionAliases scopes applied modules to the main build catalog") {
         // GIVEN
         val rootDir = Files.createTempDirectory("water-my-plants-plugin-usages").toFile()
@@ -271,4 +386,14 @@ private fun File.writeBuildFile(
     val directory = resolve(path)
     directory.mkdirs()
     directory.resolve("build.gradle.kts").writeText(content)
+}
+
+private fun File.writeKotlinFile(
+    path: String,
+    fileName: String,
+    content: String
+) {
+    val directory = resolve(path)
+    directory.mkdirs()
+    directory.resolve(fileName).writeText(content)
 }

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReaderTest.kt
@@ -62,6 +62,47 @@ internal class GradleCatalogUsageReaderTest : FunSpec({
         )
     }
 
+    test("readConventionPluginIdsByModule maps convention plugin ids to their implementing modules") {
+        // GIVEN
+        val rootDir = Files.createTempDirectory("convention-plugin-ids").toFile()
+        val includedBuildRootDir = rootDir.resolve("repo/gradle-plugins")
+        includedBuildRootDir.writeBuildFile(
+            path = "compose",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.compose"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.compose.plugin.ComposeGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeBuildFile(
+            path = "figma-design-sync",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.figmaDesignSync"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.figmaDesignSync.plugin.FigmaDesignSyncGradlePlugin"
+                }
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val pluginIdsByModule = GradleCatalogUsageReader().readConventionPluginIdsByModule(
+            rootDir = includedBuildRootDir,
+            modulePathPrefix = ":gradle-plugins"
+        )
+
+        // THEN
+        pluginIdsByModule shouldBe mapOf(
+            ":gradle-plugins:compose" to setOf("com.marmatsan.compose")
+        )
+    }
+
     test("readMainLiteralPluginUsages maps literal plugin ids to main modules") {
         // GIVEN
         val rootDir = Files.createTempDirectory("main-literal-plugin-usages").toFile()

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -124,6 +124,9 @@ Important generation details:
 - `content.catalogs` contains Water My Plants libraries/plugins, catalog data
   from included builds that publish settings catalogs, custom Gradle convention
   plugins, and regular custom Gradle plugins.
+- Water My Plants library entries include `providedByConventionPlugins`. Each
+  item records the convention plugin id, the Gradle module that implements it,
+  and the production modules that receive the dependency through that plugin.
 - `dependencyCatalog` contributes modules and module dependencies but not
   `content.catalogs.dependencyCatalog` because
   `repo/dependency-catalog/settings.gradle.kts` does not declare

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -85,17 +85,23 @@ For each section:
 - Update existing library artifact name/version text overrides when the
   instance structure can represent the model.
 - Update `Required by` module instances for library artifacts from
-  `requiredByModules`.
+  `requiredByModules` plus the modules listed by each
+  `providedByConventionPlugins.requiredByModules` entry.
+- Library artifacts and bundles may also carry `providedByConventionPlugins`.
+  Each usage has `pluginId`, `pluginModule`, and `requiredByModules`; it is the
+  model source for `Provided by` `.usage chip kind=convention-plugin` rows.
 - Update `Required by` module instances for `.artifacts bundle` entries from
-  the bundle `requiredByModules`. Child `.artifact` instances inside a bundle
-  must not show their own `Required by` section.
+  the bundle `requiredByModules` plus the modules listed by each
+  `providedByConventionPlugins.requiredByModules` entry. Child `.artifact`
+  instances inside a bundle must not show their own `Required by` section.
 - Update `Applied by` module instances for plugin tree nodes from
   `appliedToModules`.
-- Represent consumer modules with `.module` instances. If the component exposes
-  a `size` variant, set it to `small`; the deleted `big` variant is no longer
-  used.
-- Update the `.module` `name` variant instead of editing inner text overrides
-  directly.
+- Represent usage metadata with `.usage chip` instances.
+- `.usage chip` exposes only two `kind` variants: `module` for modules that
+  require or apply an item, and `convention-plugin` for Gradle convention
+  plugins that provide dependencies to production modules.
+- `.usage chip` exposes `name` as a text component property bound to the label.
+  Do not add a variant for every module, plugin, artifact, or dependency name.
 - Create missing `.tree node` instances by cloning a compatible existing node
   from the same visual section, then applying generated model values.
 - Create missing top-level tree sections when a new top-level library group or

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/catalog/LibraryCatalogEntry.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/catalog/LibraryCatalogEntry.kt
@@ -12,17 +12,35 @@ package com.marmatsan.figmaDesignSync.domain.model.catalog
  */
 sealed interface LibraryCatalogEntry {
     /**
+     * Gradle convention plugin that provides a dependency to production modules.
+     *
+     * @property pluginId Gradle plugin id applied by production modules.
+     * @property pluginModule Gradle module path that implements the convention
+     * plugin.
+     * @property requiredByModules Sorted production module paths that receive
+     * this dependency through the convention plugin.
+     */
+    data class ConventionPluginUsage(
+        val pluginId: String,
+        val pluginModule: String,
+        val requiredByModules: List<String> = emptyList()
+    )
+
+    /**
      * Single Maven artifact declared in a version catalog or dependency DSL.
      *
      * @property artifact Maven artifact id without the group.
      * @property version Version metadata rendered with the artifact.
      * @property requiredByModules Sorted Gradle module paths that use this
      * artifact.
+     * @property providedByConventionPlugins Gradle convention plugins that
+     * provide this artifact to production modules.
      */
     data class Artifact(
         val artifact: String,
         val version: CatalogVersion,
-        val requiredByModules: List<String> = emptyList()
+        val requiredByModules: List<String> = emptyList(),
+        val providedByConventionPlugins: List<ConventionPluginUsage> = emptyList()
     ) : LibraryCatalogEntry
 
     /**
@@ -36,11 +54,14 @@ sealed interface LibraryCatalogEntry {
      * @property version Version metadata shared by the bundle.
      * @property requiredByModules Sorted Gradle module paths that use this
      * bundle.
+     * @property providedByConventionPlugins Gradle convention plugins that
+     * provide this bundle to production modules.
      */
     data class ArtifactsBundle(
         val alias: String,
         val artifacts: List<String>,
         val version: CatalogVersion,
-        val requiredByModules: List<String> = emptyList()
+        val requiredByModules: List<String> = emptyList(),
+        val providedByConventionPlugins: List<ConventionPluginUsage> = emptyList()
     ) : LibraryCatalogEntry
 }

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/catalog/ProjectCatalogTreeSource.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/catalog/ProjectCatalogTreeSource.kt
@@ -28,9 +28,12 @@ sealed interface ProjectCatalogTreeSource {
      * and `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt`.
      *
      * @property rootDirPath Repository root containing the dependency DSL.
+     * @property conventionPluginIncludedBuilds Included builds that may provide
+     * dependency DSL libraries through repository convention plugins.
      */
     data class DependenciesDslVersionAliases(
-        val rootDirPath: String
+        val rootDirPath: String,
+        val conventionPluginIncludedBuilds: List<IncludedBuildSource> = emptyList()
     ) : ProjectCatalogTreeSource
 
     /**

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/samples/DomainKDocSamples.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/samples/DomainKDocSamples.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.domain.samples
 
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
@@ -39,7 +40,14 @@ internal object DomainKDocSamples {
         val artifact = LibraryCatalogEntry.Artifact(
             artifact = "kotlin-stdlib",
             version = CatalogVersion("2.4.0"),
-            requiredByModules = listOf(":app")
+            requiredByModules = listOf(":app"),
+            providedByConventionPlugins = listOf(
+                ConventionPluginUsage(
+                    pluginId = "com.marmatsan.compose",
+                    pluginModule = ":gradle-plugins:compose",
+                    requiredByModules = listOf(":app")
+                )
+            )
         )
 
         val bundle = LibraryCatalogEntry.ArtifactsBundle(
@@ -50,6 +58,7 @@ internal object DomainKDocSamples {
         )
 
         check(artifact.requiredByModules == listOf(":app"))
+        check(artifact.providedByConventionPlugins.single().pluginModule == ":gradle-plugins:compose")
         check(bundle.artifacts.contains("ui-tooling"))
     }
 

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
@@ -104,7 +104,8 @@ internal class FigmaDesignModelGenerator(
                         projectCatalogTreesPort
                             .readLibraryTree(
                                 ProjectCatalogTreeSource.DependenciesDslVersionAliases(
-                                    rootDirPath = request.projectRootDirectory.absolutePath
+                                    rootDirPath = request.projectRootDirectory.absolutePath,
+                                    conventionPluginIncludedBuilds = conventionPluginIncludedBuilds
                                 )
                             )
                             .toDesignJson()
@@ -199,6 +200,6 @@ internal class FigmaDesignModelGenerator(
         }
 
     private companion object {
-        const val SCHEMA_VERSION = 1
+        const val SCHEMA_VERSION = 2
     }
 }

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.plugin.generator
 
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
@@ -92,6 +93,7 @@ private fun LibraryCatalogEntry.toDesignJson(): JsonObject =
             put("artifact", artifact)
             put("version", version.toDesignJson())
             put("requiredByModules", requiredByModules.toSortedJsonArray())
+            put("providedByConventionPlugins", providedByConventionPlugins.toDesignJson())
         }
 
         is LibraryCatalogEntry.ArtifactsBundle -> buildJsonObject {
@@ -100,8 +102,25 @@ private fun LibraryCatalogEntry.toDesignJson(): JsonObject =
             put("artifacts", artifacts.sorted().toJsonArray())
             put("version", version.toDesignJson())
             put("requiredByModules", requiredByModules.toSortedJsonArray())
+            put("providedByConventionPlugins", providedByConventionPlugins.toDesignJson())
         }
     }
+
+private fun List<ConventionPluginUsage>.toDesignJson(): JsonArray =
+    sortedWith(
+        compareBy<ConventionPluginUsage>(
+            { usage -> usage.pluginId },
+            { usage -> usage.pluginModule }
+        )
+    )
+        .map { usage ->
+            buildJsonObject {
+                put("pluginId", usage.pluginId)
+                put("pluginModule", usage.pluginModule)
+                put("requiredByModules", usage.requiredByModules.toSortedJsonArray())
+            }
+        }
+        .let(::JsonArray)
 
 /**
  * Converts a plugin catalog tree to the array consumed by Figma plugin tree

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.plugin.generator
 
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
@@ -86,6 +87,47 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
             section.jsonObject["name"]?.jsonPrimitive?.content
         } shouldBe listOf("Main project dependencies", "Libraries")
     }
+
+    test("generate writes convention plugin provenance for library artifacts") {
+        // GIVEN
+        val generator = generator()
+
+        // WHEN
+        val result = generator.generate(request())
+
+        // THEN
+        val usages = result.model["content"]
+            ?.jsonObject
+            ?.get("catalogs")
+            ?.jsonObject
+            ?.get("waterMyPlants")
+            ?.jsonObject
+            ?.get("libraries")
+            ?.jsonArray
+            ?.single()
+            ?.jsonObject
+            ?.get("entries")
+            ?.jsonArray
+            ?.single()
+            ?.jsonObject
+            ?.get("providedByConventionPlugins")
+            ?.jsonArray
+
+        usages?.map { usage ->
+            val usageObject = usage.jsonObject
+            Triple(
+                usageObject["pluginId"]?.jsonPrimitive?.content,
+                usageObject["pluginModule"]?.jsonPrimitive?.content,
+                usageObject["requiredByModules"]?.jsonArray?.map { module -> module.jsonPrimitive.content }
+            )
+        } shouldBe listOf(
+            Triple(
+                "com.marmatsan.compose",
+                ":gradle-plugins:compose",
+                listOf(":app", ":core:ui")
+            )
+        )
+    }
 })
 
 private fun generator(): FigmaDesignModelGenerator =
@@ -140,8 +182,23 @@ private object FakeRepositoryVersionsPort : RepositoryVersionsPort {
 }
 
 private object FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
-    override fun readLibraryTree(source: ProjectCatalogTreeSource): LibraryCatalogTree =
-        LibraryCatalogTree(
+    override fun readLibraryTree(source: ProjectCatalogTreeSource): LibraryCatalogTree {
+        val conventionPluginUsages = if (
+            source is ProjectCatalogTreeSource.DependenciesDslVersionAliases &&
+            source.conventionPluginIncludedBuilds.any { includedBuild -> includedBuild.modulePathPrefix == ":gradle-plugins" }
+        ) {
+            listOf(
+                ConventionPluginUsage(
+                    pluginId = "com.marmatsan.compose",
+                    pluginModule = ":gradle-plugins:compose",
+                    requiredByModules = listOf(":core:ui", ":app")
+                )
+            )
+        } else {
+            emptyList()
+        }
+
+        return LibraryCatalogTree(
             roots = listOf(
                 LibraryCatalogNode(
                     group = "org.jetbrains.kotlin",
@@ -149,12 +206,14 @@ private object FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
                         LibraryCatalogEntry.Artifact(
                             artifact = "kotlin-stdlib",
                             version = CatalogVersion("2.4.0"),
-                            requiredByModules = listOf(":app")
+                            requiredByModules = listOf(":app"),
+                            providedByConventionPlugins = conventionPluginUsages
                         )
                     )
                 )
             )
         )
+    }
 
     override fun readPluginTree(source: ProjectCatalogTreeSource): PluginCatalogTree =
         PluginCatalogTree(

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -49,12 +49,15 @@ export const ARTIFACTS_BUNDLE_PROPS = {
 
 export const ARTIFACT_INSTANCE_NAME = ".artifact";
 export const ARTIFACTS_BUNDLE_INSTANCE_NAME = ".artifacts bundle";
-export const MODULE_INSTANCE_NAME = ".module";
-export const MODULE_PROPS = {
+export const USAGE_CHIP_INSTANCE_NAME = ".usage chip";
+export const USAGE_CHIP_PROPS = {
+  kind: "kind",
   name: "name",
-  size: "size",
 };
-export const SMALL_MODULE_SIZE = "small";
+export const USAGE_CHIP_KINDS = {
+  module: "module",
+  conventionPlugin: "convention-plugin",
+};
 
 export const CATALOG_TREE_TARGETS: CatalogTreeTarget[] = [
   {

--- a/repo/figma-design-sync/tools/src/domain/catalog/library-catalog-entries.ts
+++ b/repo/figma-design-sync/tools/src/domain/catalog/library-catalog-entries.ts
@@ -5,8 +5,9 @@ export function libraryArtifactNames(entries) {
 export function libraryArtifacts(entries) {
   return entries.flatMap((entry) => {
     if (entry.type === "artifact") {
-      const requiredByModules = sortedUnique(entry.requiredByModules || []);
-      return [{ name: entry.artifact, requiredByModules }];
+      const providedByConventionPlugins = sortedConventionPluginUsages(entry.providedByConventionPlugins || []);
+      const requiredByModules = effectiveRequiredByModules(entry.requiredByModules || [], providedByConventionPlugins);
+      return [{ name: entry.artifact, requiredByModules, providedByConventionPlugins }];
     }
     if (entry.type === "bundle") {
       return (entry.artifacts || []).map((artifact) => ({ name: artifact, requiredByModules: [] }));
@@ -18,10 +19,14 @@ export function libraryArtifacts(entries) {
 export function libraryBundles(entries) {
   return entries
     .filter((entry) => entry.type === "bundle")
-    .map((entry) => ({
-      alias: entry.alias,
-      requiredByModules: sortedUnique(entry.requiredByModules || []),
-    }));
+    .map((entry) => {
+      const providedByConventionPlugins = sortedConventionPluginUsages(entry.providedByConventionPlugins || []);
+      return {
+        alias: entry.alias,
+        requiredByModules: effectiveRequiredByModules(entry.requiredByModules || [], providedByConventionPlugins),
+        providedByConventionPlugins,
+      };
+    });
 }
 
 export function libraryArtifactVersions(entries) {
@@ -36,4 +41,24 @@ export function libraryArtifactVersions(entries) {
 
 export function sortedUnique(values) {
   return [...new Set(values)].sort();
+}
+
+function sortedConventionPluginUsages(usages) {
+  return [...usages]
+    .map((usage) => ({
+      pluginId: usage.pluginId,
+      pluginModule: usage.pluginModule,
+      requiredByModules: sortedUnique(usage.requiredByModules || []),
+    }))
+    .sort((first, second) =>
+      first.pluginId.localeCompare(second.pluginId) ||
+        first.pluginModule.localeCompare(second.pluginModule)
+    );
+}
+
+function effectiveRequiredByModules(requiredByModules, providedByConventionPlugins) {
+  return sortedUnique([
+    ...requiredByModules,
+    ...providedByConventionPlugins.flatMap((usage) => usage.requiredByModules || []),
+  ]);
 }

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -3,11 +3,12 @@ import {
   ARTIFACTS_BUNDLE_INSTANCE_NAME,
   ARTIFACTS_BUNDLE_PROPS,
   ARTIFACT_PROPS,
-  MODULE_INSTANCE_NAME,
-  MODULE_PROPS,
-  SMALL_MODULE_SIZE,
+  USAGE_CHIP_INSTANCE_NAME,
+  USAGE_CHIP_KINDS,
+  USAGE_CHIP_PROPS,
 } from "../config/figma-config";
-import { loadTextNodeFonts, updateNamedTextNodes } from "./figma-text-gateway";
+import { sortedUnique } from "../domain/catalog/library-catalog-entries";
+import { loadTextNodeFonts } from "./figma-text-gateway";
 
 type ConsumerModuleOptions = {
   excludeArtifactDescendants?: boolean;
@@ -27,11 +28,18 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
   for (let index = 0; index < artifacts.length; index += 1) {
     const artifactInstance = artifactInstances[index];
     const artifact = artifacts[index];
+    const providedByConventionPlugins = usageChipsForConventionPlugins(artifact.providedByConventionPlugins || []);
     artifactInstance.visible = true;
     artifactInstance.setProperties({
-      [ARTIFACT_PROPS.showConsumerModules]: artifact.requiredByModules.length > 0,
+      [ARTIFACT_PROPS.showConsumerModules]: artifact.requiredByModules.length > 0 || providedByConventionPlugins.length > 0,
     });
     mutatedNodeIds.push(artifactInstance.id);
+    await updateUsageChipInstances(
+      artifactInstance,
+      "Provided by",
+      providedByConventionPlugins,
+      mutatedNodeIds
+    );
     await updateConsumerModuleInstances(
       artifactInstance,
       "Required by",
@@ -57,11 +65,19 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
   for (let index = 0; index < bundles.length; index += 1) {
     const bundleInstance = bundleInstances[index];
     const bundle = bundles[index];
+    const providedByConventionPlugins = usageChipsForConventionPlugins(bundle.providedByConventionPlugins || []);
     bundleInstance.visible = true;
     bundleInstance.setProperties({
-      [ARTIFACTS_BUNDLE_PROPS.showConsumerModules]: bundle.requiredByModules.length > 0,
+      [ARTIFACTS_BUNDLE_PROPS.showConsumerModules]: bundle.requiredByModules.length > 0 || providedByConventionPlugins.length > 0,
     });
     mutatedNodeIds.push(bundleInstance.id);
+    await updateUsageChipInstances(
+      bundleInstance,
+      "Provided by",
+      providedByConventionPlugins,
+      mutatedNodeIds,
+      { excludeArtifactDescendants: true }
+    );
     await updateConsumerModuleInstances(
       bundleInstance,
       "Required by",
@@ -81,28 +97,48 @@ export async function updateConsumerModuleInstances(
   mutatedNodeIds,
   options: ConsumerModuleOptions = {}
 ) {
-  if (modules.length > 0) {
-    requireConsumerModuleHeading(root, heading);
+  await updateUsageChipInstances(
+    root,
+    heading,
+    modules.map((moduleName) => ({
+      kind: USAGE_CHIP_KINDS.module,
+      name: moduleName,
+    })),
+    mutatedNodeIds,
+    options
+  );
+}
+
+export async function updateUsageChipInstances(
+  root,
+  heading,
+  usages,
+  mutatedNodeIds,
+  options: ConsumerModuleOptions = {}
+) {
+  if (usages.length > 0) {
+    requireUsageChipHeading(root, heading);
   }
 
-  const moduleInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
-    .filter((candidate) => candidate.name === MODULE_INSTANCE_NAME)
+  const usageChipInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
+    .filter((candidate) => candidate.name === USAGE_CHIP_INSTANCE_NAME)
+    .filter((candidate) => belongsToHeadingUsageChipBlock(candidate, root, heading))
     .filter((candidate) => !options.excludeArtifactDescendants || !hasAncestorInstanceNamed(candidate, ARTIFACT_INSTANCE_NAME, root));
 
-  if (moduleInstances.length < modules.length) {
+  if (usageChipInstances.length < usages.length) {
     throw new Error(
-      `Node '${root.id}' expected at least ${modules.length} '${MODULE_INSTANCE_NAME}' instances for '${heading}', ` +
-        `found ${moduleInstances.length}. Update the .tree node component structure before writing metadata.`
+      `Node '${root.id}' expected at least ${usages.length} '${USAGE_CHIP_INSTANCE_NAME}' instances for '${heading}', ` +
+        `found ${usageChipInstances.length}. Update the .tree node component structure before writing metadata.`
     );
   }
 
-  for (let index = 0; index < modules.length; index += 1) {
-    const moduleInstance = moduleInstances[index];
-    await setModuleInstance(moduleInstance, modules[index], mutatedNodeIds);
+  for (let index = 0; index < usages.length; index += 1) {
+    const usageChipInstance = usageChipInstances[index];
+    await setUsageChipInstance(usageChipInstance, usages[index], mutatedNodeIds);
   }
 
-  for (const moduleInstance of moduleInstances.slice(modules.length)) {
-    hideInstance(moduleInstance, mutatedNodeIds);
+  for (const usageChipInstance of usageChipInstances.slice(usages.length)) {
+    hideInstance(usageChipInstance, mutatedNodeIds);
   }
 }
 
@@ -115,37 +151,65 @@ function hasAncestorInstanceNamed(node, name, boundary) {
   return false;
 }
 
-function requireConsumerModuleHeading(root, heading) {
-  const hasHeading = root.findAllWithCriteria({ types: ["TEXT"] })
-    .some((textNode) => textNode.name === "label" && textNode.characters === heading);
+function requireUsageChipHeading(root, heading) {
+  const hasHeading = findUsageChipHeading(root, heading) !== undefined;
 
   if (!hasHeading) {
-    throw new Error(`Node '${root.id}' is missing '${heading}' consumer module heading text.`);
+    throw new Error(`Node '${root.id}' is missing '${heading}' usage chip heading text.`);
   }
 }
 
-async function setModuleInstance(moduleInstance, moduleName, mutatedNodeIds) {
-  requireModuleVariantProperty(moduleInstance, MODULE_PROPS.name);
+async function setUsageChipInstance(usageChipInstance, usage, mutatedNodeIds) {
+  const kindPropertyKey = requireUsageChipProperty(usageChipInstance, USAGE_CHIP_PROPS.kind, "VARIANT");
+  const namePropertyKey = requireUsageChipProperty(usageChipInstance, USAGE_CHIP_PROPS.name, "TEXT");
 
-  moduleInstance.visible = true;
-  const properties = moduleInstance.componentProperties?.[MODULE_PROPS.size]
-    ? {
-        [MODULE_PROPS.name]: moduleName,
-        [MODULE_PROPS.size]: SMALL_MODULE_SIZE,
-      }
-    : {
-        [MODULE_PROPS.name]: moduleName,
-      };
-
-  moduleInstance.setProperties(properties);
-  mutatedNodeIds.push(moduleInstance.id);
-  await updateNamedTextNodes(moduleInstance, "label", [moduleName], mutatedNodeIds);
-  await resizeModuleInstanceToFitLabel(moduleInstance, mutatedNodeIds);
-  resizeAncestorContainersToFit(moduleInstance, mutatedNodeIds);
+  usageChipInstance.visible = true;
+  usageChipInstance.setProperties({
+    [kindPropertyKey]: usage.kind,
+    [namePropertyKey]: usage.name,
+  });
+  mutatedNodeIds.push(usageChipInstance.id);
+  await resizeUsageChipInstanceToFitLabel(usageChipInstance, mutatedNodeIds);
+  resizeAncestorContainersToFit(usageChipInstance, mutatedNodeIds);
 }
 
-async function resizeModuleInstanceToFitLabel(moduleInstance, mutatedNodeIds) {
-  const label = moduleInstance.findAllWithCriteria({ types: ["TEXT"] })
+function belongsToHeadingUsageChipBlock(candidate, root, heading) {
+  const headingNode = findUsageChipHeading(root, heading);
+  if (!headingNode) return false;
+
+  const container = nearestAncestorWithUsageChips(headingNode, root) || root;
+  return candidate.id === container.id || hasAncestor(candidate, container);
+}
+
+function findUsageChipHeading(root, heading) {
+  return root.findAllWithCriteria({ types: ["TEXT"] })
+    .find((textNode) => textNode.name === "label" && textNode.characters === heading);
+}
+
+function nearestAncestorWithUsageChips(node, boundary) {
+  let current = node.parent;
+  while (current && current.id !== boundary.id) {
+    if ("findAllWithCriteria" in current) {
+      const hasUsageChips = current.findAllWithCriteria({ types: ["INSTANCE"] })
+        .some((candidate) => candidate.name === USAGE_CHIP_INSTANCE_NAME);
+      if (hasUsageChips) return current;
+    }
+    current = current.parent;
+  }
+  return boundary;
+}
+
+function hasAncestor(node, ancestor) {
+  let current = node.parent;
+  while (current) {
+    if (current.id === ancestor.id) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+async function resizeUsageChipInstanceToFitLabel(usageChipInstance, mutatedNodeIds) {
+  const label = usageChipInstance.findAllWithCriteria({ types: ["TEXT"] })
     .find((textNode) => textNode.name === "label");
   if (!label) return;
 
@@ -153,13 +217,13 @@ async function resizeModuleInstanceToFitLabel(moduleInstance, mutatedNodeIds) {
   label.textAutoResize = "WIDTH_AND_HEIGHT";
 
   const targetWidth = Math.ceil(label.x + label.width + MODULE_HORIZONTAL_PADDING);
-  const targetHeight = Math.ceil(Math.max(moduleInstance.height, label.y + label.height + MODULE_VERTICAL_PADDING));
-  if (moduleInstance.width < targetWidth || moduleInstance.height < targetHeight) {
-    moduleInstance.resizeWithoutConstraints(
-      Math.max(moduleInstance.width, targetWidth),
-      Math.max(moduleInstance.height, targetHeight)
+  const targetHeight = Math.ceil(Math.max(usageChipInstance.height, label.y + label.height + MODULE_VERTICAL_PADDING));
+  if (usageChipInstance.width < targetWidth || usageChipInstance.height < targetHeight) {
+    usageChipInstance.resizeWithoutConstraints(
+      Math.max(usageChipInstance.width, targetWidth),
+      Math.max(usageChipInstance.height, targetHeight)
     );
-    mutatedNodeIds.push(moduleInstance.id);
+    mutatedNodeIds.push(usageChipInstance.id);
   }
 }
 
@@ -206,13 +270,27 @@ function hideInstance(instance, mutatedNodeIds) {
   mutatedNodeIds.push(instance.id);
 }
 
-function requireModuleVariantProperty(moduleInstance, propertyName) {
-  const property = moduleInstance.componentProperties?.[propertyName];
-  if (!property || property.type !== "VARIANT") {
+function requireUsageChipProperty(moduleInstance, propertyName, propertyType) {
+  const properties = (moduleInstance.componentProperties || {}) as Record<string, { type: string }>;
+  const propertyEntry = Object.entries(properties)
+    .find(([key, property]) => (key === propertyName || key.startsWith(`${propertyName}#`)) && property.type === propertyType);
+
+  if (!propertyEntry) {
     throw new Error(
-      `Expected '${moduleInstance.id}' to be a '${MODULE_INSTANCE_NAME}' instance with '${propertyName}' variant property.`
+      `Expected '${moduleInstance.id}' to be a '${USAGE_CHIP_INSTANCE_NAME}' instance with '${propertyName}' ${propertyType} property.`
     );
   }
+
+  return propertyEntry[0];
+}
+
+function usageChipsForConventionPlugins(providedByConventionPlugins) {
+  return sortedUnique(
+    providedByConventionPlugins.map((usage) => usage.pluginId)
+  ).map((pluginId) => ({
+    kind: USAGE_CHIP_KINDS.conventionPlugin,
+    name: pluginId,
+  }));
 }
 
 const MODULE_HORIZONTAL_PADDING = 26;


### PR DESCRIPTION
## What changed

- Adds `providedByConventionPlugins` to the Figma design model for library artifacts and bundles.
- Populates convention plugin usage by crossing catalog dependencies with production modules that apply those plugins.
- Updates the Figma writer so `.usage chip` renders `Provided by` convention-plugin chips and aggregates `Required by` modules from direct and convention-provided usage.
- Updates the visual sync runbooks for the new contract.

## Validation

- `./gradlew.bat -p repo/figma-design-sync :domain:test :data:test :plugin:test`
- `npm run build` in `repo/figma-design-sync/tools`
- `git diff --check`
- TeamCity CI branch run: `WaterMyPlants_WaterMyPlantsCi/765` succeeded

## Figma sync note

This PR intentionally does not generate an official `design-model.json` locally. After merge, the post-merge TeamCity `Figma Sync` pipeline on `main` must generate the official artifact before the MCP visual write is run.