### PR TITLE
feat(figma-design-sync): render catalog tooling usage

### DIFF
--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
@@ -9,6 +9,7 @@ import com.marmatsan.dependencies.Versions
 import com.marmatsan.figmaDesignSync.data.gradle.catalog.GradleCatalogUsageReader
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginConfigurationUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
@@ -117,11 +118,19 @@ class DependenciesCatalogTreesReader(
                     rootDir = includedBuildRootDir,
                     modulePathPrefix = includedBuild.modulePathPrefix
                 )
-
-                usages + libraryUsages.toConventionPluginLibraryUsages(
-                    pluginIdsByModule = pluginIdsByModule,
-                    modulesByPluginId = modulesByPluginId
+                val configurationUsages = gradleCatalogUsageReader.readConventionLibraryConfigurationUsages(
+                    rootDir = includedBuildRootDir,
+                    modulePathPrefix = includedBuild.modulePathPrefix
                 )
+
+                usages +
+                    libraryUsages.toConventionPluginLibraryUsages(
+                        pluginIdsByModule = pluginIdsByModule,
+                        modulesByPluginId = modulesByPluginId
+                    ) +
+                    configurationUsages.toConventionPluginLibraryConfigurationUsages(
+                        pluginIdsByModule = pluginIdsByModule
+                    )
             }
     }
 }
@@ -222,7 +231,8 @@ private fun LibraryCatalogEntry.withConventionPluginUsages(
 ): LibraryCatalogEntry =
     when (this) {
         is LibraryCatalogEntry.Artifact -> copy(
-            providedByConventionPlugins = usages.coordinates["$group:$artifact"].orEmpty()
+            providedByConventionPlugins = usages.coordinates["$group:$artifact"].orEmpty(),
+            configuredByConventionPlugins = usages.configuredCoordinates["$group:$artifact"].orEmpty()
         )
 
         is LibraryCatalogEntry.ArtifactsBundle -> copy(
@@ -307,7 +317,8 @@ private operator fun GradleCatalogUsageReader.LibraryUsages.plus(
 
 private data class ConventionPluginLibraryUsages(
     val coordinates: Map<String, List<ConventionPluginUsage>> = emptyMap(),
-    val bundles: Map<String, List<ConventionPluginUsage>> = emptyMap()
+    val bundles: Map<String, List<ConventionPluginUsage>> = emptyMap(),
+    val configuredCoordinates: Map<String, List<ConventionPluginConfigurationUsage>> = emptyMap()
 )
 
 private operator fun ConventionPluginLibraryUsages.plus(
@@ -315,7 +326,35 @@ private operator fun ConventionPluginLibraryUsages.plus(
 ): ConventionPluginLibraryUsages =
     ConventionPluginLibraryUsages(
         coordinates = coordinates.mergeConventionPluginUsages(other.coordinates),
-        bundles = bundles.mergeConventionPluginUsages(other.bundles)
+        bundles = bundles.mergeConventionPluginUsages(other.bundles),
+        configuredCoordinates = configuredCoordinates.mergeConventionPluginConfigurationUsages(other.configuredCoordinates)
+    )
+
+private fun GradleCatalogUsageReader.LibraryConfigurationUsages.toConventionPluginLibraryConfigurationUsages(
+    pluginIdsByModule: Map<String, Set<String>>
+): ConventionPluginLibraryUsages =
+    ConventionPluginLibraryUsages(
+        configuredCoordinates = coordinates.mapValues { (_, usages) ->
+            usages
+                .flatMap { usage ->
+                    pluginIdsByModule[usage.pluginModule].orEmpty().map { pluginId ->
+                        ConventionPluginConfigurationUsage(
+                            pluginId = pluginId,
+                            pluginModule = usage.pluginModule,
+                            target = usage.target
+                        )
+                    }
+                }
+                .distinct()
+                .sortedWith(
+                    compareBy(
+                        ConventionPluginConfigurationUsage::pluginId,
+                        ConventionPluginConfigurationUsage::pluginModule,
+                        ConventionPluginConfigurationUsage::target
+                    )
+                )
+        }
+            .filterValues(List<ConventionPluginConfigurationUsage>::isNotEmpty)
     )
 
 private fun Map<String, List<ConventionPluginUsage>>.mergeConventionPluginUsages(
@@ -325,6 +364,21 @@ private fun Map<String, List<ConventionPluginUsage>>.mergeConventionPluginUsages
         (this[key].orEmpty() + other[key].orEmpty())
             .distinct()
             .sortedWith(compareBy(ConventionPluginUsage::pluginId, ConventionPluginUsage::pluginModule))
+    }
+
+private fun Map<String, List<ConventionPluginConfigurationUsage>>.mergeConventionPluginConfigurationUsages(
+    other: Map<String, List<ConventionPluginConfigurationUsage>>
+): Map<String, List<ConventionPluginConfigurationUsage>> =
+    (keys + other.keys).associateWith { key ->
+        (this[key].orEmpty() + other[key].orEmpty())
+            .distinct()
+            .sortedWith(
+                compareBy(
+                    ConventionPluginConfigurationUsage::pluginId,
+                    ConventionPluginConfigurationUsage::pluginModule,
+                    ConventionPluginConfigurationUsage::target
+                )
+            )
     }
 
 private fun libraryAlias(

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReader.kt
@@ -37,6 +37,26 @@ class GradleCatalogUsageReader {
             }
     }
 
+    fun readConventionLibraryConfigurationUsages(
+        rootDir: File,
+        modulePathPrefix: String
+    ): LibraryConfigurationUsages {
+        val conventionPluginModuleDirs = rootDir.conventionPluginModuleDirs()
+
+        return conventionPluginModuleDirs
+            .asSequence()
+            .flatMap { moduleDir ->
+                moduleDir.kotlinFiles().map { kotlinFile -> moduleDir to kotlinFile }
+            }
+            .fold(LibraryConfigurationUsages()) { usages, (moduleDir, kotlinFile) ->
+                usages + kotlinFile.readConventionLibraryConfigurationUsageDeclarations(
+                    includedBuildRootDir = rootDir,
+                    modulePathPrefix = modulePathPrefix,
+                    moduleDir = moduleDir
+                )
+            }
+    }
+
     fun readConventionPluginUsages(
         rootDir: File,
         modulePathPrefix: String
@@ -181,6 +201,28 @@ class GradleCatalogUsageReader {
         )
     }
 
+    private fun File.readConventionLibraryConfigurationUsageDeclarations(
+        includedBuildRootDir: File,
+        modulePathPrefix: String,
+        moduleDir: File
+    ): LibraryConfigurationUsages {
+        val modulePath = moduleDir.toIncludedBuildModulePath(includedBuildRootDir, modulePathPrefix)
+        val content = readText()
+        val coordinateUsages = libraryConfigurationUsageRegex
+            .findAll(content)
+            .fold(emptyMap<String, Set<LibraryConfigurationUsage>>()) { usages, match ->
+                val coordinate = "${match.groupValues[2]}:${match.groupValues[3]}"
+                val usage = LibraryConfigurationUsage(
+                    pluginModule = modulePath,
+                    target = content.configurationTarget(match)
+                )
+
+                usages + (coordinate to (usages[coordinate].orEmpty() + usage))
+            }
+
+        return LibraryConfigurationUsages(coordinates = coordinateUsages)
+    }
+
     private fun File.readMainLibraryAliases(rootDir: File): LibraryUsages {
         val modulePath = parentFile.toModulePath(rootDir)
         if (modulePath == ROOT_MODULE) return LibraryUsages()
@@ -292,12 +334,66 @@ class GradleCatalogUsageReader {
             (this[key].orEmpty() + other[key].orEmpty()).toSortedSet()
         }
 
+    private fun Map<String, Set<LibraryConfigurationUsage>>.mergeConfigurationUsages(
+        other: Map<String, Set<LibraryConfigurationUsage>>
+    ): Map<String, Set<LibraryConfigurationUsage>> =
+        (keys + other.keys).associateWith { key ->
+            (this[key].orEmpty() + other[key].orEmpty()).toSortedSet()
+        }
+
     private operator fun LibraryUsages.plus(other: LibraryUsages): LibraryUsages =
         LibraryUsages(
             coordinates = coordinates.merge(other.coordinates),
             bundles = bundles.merge(other.bundles),
             aliases = aliases.merge(other.aliases)
         )
+
+    private operator fun LibraryConfigurationUsages.plus(
+        other: LibraryConfigurationUsages
+    ): LibraryConfigurationUsages =
+        LibraryConfigurationUsages(
+            coordinates = coordinates.mergeConfigurationUsages(other.coordinates)
+        )
+
+    private fun String.configurationTarget(match: MatchResult): String {
+        val assignmentName = match.groupValues[1]
+        val prefix = substring(0, match.range.first)
+        val blockNames = activeBlockNames(prefix)
+            .filterNot { name -> name in IgnoredConfigurationTargetSegments }
+
+        return (blockNames + assignmentName)
+            .filter(String::isNotBlank)
+            .joinToString(".")
+    }
+
+    private fun activeBlockNames(contentBeforeMatch: String): List<String> {
+        var depth = 0
+        val stack = mutableListOf<BlockName>()
+
+        configurationBlockTokenRegex.findAll(contentBeforeMatch).forEach { token ->
+            val text = token.value
+            when {
+                text == "}" -> {
+                    depth = (depth - 1).coerceAtLeast(0)
+                    stack.removeAll { block -> block.depth >= depth }
+                }
+
+                text == "{" -> {
+                    depth += 1
+                }
+
+                else -> {
+                    val blockName = token.groupValues[1].ifBlank {
+                        token.groupValues[2]
+                    }
+                    stack += BlockName(depth = depth, name = blockName)
+                    depth += 1
+                }
+            }
+        }
+
+        return stack.map(BlockName::name)
+    }
 
     private fun File.toIncludedBuildModulePath(
         includedBuildRootDir: File,
@@ -343,6 +439,28 @@ class GradleCatalogUsageReader {
         val aliases: Map<String, Set<String>> = emptyMap()
     )
 
+    data class LibraryConfigurationUsages(
+        val coordinates: Map<String, Set<LibraryConfigurationUsage>> = emptyMap()
+    )
+
+    data class LibraryConfigurationUsage(
+        val pluginModule: String,
+        val target: String
+    ) : Comparable<LibraryConfigurationUsage> {
+        override fun compareTo(other: LibraryConfigurationUsage): Int =
+            compareValuesBy(
+                this,
+                other,
+                LibraryConfigurationUsage::pluginModule,
+                LibraryConfigurationUsage::target
+            )
+    }
+
+    private data class BlockName(
+        val depth: Int,
+        val name: String
+    )
+
     private companion object {
         const val BUILD_FILE_NAME = "build.gradle.kts"
         const val KOTLIN_FILE_EXTENSION = "kt"
@@ -355,6 +473,19 @@ class GradleCatalogUsageReader {
         val libraryBundleUsageRegex = Regex(
             """(?:\blibs\.)?implementationBundle\s*\(\s*(?:libs\s*=\s*libs\s*,\s*)?bundle\s*=\s*"([^"]+)"""",
             RegexOption.DOT_MATCHES_ALL
+        )
+        val libraryConfigurationUsageRegex = Regex(
+            """([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)?requireDependencyNotation\s*\(\s*(?:libs\s*=\s*libs\s*,\s*)?libraryGroup\s*=\s*"([^"]+)"\s*,\s*artifact\s*=\s*"([^"]+)"""",
+            RegexOption.DOT_MATCHES_ALL
+        )
+        val configurationBlockTokenRegex = Regex(
+            """configure<[^>]+>\s*\(\s*"([^"]+)"\s*\)\s*\{|([A-Za-z_][A-Za-z0-9_]*)\s*\{|[{}]"""
+        )
+        val IgnoredConfigurationTargetSegments = setOf(
+            "apply",
+            "dependencies",
+            "project",
+            "tasks"
         )
         val mainLibraryBundleAliasRegex = Regex("""\blibs\.bundles\.([A-Za-z0-9_.]+)\b""")
         val mainLibraryAliasRegex = Regex("""\blibs\.(?!bundles\.)([A-Za-z0-9_.]+)\b""")

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReaderTest.kt
@@ -5,6 +5,7 @@ import com.marmatsan.dependencies.tree.dsl.plugin.pluginTree
 import com.marmatsan.figmaDesignSync.data.gradle.catalog.GradleCatalogUsageReader
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginConfigurationUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
@@ -282,6 +283,67 @@ internal class DependenciesCatalogTreesReaderTest : FunSpec({
             .providedByConventionPlugins shouldBe expectedComposeUsage
         actualTree.findArtifact("io.mockk", "mockk")
             .providedByConventionPlugins shouldBe emptyList()
+    }
+
+    test("readLibraryTreeWithVersionAliases maps convention plugin tool artifact configuration") {
+        // GIVEN
+        val rootDir = Files.createTempDirectory("water-my-plants-convention-library-configuration").toFile()
+        val includedBuildRootDir = rootDir.resolve("repo/gradle-plugins")
+        includedBuildRootDir.writeBuildFile(
+            path = "protobuf",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.protobuf"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.protobuf.plugin.ProtobufGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeKotlinFile(
+            path = "protobuf/src/main/kotlin/com/marmatsan/protobuf/plugin",
+            fileName = "ProtobufGradleConventionPlugin.kt",
+            content = """
+            package com.marmatsan.protobuf.plugin
+
+            fun configure() {
+                project.extensions.configure<ProtobufExtension>("protobuf") {
+                    protoc {
+                        artifact = libs.requireDependencyNotation(
+                            libraryGroup = "com.google.protobuf",
+                            artifact = "protoc"
+                        )
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val actualTree = dependenciesCatalogTreesReader().readLibraryTreeWithVersionAliases(
+            rootDir = rootDir,
+            conventionPluginIncludedBuilds = listOf(
+                IncludedBuildSource(
+                    settingsFilePath = includedBuildRootDir.resolve("settings.gradle.kts").absolutePath,
+                    rootDirPath = includedBuildRootDir.absolutePath,
+                    modulePathPrefix = ":gradle-plugins",
+                    publishesConventionPlugins = true
+                )
+            )
+        )
+
+        // THEN
+        val protoc = actualTree.findArtifact("com.google.protobuf", "protoc")
+        protoc.requiredByModules shouldBe emptyList()
+        protoc.providedByConventionPlugins shouldBe emptyList()
+        protoc.configuredByConventionPlugins shouldBe listOf(
+            ConventionPluginConfigurationUsage(
+                pluginId = "com.marmatsan.protobuf",
+                pluginModule = ":gradle-plugins:protobuf",
+                target = "protobuf.protoc.artifact"
+            )
+        )
     }
 
     test("readPluginTreeWithVersionAliases scopes applied modules to the main build catalog") {

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/GradleCatalogUsageReaderTest.kt
@@ -103,6 +103,59 @@ internal class GradleCatalogUsageReaderTest : FunSpec({
         )
     }
 
+    test("readConventionLibraryConfigurationUsages maps requireDependencyNotation calls to convention modules") {
+        // GIVEN
+        val rootDir = Files.createTempDirectory("convention-library-configuration-usages").toFile()
+        val includedBuildRootDir = rootDir.resolve("repo/gradle-plugins")
+        includedBuildRootDir.writeBuildFile(
+            path = "protobuf",
+            content = """
+            gradlePlugin {
+                plugins.register("protobuf") {
+                    id = "com.marmatsan.protobuf"
+                    implementationClass = "com.marmatsan.protobuf.plugin.ProtobufGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeKotlinFile(
+            path = "protobuf/src/main/kotlin/com/marmatsan/protobuf/plugin",
+            fileName = "ProtobufGradleConventionPlugin.kt",
+            content = """
+            package com.marmatsan.protobuf.plugin
+
+            fun configureProtobuf() {
+                project.extensions.configure<ProtobufExtension>("protobuf") {
+                    protoc {
+                        artifact = libs.requireDependencyNotation(
+                            libraryGroup = "com.google.protobuf",
+                            artifact = "protoc"
+                        )
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val usages = GradleCatalogUsageReader().readConventionLibraryConfigurationUsages(
+            rootDir = includedBuildRootDir,
+            modulePathPrefix = ":gradle-plugins"
+        )
+
+        // THEN
+        usages shouldBe GradleCatalogUsageReader.LibraryConfigurationUsages(
+            coordinates = mapOf(
+                "com.google.protobuf:protoc" to setOf(
+                    GradleCatalogUsageReader.LibraryConfigurationUsage(
+                        pluginModule = ":gradle-plugins:protobuf",
+                        target = "protobuf.protoc.artifact"
+                    )
+                )
+            )
+        )
+    }
+
     test("readMainLiteralPluginUsages maps literal plugin ids to main modules") {
         // GIVEN
         val rootDir = Files.createTempDirectory("main-literal-plugin-usages").toFile()

--- a/repo/figma-design-sync/docs/README.md
+++ b/repo/figma-design-sync/docs/README.md
@@ -8,6 +8,7 @@ Use this directory as the module documentation index:
 | Path | Role | Purpose |
 |------|------|---------|
 | `runbooks/trunk-sync.md` | Runbook | Execute the Figma trunk sync flow: generate the model, run MCP, write metadata, and verify TeamCity state. |
+| `runbooks/visual-preview.md` | Runbook | Iterate on Figma visual sync behavior with fixtures and sandbox sections without writing official metadata. |
 | `runbooks/visual-sync-contract.md` | Reference | Define the Figma visual contract used by the MCP sync, including catalog trees, connectors, layout, and locking. |
 | `runbooks/troubleshooting.md` | Runbook | Diagnose failed or visually incorrect Figma sync runs without weakening the metadata contract. |
 | `bdd/README.md` | Reference | Explain executable BDD scenarios and their technical resource map. |

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -35,12 +35,30 @@ For larger payloads, stage base64 chunks in temporary shared plugin data:
 
 - Store a `runId`, expected chunk count, expected encoded length, and every
   chunk.
+- Validate each chunk's own length and the previously staged length before
+  writing it.
 - In the final call, read all chunks, validate count and length, decode, run the
   script, verify the returned `modelHash`, then delete the temporary data.
 - If the final call fails before execution, Figma visuals stay unchanged; only
   temporary staged chunk data may need cleanup.
 
 Do not copy long base64 payloads manually from terminal output.
+
+The tools package can generate chunked runner files for both official sync and
+visual preview:
+
+```powershell
+cd repo\figma-design-sync\tools
+npm run build
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
+node dist\write-mcp-runner.mjs --mode=preview --entrypoint=preview-catalog --fixture=catalog-tree --target=waterMyPlants.plugins --section-node-id=SANDBOX_SECTION_ID
+```
+
+Use preview runners to reproduce visual issues quickly. They stage data under
+`water_my_plants_sync_preview` and must not be used to write official metadata.
+Catalog preview uses the smaller `sync-catalog-tree-preview.mcp.js` entrypoint
+by default so connector and layout fixes can be tested without transporting the
+full trunk-sync bundle.
 
 ## Component Instance Shape
 

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -30,39 +30,39 @@ MCP write flow.
 
 ## Sources
 
-| Source | Value |
-|--------|-------|
-| Figma page URL | `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=62934-908` |
-| Figma file key | `YBZXsd8oyGLbcI2KWxJvRK` |
-| Metadata page node id | `62934:908` |
-| Shared plugin data namespace | `water_my_plants_sync` |
-| Generated model | `build/reports/figma-sync/design-model.json` |
-| Repository versions file | `repo/dependency-catalog/versions.properties` |
-| Figma versions section | `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=62936-183` |
-| Figma versions variable collection | `repo\dependency-catalog\versions.properties` |
-| Figma UML documentation page | `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=63308-2386` |
-| Root settings file | `settings.gradle.kts` |
+| Source                             | Value                                                                                    |
+|------------------------------------|------------------------------------------------------------------------------------------|
+| Figma page URL                     | `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=62934-908`  |
+| Figma file key                     | `YBZXsd8oyGLbcI2KWxJvRK`                                                                 |
+| Metadata page node id              | `62934:908`                                                                              |
+| Shared plugin data namespace       | `water_my_plants_sync`                                                                   |
+| Generated model                    | `build/reports/figma-sync/design-model.json`                                             |
+| Repository versions file           | `repo/dependency-catalog/versions.properties`                                            |
+| Figma versions section             | `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=62936-183`  |
+| Figma versions variable collection | `repo\dependency-catalog\versions.properties`                                            |
+| Figma UML documentation page       | `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=63308-2386` |
+| Root settings file                 | `settings.gradle.kts`                                                                    |
 
 Default included builds:
 
-| Gradle build name | Model name | Root directory | Module path prefix | Publishes catalogs | Publishes convention plugins |
-|-------------------|------------|----------------|--------------------|--------------------|-----------------------------|
-| `dependency-catalog` | `dependencyCatalog` | `repo/dependency-catalog` | `:dependency-catalog` | No | No |
-| `figma-design-sync` | `figmaDesignSync` | `repo/figma-design-sync` | `:figma-design-sync` | Yes | No |
-| `gradle-plugins` | `gradlePlugins` | `repo/gradle-plugins` | `:gradle-plugins` | Yes | Yes |
+| Gradle build name    | Model name          | Root directory            | Module path prefix    | Publishes catalogs | Publishes convention plugins |
+|----------------------|---------------------|---------------------------|-----------------------|--------------------|------------------------------|
+| `dependency-catalog` | `dependencyCatalog` | `repo/dependency-catalog` | `:dependency-catalog` | No                 | No                           |
+| `figma-design-sync`  | `figmaDesignSync`   | `repo/figma-design-sync`  | `:figma-design-sync`  | Yes                | No                           |
+| `gradle-plugins`     | `gradlePlugins`     | `repo/gradle-plugins`     | `:gradle-plugins`     | Yes                | Yes                          |
 
 Catalog tree visual targets:
 
-| Model target | Source | Figma section |
-|--------------|--------|---------------|
-| `waterMyPlants.libraries` | `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/LibraryTrees.kt` | `63069:629` |
-| `waterMyPlants.plugins` | `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt` | `63069:594` |
-| `waterMyPlants.customGradleConventionPlugins` | `repo/gradle-plugins/**/build.gradle.kts` | `63216:6907` |
-| `waterMyPlants.customGradlePlugins` | repository included-build `**/build.gradle.kts` files that declare regular Gradle plugins | `63330:551` |
-| `gradlePlugins.libraries` | `repo/gradle-plugins/settings.gradle.kts` | `63099:951` |
-| `gradlePlugins.plugins` | `repo/gradle-plugins/settings.gradle.kts` | `63100:2952` |
-| `figmaDesignSync.libraries` | `repo/figma-design-sync/settings.gradle.kts` | `63573:260` |
-| `figmaDesignSync.plugins` | `repo/figma-design-sync/settings.gradle.kts` | `63573:346` |
+| Model target                                  | Source                                                                                    | Figma section |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------|---------------|
+| `waterMyPlants.libraries`                     | `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/LibraryTrees.kt`      | `63069:629`   |
+| `waterMyPlants.plugins`                       | `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt`       | `63069:594`   |
+| `waterMyPlants.customGradleConventionPlugins` | `repo/gradle-plugins/**/build.gradle.kts`                                                 | `63216:6907`  |
+| `waterMyPlants.customGradlePlugins`           | repository included-build `**/build.gradle.kts` files that declare regular Gradle plugins | `63330:551`   |
+| `gradlePlugins.libraries`                     | `repo/gradle-plugins/settings.gradle.kts`                                                 | `63099:951`   |
+| `gradlePlugins.plugins`                       | `repo/gradle-plugins/settings.gradle.kts`                                                 | `63100:2952`  |
+| `figmaDesignSync.libraries`                   | `repo/figma-design-sync/settings.gradle.kts`                                              | `63573:260`   |
+| `figmaDesignSync.plugins`                     | `repo/figma-design-sync/settings.gradle.kts`                                              | `63573:346`   |
 
 `repo/dependency-catalog` has no settings-catalog visual target. It contributes
 the versions file and the standalone `:dependency-catalog` module.
@@ -175,25 +175,150 @@ the catalogs present in the TeamCity model.
 
 ## Run The MCP Sync
 
-Use the Figma MCP `use_figma` tool to:
+The Figma MCP runtime cannot read local files or TeamCity artifacts directly.
+Before calling `use_figma`, download the official TeamCity artifact outside
+Figma, build the compatible MCP bundle, and stage both values in temporary Figma
+shared plugin data.
 
-1. Read the TeamCity `Figma Sync > Generate main design model` artifact.
-2. Update version variables and `.project version` visual nodes.
-3. Update catalog tree sections listed in this runbook.
-4. Apply the visual contract from
+The execution flow is:
+
+1. Download `Figma Sync > Generate main design model >
+   build/reports/figma-sync/design-model.json` from TeamCity.
+2. Verify that artifact is from `main` and that its `gitSha` matches the
+   TeamCity `main` revision being synced.
+3. Build the MCP bundle from code compatible with that artifact.
+4. Stage the official `design-model.json` text and generated script under
+   temporary namespace `water_my_plants_sync_staging`.
+5. Run visual targets one by one with `use_figma`.
+6. Apply the visual contract from
    [visual-sync-contract.md](visual-sync-contract.md).
-5. Verify the visual mutation result.
-6. Write metadata only after all visual updates complete successfully.
+7. Verify each visual mutation result.
+8. Write official metadata only after all visual updates complete successfully.
+
+The staging namespace is not authoritative state. It is a transport mechanism
+for the current sync run. The authoritative namespace remains
+`water_my_plants_sync`, and only the final `metadata` target writes to it.
+Always overwrite staged values for a new sync run; do not reuse values already
+present in `water_my_plants_sync_staging`.
+
+Stage these keys on page `62934:908` under
+`water_my_plants_sync_staging`:
+
+| Key                  | Value                                                                          |
+|----------------------|--------------------------------------------------------------------------------|
+| `designModelJson`    | Minified JSON text from TeamCity's official `design-model.json` artifact.      |
+| `designModelHash`    | The artifact `modelHash`, used to validate the staged model.                   |
+| `designModelGitSha`  | The artifact `gitSha`, used to validate the staged model.                      |
+| `designModelLength`  | Character length of `designModelJson`, used to catch truncated staging writes. |
+| `scriptBase64`       | Base64-encoded generated `sync-trunk-design-model.mcp.js` content.             |
+| `scriptLength`       | Character length of the decoded script.                                        |
+| `scriptBase64Length` | Character length of `scriptBase64`, used to catch truncated staging writes.    |
 
 The Figma MCP `use_figma` call has a practical source-size limit near 50k
-characters. If the generated script plus injected model is small enough, pass a
-base64 payload split into chunks in a single call. When it approaches the limit,
-stage chunks in temporary shared plugin data and validate chunk count and length
-before decoding. Do not copy long base64 payloads manually from terminal output.
+characters. Stage large payloads in temporary shared plugin data, validate
+lengths before execution, and do not copy long base64 payloads manually from
+terminal output. If chunking is needed for staging, validate chunk count and
+encoded length before assembling the final `scriptBase64` value.
 
 The runtime supports `atob`, `btoa`, and `Function`, but not browser or Node
 transfer helpers such as `fetch`, `XMLHttpRequest`, `importScripts`,
 `TextDecoder`, `Blob`, `Response`, or `DecompressionStream`.
+
+Run visual updates by granular target. Do not run `metadata` until every visual
+target has completed successfully.
+
+| Order | Target                                        | Scope                                          | Typical failure                                                                       | Quick check                                                                           |
+|-------|-----------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| 1     | `versions`                                    | Version variables and `.project version` nodes | Missing variable collection or stale version section                                  | Returned `updatedVersions` contains the expected version keys.                        |
+| 2     | `waterMyPlants.libraries`                     | Main app libraries and usage chips             | Ambiguous `.artifact` / `.artifacts bundle` usage headings or missing root chip slots | Returned `completedTargets` contains only this target and no metadata.                |
+| 3     | `waterMyPlants.plugins`                       | Main app plugin catalog tree                   | Missing `.tree node` property or connector binding issue                              | Returned catalog nodes match the plugin tree and connectors stay in the section.      |
+| 4     | `waterMyPlants.customGradleConventionPlugins` | Convention plugin catalog                      | Stale convention plugin names or missing usage chip variants                          | Returned nodes include the convention plugin ids expected from `repo/gradle-plugins`. |
+| 5     | `waterMyPlants.customGradlePlugins`           | Regular custom Gradle plugin catalog           | A regular plugin is modeled as a convention plugin, or the reverse                    | Returned nodes include `com.marmatsan.figmaDesignSync` as a regular plugin.           |
+| 6     | `gradlePlugins.libraries`                     | `repo/gradle-plugins` libraries catalog        | Large artifact/bundle update with stale nested component internals                    | Returned `completedTargets` contains the target and no metadata.                      |
+| 7     | `gradlePlugins.plugins`                       | `repo/gradle-plugins` plugins catalog          | Missing plugin tree connector or stale plugin aliases                                 | Returned catalog nodes match the settings catalog.                                    |
+| 8     | `figmaDesignSync.libraries`                   | `repo/figma-design-sync` libraries catalog     | Large artifact/bundle update with stale nested component internals                    | Returned `completedTargets` contains the target and no metadata.                      |
+| 9     | `figmaDesignSync.plugins`                     | `repo/figma-design-sync` plugins catalog       | Missing plugin tree connector or stale plugin aliases                                 | Returned catalog nodes match the settings catalog.                                    |
+| 10    | `metadata`                                    | Shared plugin sync metadata                    | Metadata written before visual targets complete                                       | Figma shared plugin data matches the TeamCity artifact.                               |
+
+When a target fails, fix that target's component or TypeScript contract, merge
+the fix to `main`, regenerate the official TeamCity artifact, and resume from
+the failed target. Do not repeat already-successful targets unless the fix
+changes their source data or shared component contract.
+
+Reusable MCP target runner:
+
+```javascript
+const page = await figma.getNodeByIdAsync("62934:908");
+
+if (!page || page.type !== "PAGE") {
+  throw new Error("Expected sync page 62934:908 to be a PAGE");
+}
+
+const stagingNamespace = "water_my_plants_sync_staging";
+const stagedModelJson = page.getSharedPluginData(stagingNamespace, "designModelJson");
+const scriptBase64 = page.getSharedPluginData(stagingNamespace, "scriptBase64");
+
+if (!stagedModelJson || !scriptBase64) {
+  throw new Error("Missing staged model or script.");
+}
+
+const stagedModel = JSON.parse(stagedModelJson);
+const stagedModelHash = page.getSharedPluginData(stagingNamespace, "designModelHash");
+const stagedModelGitSha = page.getSharedPluginData(stagingNamespace, "designModelGitSha");
+const stagedModelLength = page.getSharedPluginData(stagingNamespace, "designModelLength");
+const scriptLength = page.getSharedPluginData(stagingNamespace, "scriptLength");
+const scriptBase64Length = page.getSharedPluginData(stagingNamespace, "scriptBase64Length");
+
+const requiredStagingValues = {
+  designModelHash: stagedModelHash,
+  designModelGitSha: stagedModelGitSha,
+  designModelLength: stagedModelLength,
+  scriptLength,
+  scriptBase64Length
+};
+
+for (const [key, value] of Object.entries(requiredStagingValues)) {
+  if (!value) {
+    throw new Error(`Missing staged ${key}.`);
+  }
+}
+
+if (stagedModelHash !== stagedModel.modelHash) {
+  throw new Error(`Staged modelHash mismatch: ${stagedModelHash} != ${stagedModel.modelHash}`);
+}
+
+if (stagedModelGitSha !== stagedModel.gitSha) {
+  throw new Error(`Staged gitSha mismatch: ${stagedModelGitSha} != ${stagedModel.gitSha}`);
+}
+
+if (Number(stagedModelLength) !== stagedModelJson.length) {
+  throw new Error(`Staged model length mismatch: ${stagedModelLength} != ${stagedModelJson.length}`);
+}
+
+if (Number(scriptBase64Length) !== scriptBase64.length) {
+  throw new Error(`Staged script length mismatch: ${scriptBase64Length} != ${scriptBase64.length}`);
+}
+
+let script = atob(scriptBase64);
+
+if (Number(scriptLength) !== script.length) {
+  throw new Error(`Decoded script length mismatch: ${scriptLength} != ${script.length}`);
+}
+
+script = script.replace(
+  "const DESIGN_MODEL = undefined;",
+  "const DESIGN_MODEL = stagedModel;"
+);
+script = script.replace(
+  "const SYNC_OPTIONS = undefined;",
+  "const SYNC_OPTIONS = {\"targets\":[\"TARGET_NAME\"],\"writeMetadata\":false};"
+);
+
+const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+const run = new AsyncFunction("figma", "stagedModel", script);
+
+return await run(figma, stagedModel);
+```
 
 ## Write Metadata
 
@@ -240,6 +365,33 @@ return {
 A metadata-only write is acceptable only when the visual model is already known
 to match `design-model.json` and the only mismatch is stale shared plugin
 metadata.
+
+When using the staged MCP runner above, write metadata by changing
+`SYNC_OPTIONS` to:
+
+```javascript
+"const SYNC_OPTIONS = {\"targets\":[\"metadata\"],\"writeMetadata\":true};"
+```
+
+Then verify the stored metadata before rerunning TeamCity:
+
+```javascript
+const page = await figma.getNodeByIdAsync("62934:908");
+
+if (!page || page.type !== "PAGE") {
+  throw new Error("Expected sync page 62934:908 to be a PAGE");
+}
+
+const namespace = "water_my_plants_sync";
+
+return {
+  schemaVersion: page.getSharedPluginData(namespace, "schemaVersion"),
+  branch: page.getSharedPluginData(namespace, "branch"),
+  gitSha: page.getSharedPluginData(namespace, "gitSha"),
+  modelHash: page.getSharedPluginData(namespace, "modelHash"),
+  syncedAt: page.getSharedPluginData(namespace, "syncedAt")
+};
+```
 
 ## Verify
 

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -28,6 +28,10 @@ Local execution is useful for diagnosis, but it is not required before every
 commit because Figma sync depends on external Figma state, credentials, and the
 MCP write flow.
 
+For fast visual iteration on component shape, colors, connectors, layout, or
+fixture data, use [visual-preview.md](visual-preview.md). Preview is intentionally
+non-authoritative and must not write official metadata.
+
 ## Sources
 
 | Source                             | Value                                                                                    |
@@ -167,6 +171,15 @@ The generated script is:
 Do not commit the generated JavaScript. The script expects
 `design-model.json` to be injected as `DESIGN_MODEL` before execution and must
 run in the Figma MCP runtime because it uses the Figma plugin API.
+
+To generate chunked MCP runner snippets for an official TeamCity artifact:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
+```
+
+Use [visual-preview.md](visual-preview.md) instead when testing fixture-driven
+visual changes before the change reaches `main`.
 
 Build and execute the MCP bundle from a code version compatible with the
 TeamCity `main` artifact being synced. If local sync tooling is ahead of `main`,

--- a/repo/figma-design-sync/docs/runbooks/visual-preview.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-preview.md
@@ -119,6 +119,22 @@ node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=gr
 Use `--allow-official-sections=true` only for supervised manual repair where the
 intent is to mutate an official section without writing metadata.
 
+## Sandbox Cleanup
+
+Preview sections are temporary validation artifacts. Name copied sections with
+the `Preview - ` prefix, use their node id only for the current preview run, and
+delete them after the result has been inspected or the run has been abandoned.
+
+Do not leave `Preview - ...` sections in the official Figma file after a visual
+iteration. They are not source of truth, are not referenced by TeamCity, and
+should not be reused as stable section ids in committed documentation or
+scripts.
+
+If a preview run fails before `99-run-target.mcp.js`, clear
+`water_my_plants_sync_preview` staging first, then delete the temporary preview
+section. The official visual sections and `water_my_plants_sync` metadata should
+remain untouched.
+
 ## Version Preview
 
 Version preview still touches the configured Figma variable collection and

--- a/repo/figma-design-sync/docs/runbooks/visual-preview.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-preview.md
@@ -1,0 +1,160 @@
+# Figma Visual Preview Runbook
+
+## Purpose
+
+Use this runbook to iterate quickly on visual sync code, component contracts, and
+layout behavior without publishing official Figma sync metadata.
+
+Preview is not a repair path for `main`. The official publication flow remains
+[trunk-sync.md](trunk-sync.md): TeamCity generates the authoritative
+`design-model.json` from `main`, MCP writes the official visual state, and
+metadata is written last.
+
+## Safety Contract
+
+Preview runners:
+
+- use fixture or explicitly provided models only for visual feedback;
+- write temporary shared plugin data under `water_my_plants_sync_preview`;
+- force `writeMetadata=false`;
+- reject the `metadata` target;
+- require a sandbox section override for catalog tree targets unless
+  `--allow-official-sections=true` is passed for supervised manual repair;
+- generate only ignored files under `repo/figma-design-sync/tools/dist/`.
+
+Catalog preview also builds a smaller MCP entrypoint,
+`dist/sync-catalog-tree-preview.mcp.js`, so sandbox checks can validate catalog
+layout and connector behavior without transporting the full trunk-sync bundle.
+
+Do not use preview output to make `checkFigmaTrunkSync` pass. That check is tied
+to the official namespace `water_my_plants_sync` and the TeamCity artifact from
+`main`.
+
+## Fixtures
+
+Visual fixtures live under:
+
+```text
+repo/figma-design-sync/tools/fixtures/visual/
+```
+
+Available fixtures:
+
+| Fixture | Purpose |
+|---------|---------|
+| `catalog-tree.design-model.json` | Catalog tree layout, connectors, `.tree node`, `.artifact`, `.artifacts bundle`, and `.usage chip` variants. |
+| `versions.design-model.json` | Version variables and `.project version` visual nodes. |
+
+Fixture models keep `branch = "main"` because the MCP bundle refuses non-main
+models. They use preview `gitSha` and `modelHash` values and must not be treated
+as authoritative repository state.
+
+## Generate Preview Runner Files
+
+Build the MCP bundle and generate runner snippets from the tools directory:
+
+```powershell
+cd repo\figma-design-sync\tools
+npm ci
+npm run build
+node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=waterMyPlants.plugins --section-node-id=SANDBOX_SECTION_ID
+```
+
+Catalog tree preview defaults to `--entrypoint=preview-catalog`, which stages
+`dist/sync-catalog-tree-preview.mcp.js` instead of the full trunk-sync bundle.
+Pass it explicitly when documenting or sharing a reproduction:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=preview --entrypoint=preview-catalog --fixture=catalog-tree --target=waterMyPlants.plugins --section-node-id=SANDBOX_SECTION_ID
+```
+
+The command writes an ignored directory under:
+
+```text
+repo/figma-design-sync/tools/dist/mcp-runners/
+```
+
+Run the generated `.mcp.js` files with Figma MCP in lexical order:
+
+1. `00-clear-staging.mcp.js`
+2. `10-designModelJson-*.mcp.js`
+3. `20-scriptBase64-*.mcp.js`
+4. `90-finalize-staging.mcp.js`
+5. `99-run-target.mcp.js`
+
+The generated `manifest.json` records the mode, target, namespace, model hash,
+entrypoint, script path, script length, staged files, and optional sandbox
+section id.
+
+Do not copy long generated source from terminal output into `use_figma`. Shell
+or chat output can truncate the source before it reaches Figma. Use the
+generated `.mcp.js` files directly and reduce `--chunk-size` if a single staging
+snippet is too large for the MCP transport. Every generated staging snippet
+validates its own chunk length and the previously staged length before writing,
+so truncation fails before `99-run-target.mcp.js` can mutate visuals.
+After any staging failure, rerun `00-clear-staging.mcp.js` before trying again.
+
+The preview catalog entrypoint refuses `versions`, `metadata`, and catalog
+targets without a sandbox section id.
+
+## Catalog Tree Preview
+
+For catalog tree targets, create or duplicate a sandbox section in Figma and pass
+its node id with `--section-node-id`. The sandbox section must contain compatible
+templates for the target being tested:
+
+- at least one `.tree node` instance for the target type;
+- a `simple-solid_arrow` connector template when parent/child edges are tested;
+- nested `.artifact`, `.artifacts bundle`, and `.usage chip` instances when
+  library usage behavior is tested.
+
+Examples:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=waterMyPlants.libraries --section-node-id=SANDBOX_SECTION_ID
+node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=waterMyPlants.plugins --section-node-id=SANDBOX_SECTION_ID
+node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=gradlePlugins.plugins --section-node-id=SANDBOX_SECTION_ID
+```
+
+Use `--allow-official-sections=true` only for supervised manual repair where the
+intent is to mutate an official section without writing metadata.
+
+## Version Preview
+
+Version preview still touches the configured Figma variable collection and
+`.project version` frames. Prefer running it only in a copied Figma file or when
+the visual mutation is intentionally being inspected in the official file:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=preview --fixture=versions --target=versions
+```
+
+Do not write metadata after a version preview run.
+
+## Official Runner Generation
+
+The same generator can create chunked MCP runner files for an official TeamCity
+artifact, but the source model must be the artifact from `Figma Sync > Generate
+main design model`:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=metadata
+```
+
+Official mode stages data under `water_my_plants_sync_staging`. Only the
+`metadata` target writes to the authoritative namespace, and it should be run
+after all visual targets have completed successfully.
+
+## Verification
+
+For tooling changes:
+
+```powershell
+cd repo\figma-design-sync\tools
+npm run build
+node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=waterMyPlants.plugins --section-node-id=SANDBOX_SECTION_ID
+```
+
+For repository contract changes that affect the generated model, also run the
+Gradle checks described in [trunk-sync.md](trunk-sync.md).

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -22,6 +22,11 @@ The tool source follows the same dependency direction as the Gradle sync code:
 The generated JavaScript bundle is a temporary MCP runtime artifact and must not
 be committed.
 
+Preview runners may pass `sectionNodeOverrides` so a catalog target mutates a
+sandbox section instead of the configured official section. Official sync runs
+must use the configured section ids from `figma-config.ts` unless a documented
+manual repair explicitly overrides one target.
+
 ## Version Visual Sync
 
 The version sync reads `content.versionSections` from `design-model.json` and

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -95,6 +95,17 @@ For each section:
 - Library artifacts and bundles may also carry `providedByConventionPlugins`.
   Each usage has `pluginId`, `pluginModule`, and `requiredByModules`; it is the
   model source for `Provided by` `.usage chip kind=convention-plugin` rows.
+- Library artifacts may also carry `configuredByConventionPlugins`. Each usage
+  has `pluginId`, `pluginModule`, and `target`; it means the convention plugin
+  uses the artifact as build tooling configuration, not that it provides the
+  artifact to production modules. Render these rows under `Tool artifacts`.
+- Hide `Provided by`, `Required by`, and `Tool artifacts` blocks when their
+  source lists are empty. Do not render empty headings or empty chip
+  containers.
+- When a direct artifact entry or bundle has no `Required by`, no `Provided by`,
+  and no `Tool artifacts` data, show `Unused catalog entry` instead of empty
+  usage blocks. Do not mark child artifact rows inside a bundle as unused; the
+  bundle is the catalog entry.
 - Update `Required by` module instances for `.artifacts bundle` entries from
   the bundle `requiredByModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry. Child `.artifact`
@@ -104,7 +115,8 @@ For each section:
 - Represent usage metadata with `.usage chip` instances.
 - `.usage chip` exposes only two `kind` variants: `module` for modules that
   require or apply an item, and `convention-plugin` for Gradle convention
-  plugins that provide dependencies to production modules.
+  plugins that provide dependencies to production modules or configure tooling
+  artifacts.
 - `.usage chip` exposes `name` as a text component property bound to the label.
   Do not add a variant for every module, plugin, artifact, or dependency name.
 - Create missing `.tree node` instances by cloning a compatible existing node

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -173,7 +173,19 @@ Layout rules:
   the connector is vertical.
 - Resize every touched tree section and parent section to fit after visual
   updates.
-- Direct `.Header` instances in touched sections must span section width.
+- Stack direct child sections inside touched section containers with 114 px
+  between one section bottom edge and the next section top edge. Apply the same
+  spacing to ancestor section containers after their children are resized.
+- Direct child sections stacked inside the same container must share the same
+  left edge. This keeps module sections such as `gradle-plugins` and
+  `figma-design-sync` horizontally aligned when they belong to the same parent
+  package section.
+- Top-level parent documentation sections on the Gradle dependencies page must
+  keep 1139 px of horizontal space between one section right edge and the next
+  section left edge.
+- Direct `.Header` instances in touched sections must span section width. If a
+  section is narrower than the header's Hug width, resize the section first so
+  the fixed-width header can show its content without clipping.
 
 ## Locking Contract
 

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/catalog/LibraryCatalogEntry.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/catalog/LibraryCatalogEntry.kt
@@ -27,6 +27,23 @@ sealed interface LibraryCatalogEntry {
     )
 
     /**
+     * Gradle convention plugin that uses a catalog artifact as build tooling
+     * configuration instead of adding it to a production module dependency
+     * bucket.
+     *
+     * @property pluginId Gradle plugin id implemented by the convention plugin.
+     * @property pluginModule Gradle module path that implements the convention
+     * plugin.
+     * @property target Configuration target that consumes the artifact, such as
+     * `protobuf.protoc.artifact`.
+     */
+    data class ConventionPluginConfigurationUsage(
+        val pluginId: String,
+        val pluginModule: String,
+        val target: String
+    )
+
+    /**
      * Single Maven artifact declared in a version catalog or dependency DSL.
      *
      * @property artifact Maven artifact id without the group.
@@ -35,12 +52,15 @@ sealed interface LibraryCatalogEntry {
      * artifact.
      * @property providedByConventionPlugins Gradle convention plugins that
      * provide this artifact to production modules.
+     * @property configuredByConventionPlugins Gradle convention plugins that
+     * use this artifact to configure tooling needed by the plugin.
      */
     data class Artifact(
         val artifact: String,
         val version: CatalogVersion,
         val requiredByModules: List<String> = emptyList(),
-        val providedByConventionPlugins: List<ConventionPluginUsage> = emptyList()
+        val providedByConventionPlugins: List<ConventionPluginUsage> = emptyList(),
+        val configuredByConventionPlugins: List<ConventionPluginConfigurationUsage> = emptyList()
     ) : LibraryCatalogEntry
 
     /**

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.plugin.generator
 
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginConfigurationUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
@@ -94,6 +95,7 @@ private fun LibraryCatalogEntry.toDesignJson(): JsonObject =
             put("version", version.toDesignJson())
             put("requiredByModules", requiredByModules.toSortedJsonArray())
             put("providedByConventionPlugins", providedByConventionPlugins.toDesignJson())
+            put("configuredByConventionPlugins", configuredByConventionPlugins.toConfigurationUsageDesignJson())
         }
 
         is LibraryCatalogEntry.ArtifactsBundle -> buildJsonObject {
@@ -118,6 +120,23 @@ private fun List<ConventionPluginUsage>.toDesignJson(): JsonArray =
                 put("pluginId", usage.pluginId)
                 put("pluginModule", usage.pluginModule)
                 put("requiredByModules", usage.requiredByModules.toSortedJsonArray())
+            }
+        }
+        .let(::JsonArray)
+
+private fun List<ConventionPluginConfigurationUsage>.toConfigurationUsageDesignJson(): JsonArray =
+    sortedWith(
+        compareBy<ConventionPluginConfigurationUsage>(
+            { usage -> usage.pluginId },
+            { usage -> usage.pluginModule },
+            { usage -> usage.target }
+        )
+    )
+        .map { usage ->
+            buildJsonObject {
+                put("pluginId", usage.pluginId)
+                put("pluginModule", usage.pluginModule)
+                put("target", usage.target)
             }
         }
         .let(::JsonArray)

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.plugin.generator
 
 import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginConfigurationUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
@@ -128,6 +129,47 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
             )
         )
     }
+
+    test("generate writes convention plugin configuration usage for library artifacts") {
+        // GIVEN
+        val generator = generator()
+
+        // WHEN
+        val result = generator.generate(request())
+
+        // THEN
+        val usages = result.model["content"]
+            ?.jsonObject
+            ?.get("catalogs")
+            ?.jsonObject
+            ?.get("waterMyPlants")
+            ?.jsonObject
+            ?.get("libraries")
+            ?.jsonArray
+            ?.single()
+            ?.jsonObject
+            ?.get("entries")
+            ?.jsonArray
+            ?.single()
+            ?.jsonObject
+            ?.get("configuredByConventionPlugins")
+            ?.jsonArray
+
+        usages?.map { usage ->
+            val usageObject = usage.jsonObject
+            Triple(
+                usageObject["pluginId"]?.jsonPrimitive?.content,
+                usageObject["pluginModule"]?.jsonPrimitive?.content,
+                usageObject["target"]?.jsonPrimitive?.content
+            )
+        } shouldBe listOf(
+            Triple(
+                "com.marmatsan.kotlin",
+                ":gradle-plugins:kotlin",
+                "kotlin.compiler.classpath"
+            )
+        )
+    }
 })
 
 private fun generator(): FigmaDesignModelGenerator =
@@ -197,6 +239,20 @@ private object FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
         } else {
             emptyList()
         }
+        val conventionPluginConfigurationUsages = if (
+            source is ProjectCatalogTreeSource.DependenciesDslVersionAliases &&
+            source.conventionPluginIncludedBuilds.any { includedBuild -> includedBuild.modulePathPrefix == ":gradle-plugins" }
+        ) {
+            listOf(
+                ConventionPluginConfigurationUsage(
+                    pluginId = "com.marmatsan.kotlin",
+                    pluginModule = ":gradle-plugins:kotlin",
+                    target = "kotlin.compiler.classpath"
+                )
+            )
+        } else {
+            emptyList()
+        }
 
         return LibraryCatalogTree(
             roots = listOf(
@@ -207,7 +263,8 @@ private object FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
                             artifact = "kotlin-stdlib",
                             version = CatalogVersion("2.4.0"),
                             requiredByModules = listOf(":app"),
-                            providedByConventionPlugins = conventionPluginUsages
+                            providedByConventionPlugins = conventionPluginUsages,
+                            configuredByConventionPlugins = conventionPluginConfigurationUsages
                         )
                     )
                 )

--- a/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
@@ -1,0 +1,283 @@
+{
+  "schemaVersion": 2,
+  "branch": "main",
+  "gitSha": "preview-catalog-tree",
+  "generatedAt": "2026-07-08T00:00:00.000Z",
+  "modelHash": "sha256:preview-catalog-tree",
+  "content": {
+    "versions": {
+      "activityComposeVersion": "1.9.3",
+      "androidGradlePluginVersion": "8.9.1",
+      "dokkaVersion": "2.0.0",
+      "kspVersion": "2.1.10-1.0.31"
+    },
+    "versionSections": [],
+    "catalogs": {
+      "waterMyPlants": {
+        "libraries": [
+          {
+            "group": "androidx",
+            "artifactsVisible": false,
+            "entries": [],
+            "children": [
+              {
+                "group": "activity",
+                "artifactsVisible": true,
+                "entries": [
+                  {
+                    "type": "artifact",
+                    "artifact": "androidx.activity:activity-compose",
+                    "version": {
+                      "visible": true,
+                      "value": "activityComposeVersion"
+                    },
+                    "requiredByModules": [
+                      ":app"
+                    ],
+                    "providedByConventionPlugins": [
+                      {
+                        "pluginId": "com.marmatsan.android.compose",
+                        "pluginModule": ":gradle-plugins:android-compose",
+                        "requiredByModules": [
+                          ":app",
+                          ":onboarding:presentation"
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "children": []
+              }
+            ]
+          },
+          {
+            "group": "io.mockk",
+            "artifactsVisible": true,
+            "entries": [
+              {
+                "type": "bundle",
+                "alias": "mockk",
+                "artifacts": [
+                  "io.mockk:mockk",
+                  "io.mockk:mockk-android",
+                  "org.jetbrains.dokka:dokka-gradle-plugin"
+                ],
+                "version": {
+                  "visible": true,
+                  "value": "mockkVersion"
+                },
+                "requiredByModules": [
+                  ":figma-design-sync:data"
+                ],
+                "providedByConventionPlugins": []
+              }
+            ],
+            "children": []
+          }
+        ],
+        "plugins": [
+          {
+            "id": "com",
+            "version": {
+              "visible": false,
+              "value": null
+            },
+            "appliedToModules": [],
+            "children": [
+              {
+                "id": "marmatsan",
+                "version": {
+                  "visible": false,
+                  "value": null
+                },
+                "appliedToModules": [],
+                "children": [
+                  {
+                    "id": "android",
+                    "version": {
+                      "visible": true,
+                      "value": "androidGradlePluginVersion"
+                    },
+                    "appliedToModules": [
+                      ":app",
+                      ":core:ui"
+                    ],
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "customGradleConventionPlugins": [
+          {
+            "id": "com.marmatsan.android.compose",
+            "version": {
+              "visible": false,
+              "value": null
+            },
+            "appliedToModules": [
+              ":app",
+              ":onboarding:presentation"
+            ],
+            "children": []
+          }
+        ],
+        "customGradlePlugins": [
+          {
+            "id": "com.marmatsan.figmaDesignSync",
+            "version": {
+              "visible": false,
+              "value": null
+            },
+            "appliedToModules": [
+              ":"
+            ],
+            "children": []
+          }
+        ]
+      },
+      "gradlePlugins": {
+        "libraries": [
+          {
+            "group": "org.jetbrains.dokka",
+            "artifactsVisible": true,
+            "entries": [
+              {
+                "type": "artifact",
+                "artifact": "org.jetbrains.dokka:dokka-gradle-plugin",
+                "version": {
+                  "visible": true,
+                  "value": "dokkaVersion"
+                },
+                "requiredByModules": [
+                  ":gradle-plugins:dokka-documentation"
+                ],
+                "providedByConventionPlugins": []
+              }
+            ],
+            "children": []
+          }
+        ],
+        "plugins": [
+          {
+            "id": "org",
+            "version": {
+              "visible": false,
+              "value": null
+            },
+            "appliedToModules": [],
+            "children": [
+              {
+                "id": "jetbrains",
+                "version": {
+                  "visible": false,
+                  "value": null
+                },
+                "appliedToModules": [],
+                "children": [
+                  {
+                    "id": "dokka",
+                    "version": {
+                      "visible": true,
+                      "value": "dokkaVersion"
+                    },
+                    "appliedToModules": [
+                      ":gradle-plugins:dokka-documentation"
+                    ],
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "figmaDesignSync": {
+        "libraries": [
+          {
+            "group": "io.cucumber",
+            "artifactsVisible": true,
+            "entries": [
+              {
+                "type": "artifact",
+                "artifact": "io.cucumber:cucumber-java8",
+                "version": {
+                  "visible": true,
+                  "value": "cucumberVersion"
+                },
+                "requiredByModules": [
+                  ":figma-design-sync:plugin"
+                ],
+                "providedByConventionPlugins": []
+              }
+            ],
+            "children": []
+          }
+        ],
+        "plugins": [
+          {
+            "id": "com",
+            "version": {
+              "visible": false,
+              "value": null
+            },
+            "appliedToModules": [],
+            "children": [
+              {
+                "id": "google",
+                "version": {
+                  "visible": false,
+                  "value": null
+                },
+                "appliedToModules": [],
+                "children": [
+                  {
+                    "id": "devtools",
+                    "version": {
+                      "visible": false,
+                      "value": null
+                    },
+                    "appliedToModules": [],
+                    "children": [
+                      {
+                        "id": "ksp",
+                        "version": {
+                          "visible": true,
+                          "value": "kspVersion"
+                        },
+                        "appliedToModules": [
+                          ":figma-design-sync:plugin"
+                        ],
+                        "children": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "modules": {
+      "main": [
+        ":app",
+        ":core:ui",
+        ":onboarding:presentation"
+      ],
+      "gradlePlugins": [
+        ":gradle-plugins:dokka-documentation"
+      ],
+      "figmaDesignSync": [
+        ":figma-design-sync:data",
+        ":figma-design-sync:plugin"
+      ]
+    },
+    "moduleDependencies": {
+      "main": [],
+      "gradlePlugins": [],
+      "figmaDesignSync": []
+    }
+  }
+}

--- a/repo/figma-design-sync/tools/fixtures/visual/versions.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/versions.design-model.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 2,
+  "branch": "main",
+  "gitSha": "preview-versions",
+  "generatedAt": "2026-07-08T00:00:00.000Z",
+  "modelHash": "sha256:preview-versions",
+  "content": {
+    "versions": {
+      "activityComposeVersion": "1.9.3",
+      "androidGradlePluginVersion": "8.9.1",
+      "appVersionName": "1.0.0",
+      "dokkaVersion": "2.0.0",
+      "kspVersion": "2.1.10-1.0.31"
+    },
+    "versionSections": [
+      {
+        "name": "Main project dependencies",
+        "versions": {
+          "appVersionName": "1.0.0"
+        }
+      },
+      {
+        "name": "Libraries",
+        "versions": {
+          "activityComposeVersion": "1.9.3"
+        }
+      },
+      {
+        "name": "Plugins",
+        "versions": {
+          "androidGradlePluginVersion": "8.9.1",
+          "dokkaVersion": "2.0.0",
+          "kspVersion": "2.1.10-1.0.31"
+        }
+      }
+    ],
+    "catalogs": {
+      "waterMyPlants": {
+        "libraries": [],
+        "plugins": [],
+        "customGradleConventionPlugins": [],
+        "customGradlePlugins": []
+      },
+      "gradlePlugins": {
+        "libraries": [],
+        "plugins": []
+      },
+      "figmaDesignSync": {
+        "libraries": [],
+        "plugins": []
+      }
+    },
+    "modules": {},
+    "moduleDependencies": {}
+  }
+}

--- a/repo/figma-design-sync/tools/package.json
+++ b/repo/figma-design-sync/tools/package.json
@@ -2,7 +2,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.json && esbuild src/app/sync-trunk-design-model.mcp.ts --bundle --format=iife --global-name=FigmaTrunkSync --target=es2022 --minify --outfile=dist/sync-trunk-design-model.mcp.js && esbuild scripts/write-mcp-js.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-js.mjs && node dist/write-mcp-js.mjs"
+    "build": "tsc --project tsconfig.json && esbuild src/app/sync-trunk-design-model.mcp.ts --bundle --format=iife --global-name=FigmaTrunkSync --target=es2022 --minify --outfile=dist/sync-trunk-design-model.mcp.js && esbuild src/app/sync-catalog-tree-preview.mcp.ts --bundle --format=iife --global-name=FigmaCatalogTreePreview --target=es2022 --minify --outfile=dist/sync-catalog-tree-preview.mcp.js && esbuild scripts/write-mcp-js.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-js.mjs && esbuild scripts/write-mcp-runner.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-runner.mjs && node dist/write-mcp-js.mjs",
+    "premcp:runner": "npm run build",
+    "mcp:runner": "node dist/write-mcp-runner.mjs",
+    "premcp:preview": "npm run build",
+    "mcp:preview": "node dist/write-mcp-runner.mjs --mode=preview"
   },
   "devDependencies": {
     "@figma/plugin-typings": "^1.117.0",

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -1,0 +1,555 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TOOL_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DEFAULT_TRUNK_SYNC_SCRIPT = resolve(TOOL_ROOT, "sync-trunk-design-model.mcp.js");
+const DEFAULT_PREVIEW_CATALOG_SCRIPT = resolve(TOOL_ROOT, "dist", "sync-catalog-tree-preview.mcp.js");
+const FIXTURE_ROOT = resolve(TOOL_ROOT, "fixtures", "visual");
+const DEFAULT_OUT_ROOT = resolve(TOOL_ROOT, "dist", "mcp-runners");
+const OFFICIAL_STAGING_NAMESPACE = "water_my_plants_sync_staging";
+const PREVIEW_STAGING_NAMESPACE = "water_my_plants_sync_preview";
+const METADATA_PAGE_ID = "62934:908";
+const DEFAULT_CHUNK_SIZE = 30_000;
+
+const KNOWN_TARGETS = [
+  "versions",
+  "waterMyPlants.libraries",
+  "waterMyPlants.plugins",
+  "waterMyPlants.customGradleConventionPlugins",
+  "waterMyPlants.customGradlePlugins",
+  "gradlePlugins.libraries",
+  "gradlePlugins.plugins",
+  "figmaDesignSync.libraries",
+  "figmaDesignSync.plugins",
+  "metadata",
+];
+
+const DEFAULT_FIXTURE_TARGETS = {
+  "catalog-tree": "waterMyPlants.plugins",
+  versions: "versions",
+};
+
+const args = {
+  ...readNpmConfigArgs(),
+  ...parseArgs(process.argv.slice(2)),
+};
+const options = resolveOptions(args);
+await writeRunnerFiles(options);
+
+function parseArgs(argv) {
+  const parsed = {};
+  const positional = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      positional.push(arg);
+      continue;
+    }
+
+    const [rawKey, inlineValue] = arg.slice(2).split("=", 2);
+    const key = rawKey.trim();
+    const value = inlineValue ?? argv[index + 1];
+
+    if (inlineValue === undefined) {
+      index += 1;
+    }
+
+    if (!key || value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}.`);
+    }
+
+    parsed[key] = value;
+  }
+
+  applyPositionalArgs(parsed, positional);
+  return parsed;
+}
+
+function readNpmConfigArgs() {
+  const mappings = {
+    mode: "npm_config_mode",
+    fixture: "npm_config_fixture",
+    model: "npm_config_model",
+    script: "npm_config_script",
+    entrypoint: "npm_config_entrypoint",
+    target: "npm_config_target",
+    "out-dir": "npm_config_out_dir",
+    "chunk-size": "npm_config_chunk_size",
+    "section-node-id": "npm_config_section_node_id",
+    "allow-official-sections": "npm_config_allow_official_sections",
+  };
+  const values = {};
+
+  for (const [key, envName] of Object.entries(mappings)) {
+    const value = process.env[envName];
+    if (value) {
+      values[key] = value;
+    }
+  }
+
+  return values;
+}
+
+function applyPositionalArgs(parsed, positional) {
+  const remaining = [...positional];
+
+  if (!parsed.fixture && !parsed.model && remaining.length > 0) {
+    parsed.fixture = remaining.shift();
+  }
+  if (!parsed.target && remaining.length > 0) {
+    parsed.target = remaining.shift();
+  }
+  if (!parsed["section-node-id"] && remaining.length > 0) {
+    parsed["section-node-id"] = remaining.shift();
+  }
+  if (remaining.length > 0) {
+    throw new Error(`Unexpected positional arguments: ${remaining.join(", ")}.`);
+  }
+}
+
+function resolveOptions(args) {
+  const mode = args.mode || "preview";
+  if (!["preview", "official"].includes(mode)) {
+    throw new Error(`Unsupported mode '${mode}'. Expected 'preview' or 'official'.`);
+  }
+
+  const fixture = args.fixture || (mode === "preview" && !args.model ? "catalog-tree" : undefined);
+  const target = args.target || (fixture ? DEFAULT_FIXTURE_TARGETS[fixture] : undefined);
+  if (!target) {
+    throw new Error("Missing --target. Preview fixtures can infer a default target.");
+  }
+  if (!KNOWN_TARGETS.includes(target)) {
+    throw new Error(`Unknown target '${target}'. Expected one of: ${KNOWN_TARGETS.join(", ")}.`);
+  }
+  if (mode === "preview" && target === "metadata") {
+    throw new Error("Preview runners must not target metadata.");
+  }
+  if (mode === "official" && !args.model) {
+    throw new Error("Official runners require --model with the TeamCity design-model.json artifact.");
+  }
+
+  const entrypoint = args.entrypoint || (
+    mode === "preview" && isCatalogTarget(target) ? "preview-catalog" : "trunk-sync"
+  );
+  if (!["trunk-sync", "preview-catalog"].includes(entrypoint)) {
+    throw new Error(`Unsupported --entrypoint '${entrypoint}'. Expected 'trunk-sync' or 'preview-catalog'.`);
+  }
+  if (mode === "official" && entrypoint !== "trunk-sync") {
+    throw new Error("Official runners must use --entrypoint=trunk-sync.");
+  }
+  if (entrypoint === "preview-catalog" && (mode !== "preview" || !isCatalogTarget(target))) {
+    throw new Error("--entrypoint=preview-catalog can only be used with preview catalog targets.");
+  }
+
+  const modelPath = resolve(
+    TOOL_ROOT,
+    args.model || join("fixtures", "visual", `${fixture}.design-model.json`)
+  );
+  if (mode === "official" && modelPath.startsWith(FIXTURE_ROOT)) {
+    throw new Error("Official runners must not use visual fixtures as their design model.");
+  }
+  const defaultScriptPath = entrypoint === "preview-catalog"
+    ? DEFAULT_PREVIEW_CATALOG_SCRIPT
+    : DEFAULT_TRUNK_SYNC_SCRIPT;
+  const scriptPath = resolve(TOOL_ROOT, args.script || defaultScriptPath);
+  const outRoot = resolve(TOOL_ROOT, args["out-dir"] || DEFAULT_OUT_ROOT);
+  const chunkSize = Number(args["chunk-size"] || DEFAULT_CHUNK_SIZE);
+  if (!Number.isInteger(chunkSize) || chunkSize < 1_000) {
+    throw new Error("--chunk-size must be an integer greater than or equal to 1000.");
+  }
+
+  const namespace = mode === "preview"
+    ? PREVIEW_STAGING_NAMESPACE
+    : OFFICIAL_STAGING_NAMESPACE;
+  const writeMetadata = mode === "official" && target === "metadata";
+  const sectionNodeId = args["section-node-id"];
+  const allowOfficialSections = args["allow-official-sections"] === "true";
+
+  if (
+    mode === "preview" &&
+    isCatalogTarget(target) &&
+    !sectionNodeId &&
+    !allowOfficialSections
+  ) {
+    throw new Error(
+      "Preview catalog runners require --section-node-id for a sandbox section. " +
+        "Use --allow-official-sections=true only for supervised manual repair."
+    );
+  }
+
+  return {
+    mode,
+    fixture,
+    entrypoint,
+    target,
+    modelPath,
+    scriptPath,
+    outRoot,
+    chunkSize,
+    namespace,
+    writeMetadata,
+    sectionNodeId,
+    allowOfficialSections,
+  };
+}
+
+async function writeRunnerFiles(options) {
+  const modelJson = await readFile(options.modelPath, "utf8");
+  const minifiedModelJson = JSON.stringify(JSON.parse(modelJson));
+  const designModel = JSON.parse(minifiedModelJson);
+  const script = await readFile(options.scriptPath, "utf8");
+  validateDesignModel(designModel, options);
+
+  const scriptBase64 = Buffer.from(script, "utf8").toString("base64");
+  const runDirName = `${options.mode}-${safeName(options.entrypoint)}-${safeName(options.target)}-${safeName(basename(options.modelPath, ".design-model.json"))}`;
+  const outDir = join(options.outRoot, runDirName);
+  const files = [];
+
+  await mkdir(outDir, { recursive: true });
+
+  files.push(await writeFileIn(outDir, "00-clear-staging.mcp.js", clearStagingSource(options.namespace)));
+  files.push(...await writeChunkSources(outDir, "designModelJson", minifiedModelJson, options));
+  files.push(...await writeChunkSources(outDir, "scriptBase64", scriptBase64, options));
+  files.push(await writeFileIn(outDir, "90-finalize-staging.mcp.js", finalizeStagingSource(options, designModel, minifiedModelJson, script, scriptBase64)));
+  files.push(await writeFileIn(outDir, "99-run-target.mcp.js", runTargetSource(options)));
+  files.push(await writeManifest(outDir, files, options, designModel, minifiedModelJson, script, scriptBase64));
+
+  console.log(`Wrote ${files.length} MCP runner files to ${outDir}`);
+  console.log(`Run them in lexical order, ending with 99-run-target.mcp.js.`);
+}
+
+async function writeChunkSources(outDir, key, value, options) {
+  const chunks = chunkString(value, options.chunkSize);
+  const files = [];
+  let previousLength = 0;
+
+  for (let index = 0; index < chunks.length; index += 1) {
+    const chunk = chunks[index];
+    const fileName = `${key === "designModelJson" ? "10" : "20"}-${key}-${String(index + 1).padStart(3, "0")}.mcp.js`;
+    files.push(await writeFileIn(
+      outDir,
+      fileName,
+      appendChunkSource({
+        namespace: options.namespace,
+        key,
+        chunk,
+        chunkIndex: index + 1,
+        chunkCount: chunks.length,
+        previousLength,
+      })
+    ));
+    previousLength += chunk.length;
+  }
+
+  return files;
+}
+
+async function writeManifest(outDir, files, options, designModel, modelJson, script, scriptBase64) {
+  return writeFileIn(
+    outDir,
+    "manifest.json",
+    JSON.stringify(
+      {
+        mode: options.mode,
+        entrypoint: options.entrypoint,
+        target: options.target,
+        writeMetadata: options.writeMetadata,
+        namespace: options.namespace,
+        sectionNodeId: options.sectionNodeId || null,
+        allowOfficialSections: options.allowOfficialSections,
+        metadataPageId: METADATA_PAGE_ID,
+        modelPath: relativeToToolRoot(options.modelPath),
+        scriptPath: relativeToToolRoot(options.scriptPath),
+        modelHash: designModel.modelHash,
+        gitSha: designModel.gitSha,
+        designModelLength: modelJson.length,
+        scriptLength: script.length,
+        scriptBase64Length: scriptBase64.length,
+        files,
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function writeFileIn(outDir, fileName, source) {
+  await writeFile(join(outDir, fileName), source, "utf8");
+  return fileName;
+}
+
+function validateDesignModel(designModel, options) {
+  if (designModel.branch !== "main") {
+    throw new Error(`MCP runners require a main design model. Found '${designModel.branch ?? "<missing>"}'.`);
+  }
+  if (!designModel.gitSha) {
+    throw new Error("MCP runners require designModel.gitSha.");
+  }
+  if (!designModel.modelHash) {
+    throw new Error("MCP runners require designModel.modelHash.");
+  }
+  if (options.mode === "preview" && options.writeMetadata) {
+    throw new Error("Preview runners must never write metadata.");
+  }
+}
+
+function clearStagingSource(namespace) {
+  return `${runtimeHeader()}
+const namespace = ${JSON.stringify(namespace)};
+const keys = [
+  "designModelJson",
+  "designModelHash",
+  "designModelGitSha",
+  "designModelLength",
+  "scriptBase64",
+  "scriptLength",
+  "scriptBase64Length"
+];
+
+for (const key of keys) {
+  page.setSharedPluginData(namespace, key, "");
+}
+
+return { namespace, clearedKeys: keys };
+`;
+}
+
+function appendChunkSource({ namespace, key, chunk, chunkIndex, chunkCount, previousLength }) {
+  return `${runtimeHeader()}
+const namespace = ${JSON.stringify(namespace)};
+const key = ${JSON.stringify(key)};
+const chunk = ${JSON.stringify(chunk)};
+const expectedChunkLength = ${chunk.length};
+const expectedPreviousLength = ${previousLength};
+const previous = page.getSharedPluginData(namespace, key);
+
+if (chunk.length !== expectedChunkLength) {
+  throw new Error(\`Unexpected staged \${key} chunk ${chunkIndex}/${chunkCount} length: \${chunk.length} != \${expectedChunkLength}\`);
+}
+
+if (previous.length !== expectedPreviousLength) {
+  throw new Error(\`Unexpected staged \${key} length before chunk ${chunkIndex}/${chunkCount}: \${previous.length} != \${expectedPreviousLength}\`);
+}
+
+page.setSharedPluginData(namespace, key, previous + chunk);
+
+return {
+  namespace,
+  key,
+  chunkIndex: ${chunkIndex},
+  chunkCount: ${chunkCount},
+  currentLength: page.getSharedPluginData(namespace, key).length
+};
+`;
+}
+
+function finalizeStagingSource(options, designModel, modelJson, script, scriptBase64) {
+  return `${runtimeHeader()}
+const namespace = ${JSON.stringify(options.namespace)};
+const expected = {
+  designModelHash: ${JSON.stringify(designModel.modelHash)},
+  designModelGitSha: ${JSON.stringify(designModel.gitSha)},
+  designModelLength: ${JSON.stringify(String(modelJson.length))},
+  scriptLength: ${JSON.stringify(String(script.length))},
+  scriptBase64Length: ${JSON.stringify(String(scriptBase64.length))}
+};
+
+const stagedModelJson = page.getSharedPluginData(namespace, "designModelJson");
+const stagedScriptBase64 = page.getSharedPluginData(namespace, "scriptBase64");
+
+if (String(stagedModelJson.length) !== expected.designModelLength) {
+  throw new Error(\`Staged model length mismatch: \${stagedModelJson.length} != \${expected.designModelLength}\`);
+}
+
+if (String(stagedScriptBase64.length) !== expected.scriptBase64Length) {
+  throw new Error(\`Staged scriptBase64 length mismatch: \${stagedScriptBase64.length} != \${expected.scriptBase64Length}\`);
+}
+
+const parsedModel = JSON.parse(stagedModelJson);
+if (parsedModel.modelHash !== expected.designModelHash) {
+  throw new Error(\`Staged modelHash mismatch: \${parsedModel.modelHash} != \${expected.designModelHash}\`);
+}
+if (parsedModel.gitSha !== expected.designModelGitSha) {
+  throw new Error(\`Staged gitSha mismatch: \${parsedModel.gitSha} != \${expected.designModelGitSha}\`);
+}
+
+page.setSharedPluginData(namespace, "designModelHash", expected.designModelHash);
+page.setSharedPluginData(namespace, "designModelGitSha", expected.designModelGitSha);
+page.setSharedPluginData(namespace, "designModelLength", expected.designModelLength);
+page.setSharedPluginData(namespace, "scriptLength", expected.scriptLength);
+page.setSharedPluginData(namespace, "scriptBase64Length", expected.scriptBase64Length);
+
+return {
+  namespace,
+  mode: ${JSON.stringify(options.mode)},
+  target: ${JSON.stringify(options.target)},
+  modelHash: expected.designModelHash,
+  gitSha: expected.designModelGitSha,
+  designModelLength: expected.designModelLength,
+  scriptBase64Length: expected.scriptBase64Length
+};
+`;
+}
+
+function runTargetSource(options) {
+  const syncOptions = {
+    targets: [options.target],
+    writeMetadata: options.writeMetadata,
+    ...(options.sectionNodeId ? { sectionNodeOverrides: { [options.target]: options.sectionNodeId } } : {}),
+  };
+
+  const invokeScript = options.entrypoint === "preview-catalog"
+    ? previewCatalogInvocationSource()
+    : trunkSyncInvocationSource();
+
+  return `${runtimeHeader()}
+const namespace = ${JSON.stringify(options.namespace)};
+const mode = ${JSON.stringify(options.mode)};
+const entrypoint = ${JSON.stringify(options.entrypoint)};
+const syncOptions = ${JSON.stringify(syncOptions)};
+
+if (mode === "preview" && (syncOptions.writeMetadata === true || syncOptions.targets.includes("metadata"))) {
+  throw new Error("Preview runners must not write official Figma sync metadata.");
+}
+
+if (
+  mode === "preview" &&
+  ${JSON.stringify(isCatalogTarget(options.target))} &&
+  !syncOptions.sectionNodeOverrides?.[syncOptions.targets[0]] &&
+  ${JSON.stringify(!options.allowOfficialSections)}
+) {
+  throw new Error("Preview catalog runners require a sandbox section override.");
+}
+
+const stagedModelJson = page.getSharedPluginData(namespace, "designModelJson");
+const scriptBase64 = page.getSharedPluginData(namespace, "scriptBase64");
+
+if (!stagedModelJson || !scriptBase64) {
+  throw new Error("Missing staged model or script.");
+}
+
+const stagedModel = JSON.parse(stagedModelJson);
+const stagedModelHash = page.getSharedPluginData(namespace, "designModelHash");
+const stagedModelGitSha = page.getSharedPluginData(namespace, "designModelGitSha");
+const stagedModelLength = page.getSharedPluginData(namespace, "designModelLength");
+const scriptLength = page.getSharedPluginData(namespace, "scriptLength");
+const scriptBase64Length = page.getSharedPluginData(namespace, "scriptBase64Length");
+
+for (const [key, value] of Object.entries({
+  designModelHash: stagedModelHash,
+  designModelGitSha: stagedModelGitSha,
+  designModelLength: stagedModelLength,
+  scriptLength,
+  scriptBase64Length
+})) {
+  if (!value) {
+    throw new Error(\`Missing staged \${key}.\`);
+  }
+}
+
+if (stagedModelHash !== stagedModel.modelHash) {
+  throw new Error(\`Staged modelHash mismatch: \${stagedModelHash} != \${stagedModel.modelHash}\`);
+}
+
+if (stagedModelGitSha !== stagedModel.gitSha) {
+  throw new Error(\`Staged gitSha mismatch: \${stagedModelGitSha} != \${stagedModel.gitSha}\`);
+}
+
+if (Number(stagedModelLength) !== stagedModelJson.length) {
+  throw new Error(\`Staged model length mismatch: \${stagedModelLength} != \${stagedModelJson.length}\`);
+}
+
+if (Number(scriptBase64Length) !== scriptBase64.length) {
+  throw new Error(\`Staged script length mismatch: \${scriptBase64Length} != \${scriptBase64.length}\`);
+}
+
+let script = atob(scriptBase64);
+
+if (Number(scriptLength) !== script.length) {
+  throw new Error(\`Decoded script length mismatch: \${scriptLength} != \${script.length}\`);
+}
+
+${invokeScript}
+`;
+}
+
+function trunkSyncInvocationSource() {
+  return `
+script = script.replace(
+  "const DESIGN_MODEL = undefined;",
+  "const DESIGN_MODEL = stagedModel;"
+);
+script = script.replace(
+  "const SYNC_OPTIONS = undefined;",
+  \`const SYNC_OPTIONS = \${JSON.stringify(syncOptions)};\`
+);
+
+const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+const run = new AsyncFunction("figma", "stagedModel", script);
+
+return await run(figma, stagedModel);
+`;
+}
+
+function previewCatalogInvocationSource() {
+  return `
+if (entrypoint !== "preview-catalog") {
+  throw new Error(\`Unexpected entrypoint '\${entrypoint}'.\`);
+}
+
+const target = syncOptions.targets[0];
+const sectionNodeId = syncOptions.sectionNodeOverrides?.[target];
+if (!target || !sectionNodeId) {
+  throw new Error("Preview catalog entrypoint requires one target and a sandbox section override.");
+}
+
+const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+const run = new AsyncFunction(
+  "figma",
+  "stagedModel",
+  "target",
+  "sectionNodeId",
+  \`\${script}
+return await FigmaCatalogTreePreview.main(stagedModel, { target, sectionNodeId });
+\`
+);
+
+return await run(figma, stagedModel, target, sectionNodeId);
+`;
+}
+
+function runtimeHeader() {
+  return `const page = await figma.getNodeByIdAsync(${JSON.stringify(METADATA_PAGE_ID)});
+
+if (!page || page.type !== "PAGE") {
+  throw new Error("Expected sync page ${METADATA_PAGE_ID} to be a PAGE");
+}
+
+await figma.setCurrentPageAsync(page);
+`;
+}
+
+function chunkString(value, chunkSize) {
+  const chunks = [];
+  for (let index = 0; index < value.length; index += chunkSize) {
+    chunks.push(value.slice(index, index + chunkSize));
+  }
+  return chunks.length > 0 ? chunks : [""];
+}
+
+function safeName(value) {
+  return value.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function relativeToToolRoot(path) {
+  const relativePath = relative(TOOL_ROOT, path);
+  return relativePath && !relativePath.startsWith("..")
+    ? relativePath.replace(/\\/g, "/")
+    : path;
+}
+
+function isCatalogTarget(target) {
+  return target !== "versions" && target !== "metadata";
+}

--- a/repo/figma-design-sync/tools/src/app/sync-catalog-tree-preview.mcp.ts
+++ b/repo/figma-design-sync/tools/src/app/sync-catalog-tree-preview.mcp.ts
@@ -1,0 +1,34 @@
+import { FigmaCatalogTreeSyncGateway } from "../figma/figma-catalog-tree-sync-gateway";
+import type { DesignModel, SyncTargetName } from "../domain/design-model";
+
+export async function main(
+  designModel: DesignModel | undefined,
+  options?: {
+    target?: SyncTargetName;
+    sectionNodeId?: string;
+  }
+) {
+  if (!designModel) {
+    throw new Error("Replace DESIGN_MODEL with a preview design model fixture.");
+  }
+  if (designModel.branch !== "main") {
+    throw new Error(`Preview catalog sync requires a main-compatible model. Found '${designModel.branch ?? "<missing>"}'.`);
+  }
+  if (!options?.target || options.target === "versions" || options.target === "metadata") {
+    throw new Error("Preview catalog sync requires one catalog target.");
+  }
+  if (!options.sectionNodeId) {
+    throw new Error("Preview catalog sync requires a sandbox section node id.");
+  }
+
+  const gateway = new FigmaCatalogTreeSyncGateway();
+  return gateway.syncCatalogTrees(
+    designModel,
+    {
+      targetNames: [options.target],
+      sectionNodeOverrides: {
+        [options.target]: options.sectionNodeId,
+      },
+    }
+  );
+}

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -7,6 +7,16 @@ export const VERSIONS_COLLECTION_NAMES = [VERSIONS_COLLECTION_NAME];
 export const VERSION_ALIAS_MODE_NAME = "Version alias";
 export const VERSION_NUMBER_MODE_NAME = "Version number";
 export const PROJECT_VERSION_COMPONENT_ID = "63075:591";
+export const PARENT_SECTION_SIBLING_GAP = 1139;
+export const PARENT_SECTION_NODE_IDS = [
+  "63685:108540",
+  "62936:183",
+  "63099:949",
+  "63099:954",
+  "63216:6907",
+  "63330:551",
+];
+export const SECTION_SIBLING_GAP = 114;
 export const TREE_NODE_COMPONENT_IDS = {
   Library: "63069:681",
   Plugin: "63069:694",

--- a/repo/figma-design-sync/tools/src/domain/catalog/library-catalog-entries.ts
+++ b/repo/figma-design-sync/tools/src/domain/catalog/library-catalog-entries.ts
@@ -6,11 +6,24 @@ export function libraryArtifacts(entries) {
   return entries.flatMap((entry) => {
     if (entry.type === "artifact") {
       const providedByConventionPlugins = sortedConventionPluginUsages(entry.providedByConventionPlugins || []);
+      const configuredByConventionPlugins = sortedConventionPluginConfigurationUsages(entry.configuredByConventionPlugins || []);
       const requiredByModules = effectiveRequiredByModules(entry.requiredByModules || [], providedByConventionPlugins);
-      return [{ name: entry.artifact, requiredByModules, providedByConventionPlugins }];
+      return [{
+        name: entry.artifact,
+        requiredByModules,
+        providedByConventionPlugins,
+        configuredByConventionPlugins,
+        isCatalogEntry: true,
+      }];
     }
     if (entry.type === "bundle") {
-      return (entry.artifacts || []).map((artifact) => ({ name: artifact, requiredByModules: [] }));
+      return (entry.artifacts || []).map((artifact) => ({
+        name: artifact,
+        requiredByModules: [],
+        providedByConventionPlugins: [],
+        configuredByConventionPlugins: [],
+        isCatalogEntry: false,
+      }));
     }
     throw new Error(`Unsupported library catalog entry type '${entry.type}'.`);
   });
@@ -25,6 +38,7 @@ export function libraryBundles(entries) {
         alias: entry.alias,
         requiredByModules: effectiveRequiredByModules(entry.requiredByModules || [], providedByConventionPlugins),
         providedByConventionPlugins,
+        isCatalogEntry: true,
       };
     });
 }
@@ -53,6 +67,20 @@ function sortedConventionPluginUsages(usages) {
     .sort((first, second) =>
       first.pluginId.localeCompare(second.pluginId) ||
         first.pluginModule.localeCompare(second.pluginModule)
+    );
+}
+
+function sortedConventionPluginConfigurationUsages(usages) {
+  return [...usages]
+    .map((usage) => ({
+      pluginId: usage.pluginId,
+      pluginModule: usage.pluginModule,
+      target: usage.target,
+    }))
+    .sort((first, second) =>
+      first.pluginId.localeCompare(second.pluginId) ||
+        first.pluginModule.localeCompare(second.pluginModule) ||
+        first.target.localeCompare(second.target)
     );
 }
 

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -36,4 +36,5 @@ export type SyncTargetName =
 export type SyncFigmaDesignModelOptions = {
   targets?: SyncTargetName[];
   writeMetadata?: boolean;
+  sectionNodeOverrides?: Record<string, string>;
 };

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -62,7 +62,8 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     const expectedNodes = flattenCatalogNodes(modelNodes, target.type);
     requireUniqueLabels(target, expectedNodes);
 
-    const section = await requireSection(target.sectionNodeId);
+    const sectionNodeId = options.sectionNodeOverrides?.[target.name] || target.sectionNodeId;
+    const section = await requireSection(sectionNodeId);
     unlockSectionTreeForMutation(section, mutatedNodeIds);
     const instancesByLabel = collectTreeNodeInstancesByLabel(section, target.type);
     let connectors = collectTreeConnectors(section);

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -20,6 +20,8 @@ import {
   requireSection,
   resizeAncestorSectionsToFit,
   resizeNodeToFit,
+  stackAncestorSectionSiblingsWithGap,
+  stackDescendantSectionsWithGap,
   unlockSectionTreeForMutation,
 } from "./figma-node-gateway";
 import {
@@ -120,6 +122,8 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     layoutCatalogTreeNodes(section, expectedNodes, instancesByLabel, mutatedNodeIds);
     syncCatalogConnectors(section, expectedNodes, instancesByLabel, connectors, mutatedNodeIds);
     resizeSectionsToFit(section, [...instancesByLabel.values()], mutatedNodeIds);
+    stackDescendantSectionsWithGap(section, mutatedNodeIds);
+    stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds);
     resizeAncestorSectionsToFit(section, mutatedNodeIds);
     lockOnlyRootSection(section, mutatedNodeIds);
   }

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -29,10 +29,19 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
   for (let index = 0; index < artifacts.length; index += 1) {
     const artifactInstance = artifactInstances[index];
     const artifact = artifacts[index];
+    const requiredByModules = artifact.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(artifact.providedByConventionPlugins || []);
+    const configuredByConventionPlugins = usageChipsForConventionPluginConfigurations(
+      artifact.configuredByConventionPlugins || []
+    );
+    const isUnused = isUnusedCatalogEntry(artifact);
     artifactInstance.visible = true;
     artifactInstance.setProperties({
-      [ARTIFACT_PROPS.showConsumerModules]: artifact.requiredByModules.length > 0 || providedByConventionPlugins.length > 0,
+      [ARTIFACT_PROPS.showConsumerModules]:
+        requiredByModules.length > 0 ||
+        providedByConventionPlugins.length > 0 ||
+        configuredByConventionPlugins.length > 0 ||
+        isUnused,
     });
     mutatedNodeIds.push(artifactInstance.id);
     await updateUsageChipInstances(
@@ -41,12 +50,23 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       providedByConventionPlugins,
       mutatedNodeIds
     );
+    setUsageBlockVisible(artifactInstance, "Provided by", providedByConventionPlugins.length > 0, mutatedNodeIds);
+    await updateUsageChipInstances(
+      artifactInstance,
+      "Tool artifacts",
+      configuredByConventionPlugins,
+      mutatedNodeIds
+    );
+    setUsageBlockVisible(artifactInstance, "Tool artifacts", configuredByConventionPlugins.length > 0, mutatedNodeIds);
     await updateConsumerModuleInstances(
       artifactInstance,
       "Required by",
-      artifact.requiredByModules,
+      requiredByModules,
       mutatedNodeIds
     );
+    setUsageBlockVisible(artifactInstance, "Required by", requiredByModules.length > 0, mutatedNodeIds);
+    setUsageBlockVisible(artifactInstance, "Unused catalog entry", isUnused, mutatedNodeIds);
+    syncDirectUsageSeparators(artifactInstance, mutatedNodeIds);
   }
 
   hideUnusedInstances(artifactInstances.slice(artifacts.length), mutatedNodeIds);
@@ -66,10 +86,15 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
   for (let index = 0; index < bundles.length; index += 1) {
     const bundleInstance = bundleInstances[index];
     const bundle = bundles[index];
+    const requiredByModules = bundle.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(bundle.providedByConventionPlugins || []);
+    const isUnused = !hasConsumerUsage(bundle);
     bundleInstance.visible = true;
     bundleInstance.setProperties({
-      [ARTIFACTS_BUNDLE_PROPS.showConsumerModules]: bundle.requiredByModules.length > 0 || providedByConventionPlugins.length > 0,
+      [ARTIFACTS_BUNDLE_PROPS.showConsumerModules]:
+        requiredByModules.length > 0 ||
+        providedByConventionPlugins.length > 0 ||
+        isUnused,
     });
     mutatedNodeIds.push(bundleInstance.id);
     await updateUsageChipInstances(
@@ -79,13 +104,23 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
       mutatedNodeIds,
       { excludeArtifactDescendants: true }
     );
+    setUsageBlockVisible(bundleInstance, "Provided by", providedByConventionPlugins.length > 0, mutatedNodeIds, {
+      excludeArtifactDescendants: true,
+    });
     await updateConsumerModuleInstances(
       bundleInstance,
       "Required by",
-      bundle.requiredByModules,
+      requiredByModules,
       mutatedNodeIds,
       { excludeArtifactDescendants: true }
     );
+    setUsageBlockVisible(bundleInstance, "Required by", requiredByModules.length > 0, mutatedNodeIds, {
+      excludeArtifactDescendants: true,
+    });
+    setUsageBlockVisible(bundleInstance, "Unused catalog entry", isUnused, mutatedNodeIds, {
+      excludeArtifactDescendants: true,
+    });
+    syncDirectUsageSeparators(bundleInstance, mutatedNodeIds, { excludeArtifactDescendants: true });
   }
 
   hideUnusedInstances(bundleInstances.slice(bundles.length), mutatedNodeIds);
@@ -141,6 +176,99 @@ export async function updateUsageChipInstances(
   for (const usageChipInstance of usageChipInstances.slice(usages.length)) {
     hideInstance(usageChipInstance, mutatedNodeIds);
   }
+}
+
+function setUsageBlockVisible(
+  root,
+  heading,
+  visible,
+  mutatedNodeIds,
+  options: ConsumerModuleOptions = {}
+) {
+  const usageBlock = findUsageBlock(root, heading, options);
+  if (!usageBlock) {
+    if (visible) {
+      throw new Error(`Node '${root.id}' is missing '${heading}' usage block.`);
+    }
+    return;
+  }
+
+  setNodeVisible(usageBlock, visible, mutatedNodeIds);
+}
+
+function findUsageBlock(root, heading, options: ConsumerModuleOptions = {}) {
+  const blockName = heading.toLowerCase();
+  const directBlock = childrenOf(root)
+    .find((child) =>
+      child.name === blockName &&
+      !isExcludedByOptions(child, root, options)
+    );
+  if (directBlock) return directBlock;
+
+  const namedBlock = root.findAllWithCriteria({ types: ["FRAME"] })
+    .find((frame) =>
+      frame.name === blockName &&
+      !isExcludedByOptions(frame, root, options)
+    );
+  if (namedBlock) return namedBlock;
+
+  const headingNode = findUsageChipHeading(root, heading, options);
+  if (!headingNode) return undefined;
+
+  return nearestAncestorNamedUsageBlock(headingNode, root) ||
+    nearestDirectChildAncestor(headingNode, root);
+}
+
+function nearestAncestorNamedUsageBlock(node, boundary) {
+  let current = node.parent;
+  while (current && current.id !== boundary.id) {
+    if (USAGE_BLOCK_FRAME_NAMES.has(current.name)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function nearestDirectChildAncestor(node, boundary) {
+  let current = node.parent;
+  while (current && current.id !== boundary.id) {
+    if (current.parent?.id === boundary.id) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function syncDirectUsageSeparators(root, mutatedNodeIds, options: ConsumerModuleOptions = {}) {
+  const children = childrenOf(root);
+  const usageBlockIds = new Set(
+    [...USAGE_BLOCK_HEADINGS]
+      .map((heading) => findUsageBlock(root, heading, options))
+      .filter(Boolean)
+      .map((usageBlock) => usageBlock.id)
+  );
+
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    if (child.name !== USAGE_SEPARATOR_FRAME_NAME) continue;
+
+    const nextUsageBlock = children
+      .slice(index + 1)
+      .find((candidate) =>
+        candidate.name === USAGE_SEPARATOR_FRAME_NAME ||
+        usageBlockIds.has(candidate.id)
+      );
+    const visible = nextUsageBlock && nextUsageBlock.name !== USAGE_SEPARATOR_FRAME_NAME
+      ? nextUsageBlock.visible !== false
+      : false;
+    setNodeVisible(child, visible, mutatedNodeIds);
+  }
+}
+
+function childrenOf(node) {
+  return "children" in node ? [...node.children] : [];
+}
+
+function isExcludedByOptions(node, root, options: ConsumerModuleOptions = {}) {
+  return options.excludeArtifactDescendants && hasAncestorInstanceNamed(node, ARTIFACT_INSTANCE_NAME, root);
 }
 
 function hasAncestorInstanceNamed(node, name, boundary) {
@@ -318,10 +446,14 @@ function hideUnusedInstances(instances, mutatedNodeIds) {
 }
 
 function hideInstance(instance, mutatedNodeIds) {
-  if (instance.visible === false) return;
+  setNodeVisible(instance, false, mutatedNodeIds);
+}
 
-  instance.visible = false;
-  mutatedNodeIds.push(instance.id);
+function setNodeVisible(node, visible, mutatedNodeIds) {
+  if (node.visible === visible) return;
+
+  node.visible = visible;
+  mutatedNodeIds.push(node.id);
 }
 
 function findUsageChipProperty(moduleInstance, propertyName, propertyType) {
@@ -341,5 +473,37 @@ function usageChipsForConventionPlugins(providedByConventionPlugins) {
   }));
 }
 
+function usageChipsForConventionPluginConfigurations(configuredByConventionPlugins) {
+  return sortedUnique(
+    configuredByConventionPlugins.map((usage) => `${usage.pluginId} -> ${usage.target}`)
+  ).map((usageLabel) => ({
+    kind: USAGE_CHIP_KINDS.conventionPlugin,
+    name: usageLabel,
+  }));
+}
+
+function isUnusedCatalogEntry(entry) {
+  return entry.isCatalogEntry === true && !hasConsumerUsage(entry);
+}
+
+function hasConsumerUsage(entry) {
+  return (entry.requiredByModules || []).length > 0 ||
+    (entry.providedByConventionPlugins || []).length > 0 ||
+    (entry.configuredByConventionPlugins || []).length > 0;
+}
+
 const MODULE_HORIZONTAL_PADDING = 26;
 const MODULE_VERTICAL_PADDING = 6;
+const USAGE_SEPARATOR_FRAME_NAME = "usage separator";
+const USAGE_BLOCK_HEADINGS = [
+  "Provided by",
+  "Required by",
+  "Tool artifacts",
+  "Unused catalog entry",
+];
+const USAGE_BLOCK_FRAME_NAMES = new Set([
+  "provided by",
+  "required by",
+  "tool artifacts",
+  "unused catalog entry",
+]);

--- a/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
@@ -1,4 +1,9 @@
 import type { CatalogTreeType } from "../domain/design-model";
+import {
+  PARENT_SECTION_NODE_IDS,
+  PARENT_SECTION_SIBLING_GAP,
+  SECTION_SIBLING_GAP,
+} from "../config/figma-config";
 
 export async function requireVariableCollection(nameOrNames) {
   const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
@@ -81,10 +86,11 @@ export function resizeNodeToFit(node, children, mutatedNodeIds, padding = 100) {
     ? visibleChildren.filter((child) => !(child.type === "INSTANCE" && child.name === ".Header"))
     : visibleChildren;
   const boundsChildren = contentChildren.length > 0 ? contentChildren : visibleChildren;
+  const directHeaderHugWidth = node.type === "SECTION" ? maxDirectHeaderHugWidth(node) : 0;
   const maxRight = Math.max(...boundsChildren.map((child) => child.x + child.width));
   const maxBottom = Math.max(...boundsChildren.map((child) => child.y + child.height));
   node.resizeWithoutConstraints(
-    Math.max(1, maxRight + padding),
+    Math.max(1, maxRight + padding, directHeaderHugWidth),
     Math.max(1, maxBottom + padding)
   );
   mutatedNodeIds.push(node.id);
@@ -106,6 +112,35 @@ export function resizeAncestorSectionsToFit(node, mutatedNodeIds, padding = 100)
     );
     current = current.parent;
   }
+}
+
+export function stackDescendantSectionsWithGap(section, mutatedNodeIds, gap = SECTION_SIBLING_GAP) {
+  for (const childSection of directChildSections(section)) {
+    stackDescendantSectionsWithGap(childSection, mutatedNodeIds, gap);
+  }
+
+  stackDirectChildSectionsWithGap(section, mutatedNodeIds, gap);
+  resizeNodeToFit(
+    section,
+    section.children.filter((child) => child.visible !== false),
+    mutatedNodeIds
+  );
+}
+
+export function stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds, gap = SECTION_SIBLING_GAP) {
+  let current = section.parent;
+
+  while (current && current.type === "SECTION") {
+    stackDirectChildSectionsWithGap(current, mutatedNodeIds, gap);
+    resizeNodeToFit(
+      current,
+      current.children.filter((child) => child.visible !== false),
+      mutatedNodeIds
+    );
+    current = current.parent;
+  }
+
+  stackConfiguredPageSectionsWithGap(section, mutatedNodeIds);
 }
 
 export function unlockSectionTreeForMutation(section, mutatedNodeIds) {
@@ -137,9 +172,81 @@ function resizeDirectHeadersToSectionWidth(section, mutatedNodeIds) {
 
   for (const header of headers) {
     header.x = 0;
+    if (header.layoutMode === "VERTICAL" || header.layoutMode === "HORIZONTAL") {
+      header.counterAxisSizingMode = "FIXED";
+      header.primaryAxisSizingMode = "AUTO";
+    }
     header.resizeWithoutConstraints(section.width, header.height);
     mutatedNodeIds.push(header.id);
   }
+}
+
+function maxDirectHeaderHugWidth(section) {
+  return Math.max(
+    0,
+    ...section.children
+      .filter((child) => child.type === "INSTANCE" && child.name === ".Header")
+      .map((header) => directHeaderHugWidth(header))
+  );
+}
+
+function directHeaderHugWidth(header) {
+  if (header.layoutMode !== "VERTICAL" && header.layoutMode !== "HORIZONTAL") {
+    return header.width;
+  }
+
+  const originalCounterAxisSizingMode = header.counterAxisSizingMode;
+  header.counterAxisSizingMode = "AUTO";
+  const hugWidth = header.width;
+  header.counterAxisSizingMode = originalCounterAxisSizingMode;
+  return hugWidth;
+}
+
+function stackConfiguredPageSectionsWithGap(section, mutatedNodeIds, gap = PARENT_SECTION_SIBLING_GAP) {
+  const root = rootSection(section);
+  if (!PARENT_SECTION_NODE_IDS.includes(root.id)) return;
+  if (root.parent?.type !== "PAGE") return;
+
+  const sections = PARENT_SECTION_NODE_IDS
+    .map((sectionId) => root.parent.children.find((child) => child.id === sectionId))
+    .filter((child) => child?.type === "SECTION" && child.visible !== false);
+
+  if (sections.length < 2) return;
+
+  let nextX = sections[0].x;
+  for (const siblingSection of sections) {
+    if (Math.abs(siblingSection.x - nextX) > 0.01) {
+      siblingSection.x = nextX;
+      mutatedNodeIds.push(siblingSection.id);
+    }
+    nextX = siblingSection.x + siblingSection.width + gap;
+  }
+}
+
+function stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap) {
+  const sections = directChildSections(parent)
+    .sort((first, second) => first.y - second.y || first.x - second.x);
+
+  if (sections.length < 2) return;
+
+  const alignedX = sections[0].x;
+  let nextY = sections[0].y;
+  for (const section of sections) {
+    if (Math.abs(section.x - alignedX) > 0.01) {
+      section.x = alignedX;
+      mutatedNodeIds.push(section.id);
+    }
+    if (Math.abs(section.y - nextY) > 0.01) {
+      section.y = nextY;
+      mutatedNodeIds.push(section.id);
+    }
+    nextY = section.y + section.height + gap;
+  }
+}
+
+function directChildSections(parent) {
+  return parent.children
+    .filter((child) => child.type === "SECTION" && child.visible !== false);
 }
 
 function rootSection(section) {

--- a/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -78,11 +78,13 @@ export async function updateLibraryTreeNode(instance, node, mutatedNodeIds) {
     ...artifacts.flatMap((artifact) => artifact.requiredByModules),
     ...bundles.flatMap((bundle) => bundle.requiredByModules),
   ]);
+  const hasCatalogEntries = artifacts.some((artifact) => artifact.isCatalogEntry === true) ||
+    bundles.some((bundle) => bundle.isCatalogEntry === true);
 
   instance.setProperties({
     [TREE_NODE_PROPS.libraryGroup]: node.label,
     [TREE_NODE_PROPS.showArtifacts]: node.artifactsVisible && artifactNames.length > 0,
-    [TREE_NODE_PROPS.showConsumerModule]: requiredByModules.length > 0,
+    [TREE_NODE_PROPS.showConsumerModule]: requiredByModules.length > 0 || hasCatalogEntries,
     [TREE_NODE_PROPS.type]: "Library",
   });
   mutatedNodeIds.push(instance.id);
@@ -93,7 +95,7 @@ export async function updateLibraryTreeNode(instance, node, mutatedNodeIds) {
   await updateLibraryArtifactConsumerModules(instance, artifacts, mutatedNodeIds);
   await updateLibraryBundleConsumerModules(instance, bundles, mutatedNodeIds);
 
-  if (artifactNames.length === 0 && requiredByModules.length === 0) {
+  if (artifactNames.length === 0 && requiredByModules.length === 0 && !hasCatalogEntries) {
     resizeBareTreeNodeToFitLabel(instance, "Library group", mutatedNodeIds);
   }
 }

--- a/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
@@ -15,6 +15,7 @@ import {
   requireVariableCollection,
   resizeAncestorSectionsToFit,
   resizeNodeToFit,
+  stackAncestorSectionSiblingsWithGap,
 } from "./figma-node-gateway";
 import { collectText } from "./figma-text-gateway";
 
@@ -77,6 +78,7 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
     }
 
     resizeNodeToFit(parent, parent.children.filter((child) => child.visible !== false), mutatedNodeIds);
+    stackAncestorSectionSiblingsWithGap(parent, mutatedNodeIds);
     resizeAncestorSectionsToFit(parent, mutatedNodeIds);
   }
 

--- a/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
+++ b/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
@@ -18,6 +18,7 @@ export type CatalogTreeSyncResult = {
 
 export type CatalogTreeSyncOptions = {
   targetNames?: string[];
+  sectionNodeOverrides?: Record<string, string>;
 };
 
 export type MetadataSyncResult = {

--- a/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
+++ b/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
@@ -33,7 +33,13 @@ export async function syncFigmaDesignModel(
 
   const catalogTargets = CATALOG_SYNC_TARGETS.filter((target) => requestedTargets.has(target));
   const catalogSyncResult = catalogTargets.length > 0
-    ? await dependencies.catalogTreeSyncGateway.syncCatalogTrees(designModel, { targetNames: catalogTargets })
+    ? await dependencies.catalogTreeSyncGateway.syncCatalogTrees(
+        designModel,
+        {
+          targetNames: catalogTargets,
+          sectionNodeOverrides: options.sectionNodeOverrides,
+        }
+      )
     : emptyCatalogTreeSyncResult();
   completedTargets.push(...catalogTargets);
 


### PR DESCRIPTION
## Summary
- model convention-plugin tooling configuration usages as `configuredByConventionPlugins`
- render `Tool artifacts` usage chips and hide empty usage blocks in Figma catalog artifacts
- show `Unused catalog entry` when a catalog artifact or bundle has no consumers/providers/tooling usage

## Verification
- `git diff --check`
- `npm run build` in `repo/figma-design-sync/tools`
- `.\gradlew.bat :figma-design-sync:domain:check :figma-design-sync:data:check :figma-design-sync:plugin:check --rerun-tasks`