### PR TITLE
fix(figma-design-sync): isolate artifact usage visibility

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -74,6 +74,34 @@ visible entries. The failure signature is similar to:
 expected 0 'artifact name' text nodes, found 8
 ```
 
+## Usage Blocks Hidden Despite Model Data
+
+The official `design-model.json` can be correct while the visible Figma
+`.artifact` instance is still visually stale. The observed failure mode was a
+library artifact whose model contained `providedByConventionPlugins` and
+effective `requiredByModules`, while the visible `.artifact` kept
+`Show consumer modules=false` and its direct `Provided by` / `Required by`
+blocks hidden. Hidden template internals under the same `.tree node` still
+contained chips, which made the file look partially updated through the plugin
+API but not visually updated on canvas.
+
+Diagnose this as a visual sync inconsistency before changing catalog
+extraction:
+
+- Confirm the official TeamCity `design-model.json` contains the artifact usage.
+- Inspect the owning `.tree node` and confirm `Show consumer module=true` when
+  usage is expected.
+- Inspect the visible direct `.artifact` or `.artifacts bundle` instance under
+  the `artifacts` frame, not hidden template internals.
+- Confirm the visible direct `.artifact` / `.artifacts bundle` instance has the
+  granular component booleans expected by the model: `Show provided by`,
+  `Show required by`, `Show tool artifacts` when present, and
+  `Show unused catalog entry`. `Show consumer modules` is not enough to validate
+  the surface because it can show both `Provided by` and `Required by`.
+
+The TypeScript sync must fail the visual target before metadata if this
+invariant is not true. Do not repair this with a metadata-only write.
+
 ## Connector Binding Failures
 
 Cloned tree nodes and cloned connectors must be made visible before connector

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -98,6 +98,25 @@ The MCP sync code rejects models whose `branch` is not `main`. A branch-local
 model is never an authorized Figma write input, even when its `modelHash`
 matches the expected content.
 
+## Branch Visual Iteration With The Official Artifact
+
+If the TeamCity `main` artifact already represents the model state being tested,
+a short-lived Git branch may reuse that official `design-model.json` to iterate
+on visual sync tooling. This is valid for changes that only affect Figma
+representation, for example component property bindings, colors, connector
+behavior, layout, resize rules, spacing, or instance selection.
+
+Do not rerun TeamCity only to regenerate the JSON for those visual-only changes.
+Keep the official artifact as the stable input, build the MCP bundle from the
+branch, run only visual targets, and do not write official metadata from the
+branch.
+
+Regenerate through TeamCity on `main` when the change affects model content:
+catalog extraction, module or plugin paths, `Provided by` / `Required by` data,
+target names, `content`, `modelHash`, or any field serialized into
+`design-model.json`. After the tooling branch is merged, run the official
+TeamCity/main flow to seal the authoritative visual state and metadata.
+
 ## Local Diagnostics
 
 Do not generate `design-model.json` locally to repair Figma. Local execution is
@@ -243,7 +262,7 @@ target has completed successfully.
 | Order | Target                                        | Scope                                          | Typical failure                                                                       | Quick check                                                                           |
 |-------|-----------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
 | 1     | `versions`                                    | Version variables and `.project version` nodes | Missing variable collection or stale version section                                  | Returned `updatedVersions` contains the expected version keys.                        |
-| 2     | `waterMyPlants.libraries`                     | Main app libraries and usage chips             | Ambiguous `.artifact` / `.artifacts bundle` usage headings or missing root chip slots | Returned `completedTargets` contains only this target and no metadata.                |
+| 2     | `waterMyPlants.libraries`                     | Main app libraries and usage chips             | Ambiguous `.artifact` / `.artifacts bundle` usage headings or hidden usage blocks on the visible instance | Returned `completedTargets` contains only this target and a spot-checked artifact with model usage shows `Provided by` / `Required by` chips. |
 | 3     | `waterMyPlants.plugins`                       | Main app plugin catalog tree                   | Missing `.tree node` property or connector binding issue                              | Returned catalog nodes match the plugin tree and connectors stay in the section.      |
 | 4     | `waterMyPlants.customGradleConventionPlugins` | Convention plugin catalog                      | Stale convention plugin names or missing usage chip variants                          | Returned nodes include the convention plugin ids expected from `repo/gradle-plugins`. |
 | 5     | `waterMyPlants.customGradlePlugins`           | Regular custom Gradle plugin catalog           | A regular plugin is modeled as a convention plugin, or the reverse                    | Returned nodes include `com.marmatsan.figmaDesignSync` as a regular plugin.           |

--- a/repo/figma-design-sync/docs/runbooks/visual-preview.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-preview.md
@@ -30,6 +30,12 @@ Do not use preview output to make `checkFigmaTrunkSync` pass. That check is tied
 to the official namespace `water_my_plants_sync` and the TeamCity artifact from
 `main`.
 
+For visual-only tooling changes on a branch, an explicitly provided model may be
+the official TeamCity `main` artifact. Treat it as a stable visual input, not as
+permission to write official metadata from the branch. If the branch changes the
+model content itself, merge first and regenerate the artifact through
+TeamCity/main.
+
 ## Fixtures
 
 Visual fixtures live under:

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -89,6 +89,10 @@ For each section:
   versions, and artifact visibility.
 - Update existing library artifact name/version text overrides when the
   instance structure can represent the model.
+- When a `.tree node` contains hidden template placeholders and visible nested
+  catalog rows, update the visible representable `.artifact` /
+  `.artifacts bundle` instances. Do not let hidden placeholders win over visible
+  bundle child artifact rows.
 - Update `Required by` module instances for library artifacts from
   `requiredByModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry.
@@ -102,6 +106,14 @@ For each section:
 - Hide `Provided by`, `Required by`, and `Tool artifacts` blocks when their
   source lists are empty. Do not render empty headings or empty chip
   containers.
+- Control each usage block through its own component boolean on `.artifact` and
+  `.artifacts bundle`: `Show provided by`, `Show required by`,
+  `Show tool artifacts` where the component supports tooling rows, and
+  `Show unused catalog entry`. Do not use one aggregate boolean to show multiple
+  usage blocks.
+- Keep `.artifact` / `.artifacts bundle` `Show consumer modules` only as a
+  backwards-compatible aggregate for consumer-module rows. The decisive visual
+  contract is the granular block boolean plus the direct block visibility.
 - When a direct artifact entry or bundle has no `Required by`, no `Provided by`,
   and no `Tool artifacts` data, show `Unused catalog entry` instead of empty
   usage blocks. Do not mark child artifact rows inside a bundle as unused; the

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -51,10 +51,17 @@ export const TREE_NODE_PROPS = {
 
 export const ARTIFACT_PROPS = {
   showConsumerModules: "Show consumer modules#63086:1",
+  showProvidedBy: "Show provided by",
+  showRequiredBy: "Show required by",
+  showToolArtifacts: "Show tool artifacts",
+  showUnusedCatalogEntry: "Show unused catalog entry",
 };
 
 export const ARTIFACTS_BUNDLE_PROPS = {
   showConsumerModules: "Show consumer modules#63107:0",
+  showProvidedBy: "Show provided by",
+  showRequiredBy: "Show required by",
+  showUnusedCatalogEntry: "Show unused catalog entry",
 };
 
 export const ARTIFACT_INSTANCE_NAME = ".artifact";

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -16,8 +16,7 @@ type ConsumerModuleOptions = {
 };
 
 export async function updateLibraryArtifactConsumerModules(root, artifacts, mutatedNodeIds) {
-  const artifactInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
-    .filter((candidate) => candidate.name === ARTIFACT_INSTANCE_NAME);
+  const artifactInstances = directCatalogItemInstances(root, ARTIFACT_INSTANCE_NAME);
 
   if (artifactInstances.length < artifacts.length) {
     throw new Error(
@@ -35,14 +34,40 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       artifact.configuredByConventionPlugins || []
     );
     const isUnused = isUnusedCatalogEntry(artifact);
+    const showConsumerModuleBlocks =
+      requiredByModules.length > 0 ||
+      providedByConventionPlugins.length > 0;
     artifactInstance.visible = true;
-    artifactInstance.setProperties({
-      [ARTIFACT_PROPS.showConsumerModules]:
-        requiredByModules.length > 0 ||
-        providedByConventionPlugins.length > 0 ||
-        configuredByConventionPlugins.length > 0 ||
-        isUnused,
-    });
+    setBooleanComponentProperty(
+      artifactInstance,
+      ARTIFACT_PROPS.showConsumerModules,
+      showConsumerModuleBlocks,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      artifactInstance,
+      ARTIFACT_PROPS.showProvidedBy,
+      providedByConventionPlugins.length > 0,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      artifactInstance,
+      ARTIFACT_PROPS.showToolArtifacts,
+      configuredByConventionPlugins.length > 0,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      artifactInstance,
+      ARTIFACT_PROPS.showRequiredBy,
+      requiredByModules.length > 0,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      artifactInstance,
+      ARTIFACT_PROPS.showUnusedCatalogEntry,
+      isUnused,
+      mutatedNodeIds
+    );
     mutatedNodeIds.push(artifactInstance.id);
     await updateUsageChipInstances(
       artifactInstance,
@@ -67,14 +92,22 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
     setUsageBlockVisible(artifactInstance, "Required by", requiredByModules.length > 0, mutatedNodeIds);
     setUsageBlockVisible(artifactInstance, "Unused catalog entry", isUnused, mutatedNodeIds);
     syncDirectUsageSeparators(artifactInstance, mutatedNodeIds);
+    assertUsageSurface(
+      artifactInstance,
+      [
+        ["Provided by", providedByConventionPlugins.length > 0],
+        ["Tool artifacts", configuredByConventionPlugins.length > 0],
+        ["Required by", requiredByModules.length > 0],
+        ["Unused catalog entry", isUnused],
+      ]
+    );
   }
 
   hideUnusedInstances(artifactInstances.slice(artifacts.length), mutatedNodeIds);
 }
 
 export async function updateLibraryBundleConsumerModules(root, bundles, mutatedNodeIds) {
-  const bundleInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
-    .filter((candidate) => candidate.name === ARTIFACTS_BUNDLE_INSTANCE_NAME);
+  const bundleInstances = directCatalogItemInstances(root, ARTIFACTS_BUNDLE_INSTANCE_NAME);
 
   if (bundleInstances.length < bundles.length) {
     throw new Error(
@@ -89,13 +122,34 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
     const requiredByModules = bundle.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(bundle.providedByConventionPlugins || []);
     const isUnused = !hasConsumerUsage(bundle);
+    const showConsumerModuleBlocks =
+      requiredByModules.length > 0 ||
+      providedByConventionPlugins.length > 0;
     bundleInstance.visible = true;
-    bundleInstance.setProperties({
-      [ARTIFACTS_BUNDLE_PROPS.showConsumerModules]:
-        requiredByModules.length > 0 ||
-        providedByConventionPlugins.length > 0 ||
-        isUnused,
-    });
+    setBooleanComponentProperty(
+      bundleInstance,
+      ARTIFACTS_BUNDLE_PROPS.showConsumerModules,
+      showConsumerModuleBlocks,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      bundleInstance,
+      ARTIFACTS_BUNDLE_PROPS.showProvidedBy,
+      providedByConventionPlugins.length > 0,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      bundleInstance,
+      ARTIFACTS_BUNDLE_PROPS.showRequiredBy,
+      requiredByModules.length > 0,
+      mutatedNodeIds
+    );
+    setBooleanComponentProperty(
+      bundleInstance,
+      ARTIFACTS_BUNDLE_PROPS.showUnusedCatalogEntry,
+      isUnused,
+      mutatedNodeIds
+    );
     mutatedNodeIds.push(bundleInstance.id);
     await updateUsageChipInstances(
       bundleInstance,
@@ -121,6 +175,15 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
       excludeArtifactDescendants: true,
     });
     syncDirectUsageSeparators(bundleInstance, mutatedNodeIds, { excludeArtifactDescendants: true });
+    assertUsageSurface(
+      bundleInstance,
+      [
+        ["Provided by", providedByConventionPlugins.length > 0],
+        ["Required by", requiredByModules.length > 0],
+        ["Unused catalog entry", isUnused],
+      ],
+      { excludeArtifactDescendants: true }
+    );
   }
 
   hideUnusedInstances(bundleInstances.slice(bundles.length), mutatedNodeIds);
@@ -249,6 +312,7 @@ function syncDirectUsageSeparators(root, mutatedNodeIds, options: ConsumerModule
   for (let index = 0; index < children.length; index += 1) {
     const child = children[index];
     if (child.name !== USAGE_SEPARATOR_FRAME_NAME) continue;
+    if (child.componentPropertyReferences?.visible) continue;
 
     const nextUsageBlock = children
       .slice(index + 1)
@@ -265,6 +329,24 @@ function syncDirectUsageSeparators(root, mutatedNodeIds, options: ConsumerModule
 
 function childrenOf(node) {
   return "children" in node ? [...node.children] : [];
+}
+
+function directCatalogItemInstances(root, instanceName) {
+  const visibleInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
+    .filter((candidate) => candidate.name === instanceName)
+    .filter((candidate) => candidate.visible !== false);
+
+  if (visibleInstances.length > 0) return visibleInstances;
+
+  const container = childrenOf(root)
+    .find((child) => child.name === "artifacts" && "children" in child);
+  const directInstances = childrenOf(container || root)
+    .filter((candidate) => candidate.type === "INSTANCE" && candidate.name === instanceName);
+
+  if (directInstances.length > 0) return directInstances;
+
+  return root.findAllWithCriteria({ types: ["INSTANCE"] })
+    .filter((candidate) => candidate.name === instanceName);
 }
 
 function isExcludedByOptions(node, root, options: ConsumerModuleOptions = {}) {
@@ -456,12 +538,48 @@ function setNodeVisible(node, visible, mutatedNodeIds) {
   mutatedNodeIds.push(node.id);
 }
 
+function setBooleanComponentProperty(instance, propertyName, value, mutatedNodeIds) {
+  const propertyKey = findComponentProperty(instance, propertyName, "BOOLEAN");
+  if (!propertyKey) {
+    throw new Error(`Node '${instance.id}' is missing boolean component property '${componentPropertyName(propertyName)}'.`);
+  }
+
+  instance.setProperties({ [propertyKey]: value });
+  const actual = instance.componentProperties?.[propertyKey]?.value;
+  if (actual !== value) {
+    throw new Error(
+      `Node '${instance.id}' did not apply '${componentPropertyName(propertyName)}=${value}'. Actual value: '${actual}'.`
+    );
+  }
+  mutatedNodeIds.push(instance.id);
+}
+
+function assertUsageSurface(instance, expectedBlocks, options: ConsumerModuleOptions = {}) {
+  for (const [heading, expectedVisible] of expectedBlocks) {
+    const usageBlock = findUsageBlock(instance, heading, options);
+    const actualVisible = usageBlock?.visible === true;
+    if (actualVisible !== expectedVisible) {
+      throw new Error(
+        `Node '${instance.id}' has '${heading}' usage block visible='${actualVisible}', expected '${expectedVisible}'.`
+      );
+    }
+  }
+}
+
 function findUsageChipProperty(moduleInstance, propertyName, propertyType) {
+  return findComponentProperty(moduleInstance, propertyName, propertyType);
+}
+
+function findComponentProperty(moduleInstance, propertyName, propertyType) {
   const properties = (moduleInstance.componentProperties || {}) as Record<string, { type: string }>;
   const propertyEntry = Object.entries(properties)
-    .find(([key, property]) => (key === propertyName || key.startsWith(`${propertyName}#`)) && property.type === propertyType);
+    .find(([key, property]) => (key === propertyName || key.startsWith(`${componentPropertyName(propertyName)}#`)) && property.type === propertyType);
 
   return propertyEntry?.[0];
+}
+
+function componentPropertyName(propertyName) {
+  return propertyName.split("#")[0];
 }
 
 function usageChipsForConventionPlugins(providedByConventionPlugins) {


### PR DESCRIPTION
## Summary
- Add granular artifact and bundle usage visibility properties so empty Provided by, Required by, Tool artifacts, and Unused catalog entry blocks stay hidden independently.
- Prefer visible representable catalog instances during sync and validate direct usage block visibility.
- Document how branch visual iteration can reuse the official TeamCity design model artifact without writing official metadata.

## Validation
- npm run build in repo/figma-design-sync/tools
- git diff --cached --check