### PR TITLE
feat(figma-design-sync): show plugin usage provenance

### DIFF
--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/catalog/ProjectCatalogTreesDataSource.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/catalog/ProjectCatalogTreesDataSource.kt
@@ -70,7 +70,8 @@ class ProjectCatalogTreesDataSource(
         when (source) {
             is ProjectCatalogTreeSource.DependenciesDslVersionAliases ->
                 dependenciesCatalogTreesReader.readPluginTreeWithVersionAliases(
-                    rootDir = File(source.rootDirPath)
+                    rootDir = File(source.rootDirPath),
+                    conventionPluginIncludedBuilds = source.conventionPluginIncludedBuilds
                 )
 
             is ProjectCatalogTreeSource.IncludedBuildSettings ->
@@ -126,5 +127,13 @@ private fun PluginCatalogNode.merge(other: PluginCatalogNode): PluginCatalogNode
     copy(
         version = version ?: other.version,
         appliedToModules = (appliedToModules + other.appliedToModules).sorted(),
+        providedByConventionPlugins = (providedByConventionPlugins + other.providedByConventionPlugins)
+            .distinct()
+            .sortedWith(
+                compareBy(
+                    PluginCatalogNode.ConventionPluginUsage::pluginId,
+                    PluginCatalogNode.ConventionPluginUsage::pluginModule
+                )
+            ),
         children = children.mergePluginNodes(other.children)
     )

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
@@ -69,11 +69,18 @@ class DependenciesCatalogTreesReader(
      * Reads a plugin tree using version aliases instead of resolved versions.
      */
     fun readPluginTreeWithVersionAliases(
-        rootDir: File
+        rootDir: File,
+        conventionPluginIncludedBuilds: List<IncludedBuildSource> = emptyList()
     ): PluginCatalogTree =
         readPluginTree(versions = CatalogVersionAliases)
             .withPluginUsages(
                 gradleCatalogUsageReader.readMainPluginUsages(rootDir)
+            )
+            .withConventionPluginUsages(
+                readConventionPluginPluginUsages(
+                    rootDir = rootDir,
+                    includedBuilds = conventionPluginIncludedBuilds
+                )
             )
 
     /**
@@ -131,6 +138,34 @@ class DependenciesCatalogTreesReader(
                     configurationUsages.toConventionPluginLibraryConfigurationUsages(
                         pluginIdsByModule = pluginIdsByModule
                     )
+            }
+    }
+
+    private fun readConventionPluginPluginUsages(
+        rootDir: File,
+        includedBuilds: List<IncludedBuildSource>
+    ): Map<String, List<PluginCatalogNode.ConventionPluginUsage>> {
+        val modulesByPluginId = gradleCatalogUsageReader.readMainAppliedLiteralPluginUsages(rootDir)
+
+        return includedBuilds
+            .filter(IncludedBuildSource::publishesConventionPlugins)
+            .fold(emptyMap<String, List<PluginCatalogNode.ConventionPluginUsage>>()) { usages, includedBuild ->
+                val includedBuildRootDir = File(includedBuild.rootDirPath)
+                val pluginUsages = gradleCatalogUsageReader.readConventionPluginUsages(
+                    rootDir = includedBuildRootDir,
+                    modulePathPrefix = includedBuild.modulePathPrefix
+                )
+                val pluginIdsByModule = gradleCatalogUsageReader.readConventionPluginIdsByModule(
+                    rootDir = includedBuildRootDir,
+                    modulePathPrefix = includedBuild.modulePathPrefix
+                )
+
+                usages.mergePluginConventionPluginUsages(
+                    pluginUsages.toConventionPluginPluginUsages(
+                        pluginIdsByModule = pluginIdsByModule,
+                        modulesByPluginId = modulesByPluginId
+                    )
+                )
             }
     }
 }
@@ -301,6 +336,57 @@ private fun PluginCatalogNode.withPluginUsages(
     )
 }
 
+private fun PluginCatalogTree.withConventionPluginUsages(
+    usages: Map<String, List<PluginCatalogNode.ConventionPluginUsage>>
+): PluginCatalogTree =
+    copy(
+        roots = roots.map { node -> node.withConventionPluginUsages(usages) }
+    )
+
+private fun PluginCatalogNode.withConventionPluginUsages(
+    usages: Map<String, List<PluginCatalogNode.ConventionPluginUsage>>,
+    parentId: String = ""
+): PluginCatalogNode {
+    val pluginId = listOf(parentId, id)
+        .filter(String::isNotBlank)
+        .joinToString(".")
+
+    return copy(
+        providedByConventionPlugins = usages[pluginId].orEmpty(),
+        children = children.map { child -> child.withConventionPluginUsages(usages, pluginId) }
+    )
+}
+
+private fun Map<String, Set<String>>.toConventionPluginPluginUsages(
+    pluginIdsByModule: Map<String, Set<String>>,
+    modulesByPluginId: Map<String, Set<String>>
+): Map<String, List<PluginCatalogNode.ConventionPluginUsage>> =
+    mapValues { (_, pluginModules) ->
+        pluginModules
+            .flatMap { pluginModule ->
+                pluginIdsByModule[pluginModule].orEmpty().mapNotNull { pluginId ->
+                    val requiredByModules = modulesByPluginId[pluginId].orEmpty().sorted()
+                    if (requiredByModules.isEmpty()) {
+                        null
+                    } else {
+                        PluginCatalogNode.ConventionPluginUsage(
+                            pluginId = pluginId,
+                            pluginModule = pluginModule,
+                            requiredByModules = requiredByModules
+                        )
+                    }
+                }
+            }
+            .distinct()
+            .sortedWith(
+                compareBy(
+                    PluginCatalogNode.ConventionPluginUsage::pluginId,
+                    PluginCatalogNode.ConventionPluginUsage::pluginModule
+                )
+            )
+    }
+        .filterValues(List<PluginCatalogNode.ConventionPluginUsage>::isNotEmpty)
+
 private fun Map<String, Set<String>>.merge(other: Map<String, Set<String>>): Map<String, Set<String>> =
     (keys + other.keys).associateWith { key ->
         (this[key].orEmpty() + other[key].orEmpty()).toSortedSet()
@@ -364,6 +450,20 @@ private fun Map<String, List<ConventionPluginUsage>>.mergeConventionPluginUsages
         (this[key].orEmpty() + other[key].orEmpty())
             .distinct()
             .sortedWith(compareBy(ConventionPluginUsage::pluginId, ConventionPluginUsage::pluginModule))
+    }
+
+private fun Map<String, List<PluginCatalogNode.ConventionPluginUsage>>.mergePluginConventionPluginUsages(
+    other: Map<String, List<PluginCatalogNode.ConventionPluginUsage>>
+): Map<String, List<PluginCatalogNode.ConventionPluginUsage>> =
+    (keys + other.keys).associateWith { key ->
+        (this[key].orEmpty() + other[key].orEmpty())
+            .distinct()
+            .sortedWith(
+                compareBy(
+                    PluginCatalogNode.ConventionPluginUsage::pluginId,
+                    PluginCatalogNode.ConventionPluginUsage::pluginModule
+                )
+            )
     }
 
 private fun Map<String, List<ConventionPluginConfigurationUsage>>.mergeConventionPluginConfigurationUsages(

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReaderTest.kt
@@ -389,6 +389,114 @@ internal class DependenciesCatalogTreesReaderTest : FunSpec({
         actualTree.findPlugin("com.android.library").appliedToModules shouldBe listOf(":core:ui")
         actualTree.findPlugin("org.jetbrains.dokka").appliedToModules shouldBe emptyList()
     }
+
+    test("readPluginTreeWithVersionAliases maps convention plugin providers to main build modules") {
+        // GIVEN
+        val rootDir = Files.createTempDirectory("water-my-plants-convention-plugin-usages").toFile()
+        rootDir.writeBuildFile(
+            path = "app",
+            content = """
+            plugins {
+                id("com.marmatsan.compose")
+            }
+            """.trimIndent()
+        )
+        rootDir.writeBuildFile(
+            path = "core/ui",
+            content = """
+            plugins {
+                id("com.marmatsan.compose")
+            }
+            """.trimIndent()
+        )
+        rootDir.writeBuildFile(
+            path = "onboarding/ui",
+            content = """
+            plugins {
+                id("com.marmatsan.android")
+            }
+            """.trimIndent()
+        )
+        val includedBuildRootDir = rootDir.resolve("repo/gradle-plugins")
+        includedBuildRootDir.writeBuildFile(
+            path = "compose",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.compose"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.compose.plugin.ComposeGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeKotlinFile(
+            path = "compose/src/main/kotlin/com/marmatsan/compose/plugin",
+            fileName = "ComposeGradleConventionPlugin.kt",
+            content = """
+            package com.marmatsan.compose.plugin
+
+            fun configure(project: Project) {
+                project.pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeBuildFile(
+            path = "android",
+            content = """
+            gradlePlugin {
+                val pluginName = "com.marmatsan.android"
+                plugins.register(pluginName) {
+                    id = pluginName
+                    implementationClass = "com.marmatsan.android.plugin.AndroidGradleConventionPlugin"
+                }
+            }
+            """.trimIndent()
+        )
+        includedBuildRootDir.writeKotlinFile(
+            path = "android/src/main/kotlin/com/marmatsan/android/plugin",
+            fileName = "AndroidGradleConventionPlugin.kt",
+            content = """
+            package com.marmatsan.android.plugin
+
+            fun configure(project: Project) {
+                project.pluginManager.apply("com.google.devtools.ksp")
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val actualTree = dependenciesCatalogTreesReader().readPluginTreeWithVersionAliases(
+            rootDir = rootDir,
+            conventionPluginIncludedBuilds = listOf(
+                IncludedBuildSource(
+                    settingsFilePath = includedBuildRootDir.resolve("settings.gradle.kts").absolutePath,
+                    rootDirPath = includedBuildRootDir.absolutePath,
+                    modulePathPrefix = ":gradle-plugins",
+                    publishesConventionPlugins = true
+                )
+            )
+        )
+
+        // THEN
+        actualTree.findPlugin("org.jetbrains.kotlin.plugin.compose")
+            .providedByConventionPlugins shouldBe listOf(
+            PluginCatalogNode.ConventionPluginUsage(
+                pluginId = "com.marmatsan.compose",
+                pluginModule = ":gradle-plugins:compose",
+                requiredByModules = listOf(":app", ":core:ui")
+            )
+        )
+        actualTree.findPlugin("com.google.devtools.ksp")
+            .providedByConventionPlugins shouldBe listOf(
+            PluginCatalogNode.ConventionPluginUsage(
+                pluginId = "com.marmatsan.android",
+                pluginModule = ":gradle-plugins:android",
+                requiredByModules = listOf(":onboarding:ui")
+            )
+        )
+        actualTree.findPlugin("org.jetbrains.dokka").providedByConventionPlugins shouldBe emptyList()
+    }
 })
 
 private fun dependenciesCatalogTreesReader() =

--- a/repo/figma-design-sync/docs/bdd/README.md
+++ b/repo/figma-design-sync/docs/bdd/README.md
@@ -128,7 +128,7 @@ The contract has one main output:
 |----------------------|--------------------------------------------------------------------------------------------------------------|
 | `versions`           | Sorted flat map of version keys to repository values, used for deterministic comparison.                     |
 | `versionSections`    | Ordered version groups from `repo/dependency-catalog/versions.properties`, used to preserve the source section layout.   |
-| `catalogs`           | Dependency and plugin trees for Water My Plants, configured included builds, custom Gradle convention plugins, and plugins. |
+| `catalogs`           | Dependency and plugin trees for Water My Plants, configured included builds, custom Gradle convention plugins, and plugins, including direct and convention-plugin-provided usage metadata. |
 | `modules`            | Sorted Gradle module paths discovered from root and configured included-build settings files.                            |
 | `moduleDependencies` | Main and configured included-build module dependency edges, grouped by graph scope.                                      |
 

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -77,13 +77,16 @@ expected 0 'artifact name' text nodes, found 8
 ## Usage Blocks Hidden Despite Model Data
 
 The official `design-model.json` can be correct while the visible Figma
-`.artifact` instance is still visually stale. The observed failure mode was a
-library artifact whose model contained `providedByConventionPlugins` and
-effective `requiredByModules`, while the visible `.artifact` kept
-`Show consumer modules=false` and its direct `Provided by` / `Required by`
-blocks hidden. Hidden template internals under the same `.tree node` still
-contained chips, which made the file look partially updated through the plugin
-API but not visually updated on canvas.
+`.artifact` or `.tree node` instance is still visually stale. One observed
+failure mode was a library artifact whose model contained
+`providedByConventionPlugins` and effective `requiredByModules`, while the
+visible `.artifact` kept `Show consumer modules=false` and its direct
+`Provided by` / `Required by` blocks hidden. The equivalent plugin failure is a
+`Plugin` `.tree node` whose model contains `appliedToModules` or
+`providedByConventionPlugins`, while `Applied by` / `Provided by` stay hidden or
+an empty `Unused catalog entry` block remains visible. Hidden template internals
+under the same `.tree node` can still contain chips, which makes the file look
+partially updated through the plugin API but not visually updated on canvas.
 
 Diagnose this as a visual sync inconsistency before changing catalog
 extraction:
@@ -98,6 +101,10 @@ extraction:
   `Show required by`, `Show tool artifacts` when present, and
   `Show unused catalog entry`. `Show consumer modules` is not enough to validate
   the surface because it can show both `Provided by` and `Required by`.
+- For plugin trees, confirm the visible `Plugin` `.tree node` has the granular
+  component booleans expected by the model: `Show applied by`,
+  `Show provided by`, and `Show unused catalog entry`. `Show consumer module` is
+  only a compatibility aggregate and is not enough to validate the surface.
 
 The TypeScript sync must fail the visual target before metadata if this
 invariant is not true. Do not repair this with a metadata-only write.

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -150,6 +150,11 @@ Important generation details:
 - Water My Plants library entries include `providedByConventionPlugins`. Each
   item records the convention plugin id, the Gradle module that implements it,
   and the production modules that receive the dependency through that plugin.
+- Water My Plants plugin entries include `providedByConventionPlugins` when a
+  convention plugin applies a catalog plugin and production modules apply that
+  convention plugin. Direct plugin applications remain in `appliedToModules`;
+  the visual `Applied by` row combines direct modules with the modules listed in
+  each `providedByConventionPlugins.requiredByModules` entry.
 - `dependencyCatalog` contributes modules and module dependencies but not
   `content.catalogs.dependencyCatalog` because
   `repo/dependency-catalog/settings.gradle.kts` does not declare

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -99,6 +99,10 @@ For each section:
 - Library artifacts and bundles may also carry `providedByConventionPlugins`.
   Each usage has `pluginId`, `pluginModule`, and `requiredByModules`; it is the
   model source for `Provided by` `.usage chip kind=convention-plugin` rows.
+- Plugin catalog entries may also carry `providedByConventionPlugins`. Each
+  usage has `pluginId`, `pluginModule`, and `requiredByModules`; it is the
+  model source for `Provided by` `.usage chip kind=convention-plugin` rows on
+  the `Plugin` `.tree node` variant.
 - Library artifacts may also carry `configuredByConventionPlugins`. Each usage
   has `pluginId`, `pluginModule`, and `target`; it means the convention plugin
   uses the artifact as build tooling configuration, not that it provides the
@@ -123,7 +127,16 @@ For each section:
   `providedByConventionPlugins.requiredByModules` entry. Child `.artifact`
   instances inside a bundle must not show their own `Required by` section.
 - Update `Applied by` module instances for plugin tree nodes from
-  `appliedToModules`.
+  `appliedToModules` plus the modules listed by each
+  `providedByConventionPlugins.requiredByModules` entry.
+- For plugin tree nodes, hide `Applied by` and `Provided by` when their source
+  lists are empty. When a plugin catalog entry has no `appliedToModules` and no
+  `providedByConventionPlugins`, show `Unused catalog entry` instead of empty
+  usage blocks.
+- Control plugin usage blocks through their own component boolean on `.tree
+  node` `Plugin`: `Show applied by`, `Show provided by`, and
+  `Show unused catalog entry`. Keep `Show consumer module` only as a
+  backwards-compatible aggregate for plugin usage rows.
 - Represent usage metadata with `.usage chip` instances.
 - `.usage chip` exposes only two `kind` variants: `module` for modules that
   require or apply an item, and `convention-plugin` for Gradle convention
@@ -148,6 +161,12 @@ Use `.tree node` component:
   `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=63069-678`
 - Use the `Library` variant for libraries.
 - Use the `Plugin` variant for plugins.
+- The `Plugin` variant exposes granular usage booleans: `Show applied by`,
+  `Show provided by`, and `Show unused catalog entry`.
+- The `Plugin` variant keeps `Show consumer module` as an aggregate compatibility
+  switch only; visual correctness comes from the granular booleans and the
+  direct `Applied by`, `Provided by`, and `Unused catalog entry` block
+  visibility.
 - The plugin component property for marking repository Gradle plugin nodes is
   `Show is a gradle plugin#63112:4`.
 - The older property name

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/catalog/PluginCatalogNode.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/catalog/PluginCatalogNode.kt
@@ -4,8 +4,10 @@ package com.marmatsan.figmaDesignSync.domain.model.catalog
  * Node in the plugin catalog tree rendered in Figma.
  *
  * The [id] is one segment or full path of a Gradle plugin id. [version] is
- * present only where the catalog source declares it, and [appliedToModules]
- * records the modules that use the plugin so Figma can show usage context.
+ * present only where the catalog source declares it, [appliedToModules]
+ * records modules that apply the plugin directly, and
+ * [providedByConventionPlugins] records convention plugins that apply it
+ * indirectly to production modules.
  *
  * Example:
  * ```
@@ -19,11 +21,29 @@ package com.marmatsan.figmaDesignSync.domain.model.catalog
  * @property id Plugin id segment or full plugin id represented by this node.
  * @property version Version metadata declared for the plugin, if any.
  * @property appliedToModules Sorted Gradle module paths applying this plugin.
+ * @property providedByConventionPlugins Gradle convention plugins that apply
+ * this plugin to production modules.
  * @property children Nested plugin-id segments.
  */
 data class PluginCatalogNode(
     val id: String,
     val version: CatalogVersion? = null,
     val appliedToModules: List<String> = emptyList(),
+    val providedByConventionPlugins: List<ConventionPluginUsage> = emptyList(),
     val children: List<PluginCatalogNode> = emptyList()
-)
+) {
+    /**
+     * Gradle convention plugin that applies this plugin to production modules.
+     *
+     * @property pluginId Gradle plugin id applied by production modules.
+     * @property pluginModule Gradle module path that implements the convention
+     * plugin.
+     * @property requiredByModules Sorted production module paths that receive
+     * this plugin through the convention plugin.
+     */
+    data class ConventionPluginUsage(
+        val pluginId: String,
+        val pluginModule: String,
+        val requiredByModules: List<String> = emptyList()
+    )
+}

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
@@ -156,6 +156,7 @@ private fun PluginCatalogNode.toDesignJson(): JsonObject =
         put("id", id)
         put("version", version?.toDesignJson() ?: JsonNull)
         put("appliedToModules", appliedToModules.toSortedJsonArray())
+        put("providedByConventionPlugins", providedByConventionPlugins.toPluginConventionUsageDesignJson())
         put(
             "children",
             children
@@ -164,6 +165,22 @@ private fun PluginCatalogNode.toDesignJson(): JsonObject =
                 .let(::JsonArray)
         )
     }
+
+private fun List<PluginCatalogNode.ConventionPluginUsage>.toPluginConventionUsageDesignJson(): JsonArray =
+    sortedWith(
+        compareBy<PluginCatalogNode.ConventionPluginUsage>(
+            { usage -> usage.pluginId },
+            { usage -> usage.pluginModule }
+        )
+    )
+        .map { usage ->
+            buildJsonObject {
+                put("pluginId", usage.pluginId)
+                put("pluginModule", usage.pluginModule)
+                put("requiredByModules", usage.requiredByModules.toSortedJsonArray())
+            }
+        }
+        .let(::JsonArray)
 
 private fun CatalogVersion.toDesignJson(): JsonObject =
     buildJsonObject {

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -170,6 +170,43 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
             )
         )
     }
+
+    test("generate writes convention plugin provenance for plugins") {
+        // GIVEN
+        val generator = generator()
+
+        // WHEN
+        val result = generator.generate(request())
+
+        // THEN
+        val usages = result.model["content"]
+            ?.jsonObject
+            ?.get("catalogs")
+            ?.jsonObject
+            ?.get("waterMyPlants")
+            ?.jsonObject
+            ?.get("plugins")
+            ?.jsonArray
+            ?.single()
+            ?.jsonObject
+            ?.get("providedByConventionPlugins")
+            ?.jsonArray
+
+        usages?.map { usage ->
+            val usageObject = usage.jsonObject
+            Triple(
+                usageObject["pluginId"]?.jsonPrimitive?.content,
+                usageObject["pluginModule"]?.jsonPrimitive?.content,
+                usageObject["requiredByModules"]?.jsonArray?.map { module -> module.jsonPrimitive.content }
+            )
+        } shouldBe listOf(
+            Triple(
+                "com.marmatsan.compose",
+                ":gradle-plugins:compose",
+                listOf(":app", ":core:ui")
+            )
+        )
+    }
 })
 
 private fun generator(): FigmaDesignModelGenerator =
@@ -278,7 +315,14 @@ private object FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
                 PluginCatalogNode(
                     id = "org.jetbrains.kotlin.android",
                     version = CatalogVersion("2.4.0"),
-                    appliedToModules = listOf(":app")
+                    appliedToModules = listOf(":app"),
+                    providedByConventionPlugins = listOf(
+                        PluginCatalogNode.ConventionPluginUsage(
+                            pluginId = "com.marmatsan.compose",
+                            pluginModule = ":gradle-plugins:compose",
+                            requiredByModules = listOf(":core:ui", ":app")
+                        )
+                    )
                 )
             )
         )

--- a/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
@@ -83,6 +83,7 @@
               "value": null
             },
             "appliedToModules": [],
+            "providedByConventionPlugins": [],
             "children": [
               {
                 "id": "marmatsan",
@@ -91,6 +92,7 @@
                   "value": null
                 },
                 "appliedToModules": [],
+                "providedByConventionPlugins": [],
                 "children": [
                   {
                     "id": "android",
@@ -102,6 +104,7 @@
                       ":app",
                       ":core:ui"
                     ],
+                    "providedByConventionPlugins": [],
                     "children": []
                   }
                 ]
@@ -120,6 +123,7 @@
               ":app",
               ":onboarding:presentation"
             ],
+            "providedByConventionPlugins": [],
             "children": []
           }
         ],
@@ -133,6 +137,7 @@
             "appliedToModules": [
               ":"
             ],
+            "providedByConventionPlugins": [],
             "children": []
           }
         ]
@@ -167,6 +172,7 @@
               "value": null
             },
             "appliedToModules": [],
+            "providedByConventionPlugins": [],
             "children": [
               {
                 "id": "jetbrains",
@@ -175,6 +181,7 @@
                   "value": null
                 },
                 "appliedToModules": [],
+                "providedByConventionPlugins": [],
                 "children": [
                   {
                     "id": "dokka",
@@ -185,6 +192,7 @@
                     "appliedToModules": [
                       ":gradle-plugins:dokka-documentation"
                     ],
+                    "providedByConventionPlugins": [],
                     "children": []
                   }
                 ]
@@ -223,6 +231,7 @@
               "value": null
             },
             "appliedToModules": [],
+            "providedByConventionPlugins": [],
             "children": [
               {
                 "id": "google",
@@ -231,6 +240,7 @@
                   "value": null
                 },
                 "appliedToModules": [],
+                "providedByConventionPlugins": [],
                 "children": [
                   {
                     "id": "devtools",
@@ -239,6 +249,7 @@
                       "value": null
                     },
                     "appliedToModules": [],
+                    "providedByConventionPlugins": [],
                     "children": [
                       {
                         "id": "ksp",
@@ -249,6 +260,7 @@
                         "appliedToModules": [
                           ":figma-design-sync:plugin"
                         ],
+                        "providedByConventionPlugins": [],
                         "children": []
                       }
                     ]

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -45,6 +45,9 @@ export const TREE_NODE_PROPS = {
   showArtifacts: "Show artifacts#63079:0",
   pluginVersion: "Plugin version#63081:2",
   showConsumerModule: "Show consumer module#63085:0",
+  showAppliedBy: "Show applied by",
+  showProvidedBy: "Show provided by",
+  showUnusedCatalogEntry: "Show unused catalog entry",
   showIsGradleConventionPlugin: "Show is a gradle plugin#63112:4",
   type: "Type",
 };

--- a/repo/figma-design-sync/tools/src/domain/catalog/flatten-catalog-nodes.ts
+++ b/repo/figma-design-sync/tools/src/domain/catalog/flatten-catalog-nodes.ts
@@ -25,6 +25,7 @@ export function flattenCatalogNodes(
           path,
           version: node.version,
           appliedToModules: node.appliedToModules || [],
+          providedByConventionPlugins: node.providedByConventionPlugins || [],
           children: node.children || [],
         };
 

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -3,6 +3,7 @@ import {
   ARTIFACTS_BUNDLE_INSTANCE_NAME,
   ARTIFACTS_BUNDLE_PROPS,
   ARTIFACT_PROPS,
+  TREE_NODE_PROPS,
   USAGE_CHIP_COMPONENT_SET_ID,
   USAGE_CHIP_INSTANCE_NAME,
   USAGE_CHIP_KINDS,
@@ -205,6 +206,68 @@ export async function updateConsumerModuleInstances(
     })),
     mutatedNodeIds,
     options
+  );
+}
+
+export async function updatePluginUsageBlocks(
+  root,
+  appliedToModules,
+  providedByConventionPlugins,
+  isUnused,
+  mutatedNodeIds
+) {
+  const providedByConventionPluginChips = usageChipsForConventionPlugins(providedByConventionPlugins || []);
+  const showAppliedBy = appliedToModules.length > 0;
+  const showProvidedBy = providedByConventionPluginChips.length > 0;
+
+  setBooleanComponentProperty(
+    root,
+    TREE_NODE_PROPS.showConsumerModule,
+    showAppliedBy || showProvidedBy,
+    mutatedNodeIds
+  );
+  setBooleanComponentProperty(
+    root,
+    TREE_NODE_PROPS.showAppliedBy,
+    showAppliedBy,
+    mutatedNodeIds
+  );
+  setBooleanComponentProperty(
+    root,
+    TREE_NODE_PROPS.showProvidedBy,
+    showProvidedBy,
+    mutatedNodeIds
+  );
+  setBooleanComponentProperty(
+    root,
+    TREE_NODE_PROPS.showUnusedCatalogEntry,
+    isUnused,
+    mutatedNodeIds
+  );
+
+  await updateUsageChipInstances(
+    root,
+    "Provided by",
+    providedByConventionPluginChips,
+    mutatedNodeIds
+  );
+  setUsageBlockVisible(root, "Provided by", showProvidedBy, mutatedNodeIds);
+  await updateConsumerModuleInstances(
+    root,
+    "Applied by",
+    appliedToModules,
+    mutatedNodeIds
+  );
+  setUsageBlockVisible(root, "Applied by", showAppliedBy, mutatedNodeIds);
+  setUsageBlockVisible(root, "Unused catalog entry", isUnused, mutatedNodeIds);
+  syncDirectUsageSeparators(root, mutatedNodeIds);
+  assertUsageSurface(
+    root,
+    [
+      ["Provided by", showProvidedBy],
+      ["Applied by", showAppliedBy],
+      ["Unused catalog entry", isUnused],
+    ]
   );
 }
 
@@ -616,12 +679,14 @@ const USAGE_SEPARATOR_FRAME_NAME = "usage separator";
 const USAGE_BLOCK_HEADINGS = [
   "Provided by",
   "Required by",
+  "Applied by",
   "Tool artifacts",
   "Unused catalog entry",
 ];
 const USAGE_BLOCK_FRAME_NAMES = new Set([
   "provided by",
   "required by",
+  "applied by",
   "tool artifacts",
   "unused catalog entry",
 ]);

--- a/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -2,7 +2,7 @@ import {
   TREE_NODE_COMPONENT_IDS,
   TREE_NODE_PROPS,
 } from "../config/figma-config";
-import { updateConsumerModuleInstances, updateLibraryArtifactConsumerModules, updateLibraryBundleConsumerModules } from "./figma-consumer-modules-gateway";
+import { updateLibraryArtifactConsumerModules, updateLibraryBundleConsumerModules, updatePluginUsageBlocks } from "./figma-consumer-modules-gateway";
 import type { FlattenedCatalogNode } from "../domain/design-model";
 import { getComponentPropertyValue, requireTreeNodeComponent } from "./figma-node-gateway";
 import {
@@ -105,27 +105,50 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     ? node.version.value
     : "Plugin version";
   const appliedToModules = sortedUnique(node.appliedToModules || []);
+  const providedByConventionPlugins = node.providedByConventionPlugins || [];
+  const effectiveAppliedToModules = sortedUnique([
+    ...appliedToModules,
+    ...providedByConventionPlugins.flatMap((usage) => usage.requiredByModules || []),
+  ]);
+  const isUnusedCatalogEntry = isPluginCatalogEntry(node) &&
+    effectiveAppliedToModules.length === 0 &&
+    providedByConventionPlugins.length === 0;
   const isGradleConventionPlugin = target?.gradleConventionPluginNodes === true && node.children.length === 0;
 
   instance.setProperties({
     [TREE_NODE_PROPS.pluginId]: node.label,
     [TREE_NODE_PROPS.pluginVersion]: versionValue,
     [TREE_NODE_PROPS.showPluginVersion]: node.version?.visible === true && Boolean(node.version?.value),
-    [TREE_NODE_PROPS.showConsumerModule]: appliedToModules.length > 0,
+    [TREE_NODE_PROPS.showConsumerModule]: effectiveAppliedToModules.length > 0 || providedByConventionPlugins.length > 0,
     [TREE_NODE_PROPS.showIsGradleConventionPlugin]: isGradleConventionPlugin,
     [TREE_NODE_PROPS.type]: "Plugin",
   });
   mutatedNodeIds.push(instance.id);
 
-  await updateConsumerModuleInstances(instance, "Applied by", appliedToModules, mutatedNodeIds);
+  await updatePluginUsageBlocks(
+    instance,
+    effectiveAppliedToModules,
+    providedByConventionPlugins,
+    isUnusedCatalogEntry,
+    mutatedNodeIds
+  );
 
-  if (appliedToModules.length === 0 && !isGradleConventionPlugin && !hasVisiblePluginVersion(node)) {
+  if (effectiveAppliedToModules.length === 0 &&
+    providedByConventionPlugins.length === 0 &&
+    !isUnusedCatalogEntry &&
+    !isGradleConventionPlugin &&
+    !hasVisiblePluginVersion(node)
+  ) {
     resizeBareTreeNodeToFitLabel(instance, "Plugin ID", mutatedNodeIds);
   }
 }
 
 function hasVisiblePluginVersion(node: FlattenedCatalogNode) {
   return node.version?.visible === true && Boolean(node.version?.value);
+}
+
+function isPluginCatalogEntry(node: FlattenedCatalogNode) {
+  return node.version !== null && node.version !== undefined;
 }
 
 function resizeBareTreeNodeToFitLabel(instance, labelName, mutatedNodeIds) {


### PR DESCRIPTION
Adds plugin catalog provenance for convention-plugin-provided usage and updates Figma plugin tree rendering/docs. Verification: targeted figma-design-sync Gradle tests and npm run build.