### PR TITLE
fix(figma-design-sync): pass convention builds to plugin catalog

### DIFF
--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
@@ -115,7 +115,8 @@ internal class FigmaDesignModelGenerator(
                         projectCatalogTreesPort
                             .readPluginTree(
                                 ProjectCatalogTreeSource.DependenciesDslVersionAliases(
-                                    rootDirPath = request.projectRootDirectory.absolutePath
+                                    rootDirPath = request.projectRootDirectory.absolutePath,
+                                    conventionPluginIncludedBuilds = conventionPluginIncludedBuilds
                                 )
                             )
                             .toDesignJson()

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -309,23 +309,33 @@ private object FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
         )
     }
 
-    override fun readPluginTree(source: ProjectCatalogTreeSource): PluginCatalogTree =
-        PluginCatalogTree(
+    override fun readPluginTree(source: ProjectCatalogTreeSource): PluginCatalogTree {
+        val conventionPluginUsages = if (
+            source is ProjectCatalogTreeSource.DependenciesDslVersionAliases &&
+            source.conventionPluginIncludedBuilds.any { includedBuild -> includedBuild.modulePathPrefix == ":gradle-plugins" }
+        ) {
+            listOf(
+                PluginCatalogNode.ConventionPluginUsage(
+                    pluginId = "com.marmatsan.compose",
+                    pluginModule = ":gradle-plugins:compose",
+                    requiredByModules = listOf(":core:ui", ":app")
+                )
+            )
+        } else {
+            emptyList()
+        }
+
+        return PluginCatalogTree(
             roots = listOf(
                 PluginCatalogNode(
                     id = "org.jetbrains.kotlin.android",
                     version = CatalogVersion("2.4.0"),
                     appliedToModules = listOf(":app"),
-                    providedByConventionPlugins = listOf(
-                        PluginCatalogNode.ConventionPluginUsage(
-                            pluginId = "com.marmatsan.compose",
-                            pluginModule = ":gradle-plugins:compose",
-                            requiredByModules = listOf(":core:ui", ":app")
-                        )
-                    )
+                    providedByConventionPlugins = conventionPluginUsages
                 )
             )
         )
+    }
 }
 
 private object FakeProjectModulesPort : ProjectModulesPort {


### PR DESCRIPTION
Pass convention-plugin included builds into Water My Plants plugin catalog generation so plugin providedByConventionPlugins is populated in the official design model. Verification: .\\gradlew.bat :figma-design-sync:plugin:test --tests "*FigmaDesignModelGeneratorTest".