### PR TITLE
fix(figma-design-sync): enforce catalog usage surfaces

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -27,9 +27,45 @@ characters. The plugin runtime supports `atob`, `btoa`, and `Function`, but it
 does not provide browser or Node transfer helpers such as `fetch`,
 `XMLHttpRequest`, `importScripts`, `TextDecoder`, `Blob`, `Response`, or
 `DecompressionStream`.
+Do not try to work around this with a local HTTP payload server; `fetch` is not
+defined in the Figma MCP `use_figma` runtime, so Figma cannot download the
+TeamCity artifact from `127.0.0.1`.
 
 If a payload is truncated, fail before mutating Figma. One failed sync attempt
 had expected encoded length `45228`, but only `44624` characters reached Figma.
+
+If a target runner appears to complete without visual changes, inspect staging
+before debugging the catalog model. An empty staging value means the runner had
+no official payload to apply:
+
+```javascript
+const page = await figma.getNodeByIdAsync("62934:908");
+
+if (!page || page.type !== "PAGE") {
+  throw new Error("Expected sync page 62934:908 to be a PAGE");
+}
+
+await figma.setCurrentPageAsync(page);
+
+return {
+  designModelJsonLength: page.getSharedPluginData(
+    "water_my_plants_sync_staging",
+    "designModelJson"
+  ).length,
+  scriptBase64Length: page.getSharedPluginData(
+    "water_my_plants_sync_staging",
+    "scriptBase64"
+  ).length
+};
+```
+
+`designModelJsonLength: 0` after `00-clear-staging.mcp.js` usually means a
+large chunk call never reached Figma. Regenerate the runner with a smaller
+chunk size and rerun the files in lexical order:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --chunk-size=8000
+```
 
 For larger payloads, stage base64 chunks in temporary shared plugin data:
 
@@ -60,6 +96,20 @@ Catalog preview uses the smaller `sync-catalog-tree-preview.mcp.js` entrypoint
 by default so connector and layout fixes can be tested without transporting the
 full trunk-sync bundle.
 
+## Figma REST Read Flakes
+
+`checkFigmaTrunkSync` can fail because the Figma REST API closes the connection
+while the task is reading metadata:
+
+```text
+java.io.EOFException: Failed to parse HTTP response: the server prematurely closed the connection
+```
+
+Treat this as a transport failure, not as proof that Figma metadata is stale. If
+a direct Figma MCP read shows `water_my_plants_sync.modelHash` and `gitSha`
+match the TeamCity artifact, rerun `checkFigmaTrunkSync` once before changing
+the model, the metadata, or the visual sync code.
+
 ## Component Instance Shape
 
 Figma component instances can contain hidden template internals that remain
@@ -87,6 +137,10 @@ visible `.artifact` kept `Show consumer modules=false` and its direct
 an empty `Unused catalog entry` block remains visible. Hidden template internals
 under the same `.tree node` can still contain chips, which makes the file look
 partially updated through the plugin API but not visually updated on canvas.
+`Unused catalog entry` is a static status block, not usage metadata. The
+`.tree node` `Plugin` variant must not contain `.usage chip` instances inside
+that block; if one appears there, repair the component contract before changing
+catalog extraction.
 
 Diagnose this as a visual sync inconsistency before changing catalog
 extraction:

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -202,6 +202,13 @@ To generate chunked MCP runner snippets for an official TeamCity artifact:
 node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
 ```
 
+If a generated runner file is too large for the MCP transport, reduce the chunk
+size instead of copying the long payload manually:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --chunk-size=8000
+```
+
 Use [visual-preview.md](visual-preview.md) instead when testing fixture-driven
 visual changes before the change reaches `main`.
 
@@ -260,6 +267,35 @@ encoded length before assembling the final `scriptBase64` value.
 The runtime supports `atob`, `btoa`, and `Function`, but not browser or Node
 transfer helpers such as `fetch`, `XMLHttpRequest`, `importScripts`,
 `TextDecoder`, `Blob`, `Response`, or `DecompressionStream`.
+That means a local HTTP payload server is not a valid shortcut for loading the
+TeamCity artifact into `use_figma`; the payload must be staged through Figma
+shared plugin data.
+
+Before diagnosing a visual no-op as a model or component bug, confirm that the
+official payload was actually staged. A common interrupted-sync symptom is
+`designModelJson.length = 0` in `water_my_plants_sync_staging`, which means
+`99-run-target.mcp.js` has no model to apply:
+
+```javascript
+const page = await figma.getNodeByIdAsync("62934:908");
+
+if (!page || page.type !== "PAGE") {
+  throw new Error("Expected sync page 62934:908 to be a PAGE");
+}
+
+await figma.setCurrentPageAsync(page);
+
+return {
+  designModelJsonLength: page.getSharedPluginData(
+    "water_my_plants_sync_staging",
+    "designModelJson"
+  ).length,
+  scriptBase64Length: page.getSharedPluginData(
+    "water_my_plants_sync_staging",
+    "scriptBase64"
+  ).length
+};
+```
 
 Run visual updates by granular target. Do not run `metadata` until every visual
 target has completed successfully.

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -110,6 +110,10 @@ For each section:
 - Hide `Provided by`, `Required by`, and `Tool artifacts` blocks when their
   source lists are empty. Do not render empty headings or empty chip
   containers.
+- Keep structural `separator` frames inside `.artifact` and `.artifacts bundle`
+  visible. Only `usage separator` frames, or separators bound to a usage
+  boolean through `componentPropertyReferences.visible`, are conditional on
+  usage content.
 - Control each usage block through its own component boolean on `.artifact` and
   `.artifacts bundle`: `Show provided by`, `Show required by`,
   `Show tool artifacts` where the component supports tooling rows, and
@@ -137,13 +141,22 @@ For each section:
   node` `Plugin`: `Show applied by`, `Show provided by`, and
   `Show unused catalog entry`. Keep `Show consumer module` only as a
   backwards-compatible aggregate for plugin usage rows.
-- Represent usage metadata with `.usage chip` instances.
+- Parent components must expose every usage section in their template. The sync
+  decides visibility on each generated instance from the model data by setting
+  the granular boolean and the direct block visibility for that section.
+- Represent usage metadata with `.usage chip` instances. `Unused catalog entry`
+  is not usage metadata and must not be rendered as a `.usage chip`.
 - `.usage chip` exposes only two `kind` variants: `module` for modules that
   require or apply an item, and `convention-plugin` for Gradle convention
   plugins that provide dependencies to production modules or configure tooling
   artifacts.
 - `.usage chip` exposes `name` as a text component property bound to the label.
   Do not add a variant for every module, plugin, artifact, or dependency name.
+- Render `Unused catalog entry` as a static status block matching `.artifact`
+  and `.artifacts bundle`: the container fill is
+  `md/sys/color/error-container`, the label fill is
+  `md/sys/color/on-error-container`. The `.tree node` `Plugin` variant must
+  not contain `.usage chip` instances inside that block.
 - Create missing `.tree node` instances by cloning a compatible existing node
   from the same visual section, then applying generated model values.
 - Create missing top-level tree sections when a new top-level library group or

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -39,6 +39,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       requiredByModules.length > 0 ||
       providedByConventionPlugins.length > 0;
     artifactInstance.visible = true;
+    syncStructuralSeparators(artifactInstance, mutatedNodeIds);
     setBooleanComponentProperty(
       artifactInstance,
       ARTIFACT_PROPS.showConsumerModules,
@@ -127,6 +128,7 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
       requiredByModules.length > 0 ||
       providedByConventionPlugins.length > 0;
     bundleInstance.visible = true;
+    syncStructuralSeparators(bundleInstance, mutatedNodeIds);
     setBooleanComponentProperty(
       bundleInstance,
       ARTIFACTS_BUNDLE_PROPS.showConsumerModules,
@@ -390,6 +392,15 @@ function syncDirectUsageSeparators(root, mutatedNodeIds, options: ConsumerModule
   }
 }
 
+function syncStructuralSeparators(root, mutatedNodeIds) {
+  for (const child of childrenOf(root)) {
+    if (child.name !== STRUCTURAL_SEPARATOR_FRAME_NAME) continue;
+    if (child.componentPropertyReferences?.visible) continue;
+
+    setNodeVisible(child, true, mutatedNodeIds);
+  }
+}
+
 function childrenOf(node) {
   return "children" in node ? [...node.children] : [];
 }
@@ -626,7 +637,20 @@ function assertUsageSurface(instance, expectedBlocks, options: ConsumerModuleOpt
         `Node '${instance.id}' has '${heading}' usage block visible='${actualVisible}', expected '${expectedVisible}'.`
       );
     }
+    if (heading === UNUSED_CATALOG_ENTRY_HEADING && actualVisible && hasVisibleUsageChip(usageBlock)) {
+      throw new Error(
+        `Node '${instance.id}' has visible '${USAGE_CHIP_INSTANCE_NAME}' instances inside '${heading}'. ` +
+          "The unused catalog entry state must be rendered as a static status block."
+      );
+    }
   }
+}
+
+function hasVisibleUsageChip(usageBlock) {
+  if (!usageBlock) return false;
+
+  return usageBlock.findAllWithCriteria({ types: ["INSTANCE"] })
+    .some((candidate) => candidate.name === USAGE_CHIP_INSTANCE_NAME && candidate.visible !== false);
 }
 
 function findUsageChipProperty(moduleInstance, propertyName, propertyType) {
@@ -675,13 +699,15 @@ function hasConsumerUsage(entry) {
 
 const MODULE_HORIZONTAL_PADDING = 26;
 const MODULE_VERTICAL_PADDING = 6;
+const STRUCTURAL_SEPARATOR_FRAME_NAME = "separator";
 const USAGE_SEPARATOR_FRAME_NAME = "usage separator";
+const UNUSED_CATALOG_ENTRY_HEADING = "Unused catalog entry";
 const USAGE_BLOCK_HEADINGS = [
   "Provided by",
   "Required by",
   "Applied by",
   "Tool artifacts",
-  "Unused catalog entry",
+  UNUSED_CATALOG_ENTRY_HEADING,
 ];
 const USAGE_BLOCK_FRAME_NAMES = new Set([
   "provided by",


### PR DESCRIPTION
## What changed

- Keep structural `.artifact` and `.artifacts bundle` separators visible during catalog sync while leaving usage separators data-driven.
- Treat `Unused catalog entry` as a static status block and fail if visible usage chips appear inside it.
- Document the Figma MCP official sync staging constraints, chunk-size fallback, REST read flake handling, and the updated visual usage-block contract.

## Why

Recent visual sync work exposed stale component state: usage blocks could remain visible without model data, structural separators could be hidden, and unused catalog entries could be confused with usage metadata. This keeps the generated Figma surface driven by the model and documents the failure modes seen during official sync.

## Validation

- `npm run build` in `repo/figma-design-sync/tools`
- `git diff --check`
- Manual Figma verification on the affected catalog sections