### PR TITLE
fix(figma-design-sync): reuse hidden catalog item slots

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -124,6 +124,15 @@ visible entries. The failure signature is similar to:
 expected 0 'artifact name' text nodes, found 8
 ```
 
+Library artifact and bundle slot selection must prefer direct children of the
+`.tree node` `artifacts` frame, including hidden reusable slots. If the sync
+counts only visible descendants, it can accidentally select a nested artifact
+inside `.artifacts bundle` and fail with a misleading slot count:
+
+```text
+Tree node '...' expected at least 4 '.artifact' instances, found 1.
+```
+
 ## Usage Blocks Hidden Despite Model Data
 
 The official `design-model.json` can be correct while the visible Figma

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -95,10 +95,10 @@ For each section:
   versions, and artifact visibility.
 - Update existing library artifact name/version text overrides when the
   instance structure can represent the model.
-- When a `.tree node` contains hidden template placeholders and visible nested
-  catalog rows, update the visible representable `.artifact` /
-  `.artifacts bundle` instances. Do not let hidden placeholders win over visible
-  bundle child artifact rows.
+- When a `.tree node` contains an `artifacts` frame, select its direct
+  `.artifact` / `.artifacts bundle` children first, including hidden template
+  slots that can be made visible. Do not let visible nested `.artifact` rows
+  inside a `.artifacts bundle` win over direct hidden slots.
 - Update `Used by module` instances for library artifacts from
   `requiredByModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry.

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -442,12 +442,6 @@ function childrenOf(node) {
 }
 
 function directCatalogItemInstances(root, instanceName) {
-  const visibleInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
-    .filter((candidate) => candidate.name === instanceName)
-    .filter((candidate) => candidate.visible !== false);
-
-  if (visibleInstances.length > 0) return visibleInstances;
-
   const container = childrenOf(root)
     .find((child) => child.name === "artifacts" && "children" in child);
   const directInstances = childrenOf(container || root)


### PR DESCRIPTION
## What changed

- Prefer direct `.artifact` / `.artifacts bundle` slots under a `.tree node` `artifacts` frame, including hidden reusable slots.
- Avoid selecting visible nested `.artifact` rows inside `.artifacts bundle` as the available direct catalog item instances.
- Document the failure signature and the visual sync contract for hidden catalog item slots.

## Why

The official Figma sync for `waterMyPlants.libraries` failed on the `ui` node because the script counted only one visible nested `.artifact` inside `.artifacts bundle`, while the component had the required direct `.artifact` slots hidden under the `artifacts` frame.

## Verification

- `npm run build` in `repo/figma-design-sync/tools`