### PR TITLE
fix(figma-design-sync): align tool artifact visual sync

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -101,6 +101,23 @@ lengths before execution, and do not copy long base64 payloads manually from
 terminal output. If chunking is needed for staging, validate chunk count and
 encoded length before assembling the final `scriptBase64` value.
 
+Generated `.mcp.js` runner files are source snippets for the Figma MCP
+`use_figma` call. They are not local scripts that can talk to Figma from
+PowerShell or Node. The Figma plugin runtime cannot read local files from
+`%TEMP%`, `dist/`, or any repository path, so a generated runner must still be
+passed as the `use_figma` code argument or transported through staged shared
+plugin data.
+
+Generated staging snippets are intentionally defensive: each chunk validates
+its own length and the previously staged length before writing. A failed
+`use_figma` call is atomic, so a chunk length failure does not append partial
+data. If `designModelJson` is already fully staged and only a `scriptBase64`
+chunk fails, clear only `scriptBase64`, `scriptLength`, and
+`scriptBase64Length`, regenerate the runner with a smaller `--chunk-size`, and
+rerun the `20-scriptBase64-*.mcp.js`, `90-finalize-staging.mcp.js`, and target
+runner files in lexical order. If the model chunks are uncertain, rerun the
+full runner from `00-clear-staging.mcp.js`.
+
 Before diagnosing a visual no-op as a model or component bug, confirm that the
 official payload was actually staged. A common interrupted-sync symptom is
 `designModelJson.length = 0` in `water_my_plants_sync_staging`, which means

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -20,6 +20,13 @@ metadata.
 If visual mutation fails, leave the old hash in Figma and let
 `checkFigmaTrunkSync` fail until the visual sync can be rerun successfully.
 
+The official TeamCity artifact and the MCP visual write are separate failure
+domains. A `Figma Sync` run can generate and publish a valid `design-model.json`
+artifact from `main`, while the visual write fails later because the Figma
+component contract no longer matches the writer code. In that case, keep using
+the TeamCity artifact as the authoritative model input, fix the visual contract
+or writer, and rerun the failed MCP visual target before writing metadata.
+
 ## Payload Transport Failures
 
 The Figma MCP `use_figma` call has a practical source-size limit near 50k
@@ -96,6 +103,17 @@ Catalog preview uses the smaller `sync-catalog-tree-preview.mcp.js` entrypoint
 by default so connector and layout fixes can be tested without transporting the
 full trunk-sync bundle.
 
+For narrow connector or catalog-tree diagnostics, a temporary bundle that
+imports only the catalog tree gateway can reduce the payload enough to run a
+single root scope. Treat that bundle as a diagnostic artifact only: it does not
+replace the official TeamCity artifact plus `sync-trunk-design-model.mcp.js`
+runner, and it must not write final sync metadata.
+
+Figma MCP cannot execute a local runner file by path. If a diagnostic bundle is
+generated under `%TEMP%` or `dist/`, its JavaScript still has to be supplied as
+the `use_figma` code argument or staged through shared plugin data. Do not
+spend time trying to make the Figma runtime read local files directly.
+
 ## Figma REST Read Flakes
 
 `checkFigmaTrunkSync` can fail because the Figma REST API closes the connection
@@ -171,6 +189,33 @@ extraction:
 The TypeScript sync must fail the visual target before metadata if this
 invariant is not true. Do not repair this with a metadata-only write.
 
+## Missing Usage Chip Heading Text
+
+If the visual target fails with a message like:
+
+```text
+Node '...' is missing 'Configured as tool' usage chip heading text.
+```
+
+the official TeamCity artifact and staging can still be valid. This failure
+usually means the writer's expected visual contract is stale relative to the
+Figma component structure. For example, `.artifact` now renders tooling rows in
+a visible `Tool artifacts` section that contains `.tool artifact usage`
+instances; `Configured as tool` is no longer the visible heading text even
+though the granular boolean may still be named `Show configured as tool`.
+
+Treat this as a sync-code/component-contract mismatch:
+
+- Inspect the failing node id and confirm which visible section and nested
+  component instances exist.
+- Update `repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts`
+  and the Figma config constants to match the current component text and
+  component property names.
+- Rebuild the tools package, regenerate the MCP runner, and rerun the failed
+  visual target before writing metadata.
+
+Do not fix this by editing metadata. The visual mutation did not complete.
+
 ## Connector Binding Failures
 
 Cloned tree nodes and cloned connectors must be made visible before connector
@@ -230,6 +275,28 @@ connector into a section: that makes the line render far away from the
 
 Verify a touched section visually before writing metadata when connector
 behavior changes.
+
+## Removed Connector Lookup Failures
+
+If a catalog tree sync fails with a message like:
+
+```text
+The node with id "..." does not exist
+```
+
+while removing stale tree nodes or connectors, inspect whether the sync removed
+a `simple-solid_arrow` connector and then read that same connector object again
+in the same `use_figma` execution. Figma can invalidate removed nodes
+immediately.
+
+The cleanup code must collect removed connector ids before calling
+`connector.remove()` and then filter the in-memory connector list by those ids.
+Do not call `connectorReferencesAnyNode()` or read shared plugin data from a
+connector after it has been removed.
+
+This is a writer bug, not evidence that the TeamCity `design-model.json`
+artifact is invalid. Rebuild the MCP bundle after fixing the writer and rerun
+the failed visual target before writing metadata.
 
 ## Missing Connector Template
 

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -31,6 +31,13 @@ TeamCity owns the repository workflow:
   TeamCity's `Generate main design model` job. Do not regenerate the model from
   a feature branch to repair `main`.
 
+Treat artifact generation, metadata verification, and visual writing as
+separate phases. A TeamCity `Figma Sync` run can successfully generate and
+publish a valid official `design-model.json` artifact while the later MCP
+visual write still fails because the Figma component contract or writer code is
+stale. Do not interpret a valid artifact, or a green repository check, as proof
+that the visual MCP write has completed.
+
 Local execution is useful for diagnosis, but it is not required before every
 commit because Figma sync depends on external Figma state, credentials, and the
 MCP write flow.

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -113,10 +113,11 @@ For each section:
 - Library artifacts may also carry `configuredByConventionPlugins`. Each usage
   has `pluginId`, `pluginModule`, and `target`; it means the convention plugin
   uses the artifact as build tooling configuration, not that it provides the
-  artifact to production modules. Render these rows under `Configured as tool`
-  with `.tool artifact usage`, not a plain `.usage chip`.
-- Hide `Applied by plugin`, `Used by module`, and `Configured as tool` blocks
-  when their source lists are empty. Do not render empty headings or empty chip
+  artifact to production modules. Render these rows under the visible
+  `Tool artifacts` section with `.tool artifact usage`, not a plain
+  `.usage chip`.
+- Hide `Applied by plugin`, `Used by module`, and `Tool artifacts` blocks when
+  their source lists are empty. Do not render empty headings or empty chip
   containers.
 - Keep structural `separator` frames inside `.artifact` and `.artifacts bundle`
   visible. Only `usage separator` frames, or separators bound to a usage
@@ -125,13 +126,14 @@ For each section:
 - Control each usage block through its own component boolean on `.artifact` and
   `.artifacts bundle`: `Show applied by plugin`, `Show used by module`,
   `Show configured as tool` where the component supports tooling rows, and
-  `Show unused catalog entry`. Do not use one aggregate boolean to show multiple
-  usage blocks.
+  `Show unused catalog entry`. `Show configured as tool` controls the visible
+  `Tool artifacts` section; it is not the required heading text. Do not use one
+  aggregate boolean to show multiple usage blocks.
 - `.artifact` and `.artifacts bundle` must not expose the legacy aggregate
   `Show consumer modules` property. Their usage block visibility is derived
   only from model data and the granular booleans above.
 - When a direct artifact entry or bundle has no `Used by module`, no
-  `Applied by plugin`, and no `Configured as tool` data, show
+  `Applied by plugin`, and no `Tool artifacts` data, show
   `Unused catalog entry` instead of empty usage blocks. Do not mark child
   artifact rows inside a bundle as unused; the bundle is the catalog entry.
 - Update `Used by module` instances for `.artifacts bundle` entries from
@@ -186,6 +188,10 @@ For each section:
   plugin id appears.
 - Remove stale catalog tree nodes and their connectors when they no longer
   exist in the generated model.
+- Treat removed Figma nodes as immediately invalid. When removing stale
+  connectors, record connector ids before `connector.remove()` and keep the
+  remaining connector list by id. Do not inspect connector endpoints or shared
+  plugin data after removal.
 - Fail without writing metadata if an existing or cloned instance cannot
   represent artifact text or consumer module structure from the generated model.
 - Library/plugin catalog tree sections must not have fill. Only parent
@@ -229,6 +235,9 @@ is group-based:
 - Connector endpoints point to `.tree node group` nodes:
   `connectorStart = parentGroup.BOTTOM` and
   `connectorEnd = childGroup.TOP`.
+- `simple-solid_arrow` connectors with `treeConnectorEdge` are managed sync
+  state. Cleanup, stale-node removal, and connector reconciliation must identify
+  them by metadata and id, not by visual position alone.
 
 Do not bind connectors directly to `.tree node` instances. Figma rejects that
 endpoint shape with:

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -220,10 +220,12 @@ function removeStaleCatalogNodes(target, expectedNodes, instancesByLabel, connec
   const staleInstanceIds = new Set(staleInstances.map(([, instance]) => instance.id));
   const removedCatalogNodes = [];
   const removedCatalogConnectors = [];
+  const removedConnectorIds = new Set();
 
   for (const connector of connectors) {
     if (connectorReferencesAnyNode(connector, staleInstanceIds)) {
       removedCatalogConnectors.push(`${target.name}/${connector.id}`);
+      removedConnectorIds.add(connector.id);
       connector.remove();
     }
   }
@@ -237,9 +239,7 @@ function removeStaleCatalogNodes(target, expectedNodes, instancesByLabel, connec
   return {
     removedCatalogNodes,
     removedCatalogConnectors,
-    connectors: connectors.filter((connector) =>
-      !connectorReferencesAnyNode(connector, staleInstanceIds)
-    ),
+    connectors: connectors.filter((connector) => !removedConnectorIds.has(connector.id)),
   };
 }
 

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -74,7 +74,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       configuredByConventionPlugins,
       mutatedNodeIds
     );
-    setUsageBlockVisible(artifactInstance, CONFIGURED_AS_TOOL_HEADING, configuredByConventionPlugins.length > 0, mutatedNodeIds);
+    setUsageBlockVisible(artifactInstance, TOOL_ARTIFACTS_HEADING, configuredByConventionPlugins.length > 0, mutatedNodeIds);
     await updateConsumerModuleInstances(
       artifactInstance,
       USED_BY_MODULE_HEADING,
@@ -88,7 +88,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       artifactInstance,
       [
         [APPLIED_BY_PLUGIN_HEADING, providedByConventionPlugins.length > 0],
-        [CONFIGURED_AS_TOOL_HEADING, configuredByConventionPlugins.length > 0],
+        [TOOL_ARTIFACTS_HEADING, configuredByConventionPlugins.length > 0],
         [USED_BY_MODULE_HEADING, requiredByModules.length > 0],
         [UNUSED_CATALOG_ENTRY_HEADING, isUnused],
       ]
@@ -288,17 +288,17 @@ async function updateToolArtifactUsageInstances(
   options: ConsumerModuleOptions = {}
 ) {
   if (usages.length > 0) {
-    requireUsageChipHeading(root, CONFIGURED_AS_TOOL_HEADING, options);
+    requireUsageChipHeading(root, TOOL_ARTIFACTS_HEADING, options);
   }
 
   const toolArtifactUsageInstances = root.findAllWithCriteria({ types: ["INSTANCE"] })
     .filter((candidate) => candidate.name === TOOL_ARTIFACT_USAGE_INSTANCE_NAME)
-    .filter((candidate) => belongsToHeadingUsageChipBlock(candidate, root, CONFIGURED_AS_TOOL_HEADING, options))
+    .filter((candidate) => belongsToHeadingUsageChipBlock(candidate, root, TOOL_ARTIFACTS_HEADING, options))
     .filter((candidate) => !options.excludeArtifactDescendants || !hasAncestorInstanceNamed(candidate, ARTIFACT_INSTANCE_NAME, root));
 
   if (toolArtifactUsageInstances.length < usages.length) {
     throw new Error(
-      `Node '${root.id}' expected at least ${usages.length} '${TOOL_ARTIFACT_USAGE_INSTANCE_NAME}' instances for '${CONFIGURED_AS_TOOL_HEADING}', ` +
+      `Node '${root.id}' expected at least ${usages.length} '${TOOL_ARTIFACT_USAGE_INSTANCE_NAME}' instances for '${TOOL_ARTIFACTS_HEADING}', ` +
         `found ${toolArtifactUsageInstances.length}. Update the .artifact component structure before writing metadata.`
     );
   }
@@ -741,13 +741,13 @@ const USAGE_SEPARATOR_FRAME_NAME = "usage separator";
 const APPLIED_BY_PLUGIN_HEADING = "Applied by plugin";
 const USED_BY_MODULE_HEADING = "Used by module";
 const USED_BY_CONVENTION_PLUGIN_HEADING = "Used by convention plugin";
-const CONFIGURED_AS_TOOL_HEADING = "Configured as tool";
+const TOOL_ARTIFACTS_HEADING = "Tool artifacts";
 const UNUSED_CATALOG_ENTRY_HEADING = "Unused catalog entry";
 const USAGE_BLOCK_HEADINGS = [
   APPLIED_BY_PLUGIN_HEADING,
   USED_BY_MODULE_HEADING,
   USED_BY_CONVENTION_PLUGIN_HEADING,
-  CONFIGURED_AS_TOOL_HEADING,
+  TOOL_ARTIFACTS_HEADING,
   UNUSED_CATALOG_ENTRY_HEADING,
 ];
 const USAGE_BLOCK_FRAME_NAMES = new Set([


### PR DESCRIPTION
## Summary
- render tooling usages under the visible Tool artifacts section
- avoid re-reading removed Figma connector nodes during cleanup
- document TeamCity artifact vs MCP visual write failure domains and runner transport constraints

## Verification
- npm run build
- git diff --check