### PR TITLE
fix(figma-design-sync): align plugin usage visual contract

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -66,7 +66,9 @@ The GitHub ruleset for `main` is documented in
 The pipeline:
 
 - monitors all branches;
-- runs `Verify`;
+- runs `Verify` with `.\gradlew.bat check`;
+- blocks unused dependency catalog entries through `checkFigmaCatalogUsage`,
+  which is wired into the Gradle `check` lifecycle;
 - publishes the `TeamCity CI` GitHub status from `Verify`.
 
 `CI` does not run `generateFigmaDesignModel` and does not publish

--- a/repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt
+++ b/repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt
@@ -70,10 +70,6 @@ private fun orgPluginTree(
                     id = "compose",
                     version = versions.kotlinVersion
                 )
-                plugin(
-                    id = "serialization",
-                    version = versions.kotlinVersion
-                )
             }
         }
     }

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -54,6 +54,9 @@ used by CI.
 
 - `generateFigmaDesignModel`: generates
   `build/reports/figma-sync/design-model.json`.
+- `checkFigmaCatalogUsage`: fails when dependency catalogs declare library or
+  plugin entries that are not used by a module, convention plugin, or tool
+  configuration. This task is wired into the root `check` lifecycle.
 - `checkFigmaTrunkSync`: compares the generated model hash with Figma shared
   plugin data.
 - Treat `figmaDesignSync` as a CI-owned verification step. Developers may run it

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/IncludedBuildSettingsCatalogReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/IncludedBuildSettingsCatalogReader.kt
@@ -26,7 +26,8 @@ class IncludedBuildSettingsCatalogReader {
         usageByAlias: Map<String, Set<String>> = emptyMap()
     ): LibraryCatalogTree {
         val content = settingsFile.readText()
-        val libsBlock = content.extractCreateBlock("libs")
+        val libsBlock = content.extractCreateBlockOrNull("libs")
+            ?: return LibraryCatalogTree(roots = emptyList())
 
         return libsBlock
             .readLibraryDeclarations()
@@ -41,7 +42,8 @@ class IncludedBuildSettingsCatalogReader {
         usageByAlias: Map<String, Set<String>> = emptyMap()
     ): PluginCatalogTree {
         val content = settingsFile.readText()
-        val pluginsBlock = content.extractCreateBlock("plugins")
+        val pluginsBlock = content.extractCreateBlockOrNull("plugins")
+            ?: return PluginCatalogTree(roots = emptyList())
 
         return pluginsBlock
             .readPluginDeclarations()
@@ -134,13 +136,11 @@ class IncludedBuildSettingsCatalogReader {
         )
     }
 
-    private fun String.extractCreateBlock(catalogName: String): String {
+    private fun String.extractCreateBlockOrNull(catalogName: String): String? {
         val createCall = """create("$catalogName")"""
         val createCallIndex = indexOf(createCall)
 
-        require(createCallIndex >= 0) {
-            "Catalog '$catalogName' not found in included-build settings.gradle.kts"
-        }
+        if (createCallIndex < 0) return null
 
         val blockStart = indexOf('{', startIndex = createCallIndex)
 

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/IncludedBuildSettingsCatalogReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/gradle/catalog/IncludedBuildSettingsCatalogReaderTest.kt
@@ -64,6 +64,30 @@ internal class IncludedBuildSettingsCatalogReaderTest : FunSpec({
         )
     }
 
+    test("readLibraryTree returns an empty tree when the included build has no libs catalog") {
+        // GIVEN
+        val settingsFile = settingsFile(
+            """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    create("plugins") {
+                        plugin(
+                            alias = "org.jetbrains.dokka",
+                            id = "org.jetbrains.dokka"
+                        ).version(version("dokkaVersion"))
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val actualTree = IncludedBuildSettingsCatalogReader().readLibraryTree(settingsFile)
+
+        // THEN
+        actualTree shouldBe LibraryCatalogTree(roots = emptyList())
+    }
+
     test("readPluginTree maps included build settings plugins catalog to plugin catalog tree") {
         // GIVEN
         val settingsFile = settingsFile(
@@ -108,6 +132,31 @@ internal class IncludedBuildSettingsCatalogReaderTest : FunSpec({
                 )
             )
         )
+    }
+
+    test("readPluginTree returns an empty tree when the included build has no plugins catalog") {
+        // GIVEN
+        val settingsFile = settingsFile(
+            """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    create("libs") {
+                        library(
+                            alias = "io.ktor.client.core",
+                            group = "io.ktor",
+                            artifact = "ktor-client-core"
+                        ).withoutVersion()
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        // WHEN
+        val actualTree = IncludedBuildSettingsCatalogReader().readPluginTree(settingsFile)
+
+        // THEN
+        actualTree shouldBe PluginCatalogTree(roots = emptyList())
     }
 })
 

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -88,8 +88,8 @@ Important generation details:
   dependency but no module applies the convention plugin yet.
 - Water My Plants plugin entries include `providedByConventionPlugins` when a
   convention plugin applies a catalog plugin. Direct plugin applications remain
-  in `appliedToModules`; the visual `Used by module` row combines direct modules
-  with the modules listed in each
+  in `appliedToModules`; the visual `Applied by module` row combines direct
+  modules with the modules listed in each
   `providedByConventionPlugins.requiredByModules` entry, which may be empty.
 - `dependencyCatalog` contributes modules and module dependencies but not
   `content.catalogs.dependencyCatalog` because
@@ -107,7 +107,7 @@ Important generation details:
   runs through `.\gradlew.bat check` and rejects unused library/plugin entries
   before they can be merged. Repository-owned custom Gradle plugin inventories
   are the exception: they may include plugins that no module consumes yet, and
-  the visual sync renders those leaves with a `Not used by module` warning.
+  the visual sync renders those leaves with a `No module applies it` warning.
 - Included-build catalog targets with no model nodes are hidden by visual sync.
   An included build may omit `versionCatalogs.create("plugins")`; the resulting
   `*.plugins` Figma section should disappear instead of staying as an empty

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -103,6 +103,15 @@ Important generation details:
   `GradleConventionPlugin` and whose plugin id is applied from the main build.
 - `com.marmatsan.figmaDesignSync` is a regular Gradle plugin, not a convention
   plugin. It is included in `content.catalogs.waterMyPlants.customGradlePlugins`.
+- Dependency catalog entries are expected to be used. `checkFigmaCatalogUsage`
+  runs through `.\gradlew.bat check` and rejects unused library/plugin entries
+  before they can be merged. Repository-owned custom Gradle plugin inventories
+  are the exception: they may include plugins that no module consumes yet, and
+  the visual sync renders those leaves with a `Not used by module` warning.
+- Included-build catalog targets with no model nodes are hidden by visual sync.
+  An included build may omit `versionCatalogs.create("plugins")`; the resulting
+  `*.plugins` Figma section should disappear instead of staying as an empty
+  section.
 - `content.moduleDependencies` contains one graph for the root build and one
   graph per configured included build: `main`, `dependencyCatalog`,
   `figmaDesignSync`, and `gradlePlugins`.

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -161,7 +161,7 @@ visible `.artifact` either still exposed the obsolete aggregate
 `Show consumer modules` property or kept its direct `Applied by plugin` /
 `Used by module` blocks hidden. The equivalent plugin failure is a
 `Plugin` `.tree node` whose model contains `appliedToModules` or
-`providedByConventionPlugins`, while `Used by module` /
+`providedByConventionPlugins`, while `Applied by module` /
 `Used by convention plugin` stay hidden or the custom-plugin warning block
 remains visible. Hidden template internals under the same `.tree node` can
 still contain chips, which makes the file look partially updated through the
@@ -184,13 +184,13 @@ extraction:
 - Confirm the visible direct `.artifact` / `.artifacts bundle` instance has the
   granular component booleans expected by the model:
   `Show applied by plugin`, `Show used by module`, `Show configured as tool`
-  when present. `Show unused catalog entry` should stay false for library
-  catalog entries because unused libraries are rejected by CI. `Show consumer
-  modules` is obsolete and must not be used to validate the surface.
+  when present. `.artifact` and `.artifacts bundle` do not expose an
+  unused-entry boolean because unused libraries are rejected by CI. `Show
+  consumer modules` is obsolete and must not be used to validate the surface.
 - For plugin trees, confirm the visible `Plugin` `.tree node` has the granular
-  component booleans expected by the model: `Show used by module`,
-  `Show used by convention plugin`, and `Show unused catalog entry` only when a
-  custom Gradle plugin warning is expected.
+  component booleans expected by the model: `Show applied by module`,
+  `Show used by convention plugin`, and `Show unused` only when a custom Gradle
+  plugin warning is expected.
 
 The TypeScript sync must fail the visual target before metadata if this
 invariant is not true. Do not repair this with a metadata-only write.

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -162,14 +162,15 @@ visible `.artifact` either still exposed the obsolete aggregate
 `Used by module` blocks hidden. The equivalent plugin failure is a
 `Plugin` `.tree node` whose model contains `appliedToModules` or
 `providedByConventionPlugins`, while `Used by module` /
-`Used by convention plugin` stay hidden or an empty `Unused catalog entry`
-block remains visible. Hidden template internals under the same `.tree node`
-can still contain chips, which makes the file look partially updated through
-the plugin API but not visually updated on canvas.
-`Unused catalog entry` is a static status block, not usage metadata. The
-`.tree node` `Plugin` variant must not contain `.usage chip` instances inside
-that block; if one appears there, repair the component contract before changing
-catalog extraction.
+`Used by convention plugin` stay hidden or the custom-plugin warning block
+remains visible. Hidden template internals under the same `.tree node` can
+still contain chips, which makes the file look partially updated through the
+plugin API but not visually updated on canvas.
+Dependency catalog entries without usage should fail `checkFigmaCatalogUsage`
+before merge. The static warning block is only for repository-owned custom
+Gradle plugin leaves that no module consumes yet. The `.tree node` `Plugin`
+variant must not contain `.usage chip` instances inside that block; if one
+appears there, repair the component contract before changing catalog extraction.
 Do not treat an empty `providedByConventionPlugins.requiredByModules` list as
 unused by itself: the entry is still applied by the convention plugin, but no
 module currently applies that convention plugin.
@@ -183,11 +184,13 @@ extraction:
 - Confirm the visible direct `.artifact` / `.artifacts bundle` instance has the
   granular component booleans expected by the model:
   `Show applied by plugin`, `Show used by module`, `Show configured as tool`
-  when present, and `Show unused catalog entry`. `Show consumer modules` is
-  obsolete and must not be used to validate the surface.
+  when present. `Show unused catalog entry` should stay false for library
+  catalog entries because unused libraries are rejected by CI. `Show consumer
+  modules` is obsolete and must not be used to validate the surface.
 - For plugin trees, confirm the visible `Plugin` `.tree node` has the granular
   component booleans expected by the model: `Show used by module`,
-  `Show used by convention plugin`, and `Show unused catalog entry`.
+  `Show used by convention plugin`, and `Show unused catalog entry` only when a
+  custom Gradle plugin warning is expected.
 
 The TypeScript sync must fail the visual target before metadata if this
 invariant is not true. Do not repair this with a metadata-only write.

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -144,16 +144,17 @@ For each section:
 - Control each usage block through its own component boolean on `.artifact` and
   `.artifacts bundle`: `Show applied by plugin`, `Show used by module`,
   `Show configured as tool` where the component supports tooling rows, and
-  `Show unused catalog entry`. `Show configured as tool` controls the visible
-  `Tool artifacts` section; it is not the required heading text. Do not use one
-  aggregate boolean to show multiple usage blocks.
+  `Show unused catalog entry` forced to `false` by the writer. `Show configured
+  as tool` controls the visible `Tool artifacts` section; it is not the required
+  heading text. Do not use one aggregate boolean to show multiple usage blocks.
 - `.artifact` and `.artifacts bundle` must not expose the legacy aggregate
   `Show consumer modules` property. Their usage block visibility is derived
   only from model data and the granular booleans above.
-- When a direct artifact entry or bundle has no direct `requiredByModules`, no
-  `providedByConventionPlugins`, and no `configuredByConventionPlugins`, show
-  `Unused catalog entry` instead of empty usage blocks. Do not mark child
-  artifact rows inside a bundle as unused; the bundle is the catalog entry.
+- Direct artifact entries and bundles with no direct `requiredByModules`, no
+  `providedByConventionPlugins`, and no `configuredByConventionPlugins` are
+  invalid catalog data. `checkFigmaCatalogUsage` must fail in CI before the
+  model can be merged, so visual sync must not render `Unused catalog entry`
+  for `.artifact` or `.artifacts bundle`.
 - Update `Used by module` instances for `.artifacts bundle` entries from
   the bundle `requiredByModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry. Child `.artifact`
@@ -162,27 +163,29 @@ For each section:
   `appliedToModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry.
 - For plugin tree nodes, hide `Used by module` and
-  `Used by convention plugin` when their source lists are empty. When a plugin
-  catalog entry has no `appliedToModules` and no `providedByConventionPlugins`,
-  show `Unused catalog entry` instead of empty usage blocks.
-- Leaf nodes in `waterMyPlants.customGradleConventionPlugins` are also catalog
-  entries for this visual state even though they do not declare versions. A
-  convention plugin such as `dokkaDocumentation` or `protobuf` with no
-  `appliedToModules` must show `Unused catalog entry`.
+  `Used by convention plugin` when their source lists are empty. Plugin catalog
+  entries with no `appliedToModules` and no `providedByConventionPlugins` are
+  invalid catalog data and must be rejected by `checkFigmaCatalogUsage`.
+- Leaf nodes in `waterMyPlants.customGradlePlugins` are an inventory of
+  repository-owned Gradle plugins, not dependency catalog entries. They may be
+  present even when no module consumes them yet. When such a leaf has no
+  effective consumers, show the static warning block `Not used by module`
+  instead of `Unused catalog entry`.
 - Control plugin usage blocks through their own component boolean on `.tree
   node` `Plugin`: `Show used by module`, `Show used by convention plugin`, and
-  `Show unused catalog entry`. Do not expose the legacy aggregate
-  `Show consumer module` property.
+  `Show unused catalog entry` for the custom-plugin warning block. Do not expose
+  the legacy aggregate `Show consumer module` property.
 - In `.tree node` `Plugin`, usage blocks are direct children of the component:
   `.usage block type=used-by-module`, `.usage block
   type=used-by-convention-plugin`, and `.usage block
-  type=unused-catalog-entry`, each controlled by its own boolean. Do not
-  require a wrapper frame named `content`.
+  type=unused-catalog-entry` for the custom-plugin warning, each controlled by
+  its own boolean. Do not require a wrapper frame named `content`.
 - Parent components must expose every usage section in their template. The sync
   decides visibility on each generated instance from the model data by setting
   the granular boolean and the direct block visibility for that section.
-- Represent usage metadata with `.usage chip` instances. `Unused catalog entry`
-  is not usage metadata and must not be rendered as a `.usage chip`.
+- Represent usage metadata with `.usage chip` instances. The custom-plugin
+  warning block is not usage metadata and must not render `.usage chip`
+  instances.
 - Represent shared usage sections with `.usage block`. The supported `type`
   variants are `applied-by-plugin`, `used-by-module`,
   `used-by-convention-plugin`, and `unused-catalog-entry`.
@@ -195,11 +198,16 @@ For each section:
 - `.tool artifact usage` represents one `configuredByConventionPlugins` entry.
   Its direct text property `tool artifact target` receives `target`; its nested
   `.usage chip` receives `kind=convention-plugin` and `name=pluginId`.
-- Render `Unused catalog entry` as a static status block matching `.artifact`
-  and `.artifacts bundle`: the container fill is
-  `md/sys/color/error-container`, the label fill is
-  `md/sys/color/on-error-container`. The `.tree node` `Plugin` variant must
-  not contain `.usage chip` instances inside that block.
+- Render the custom-plugin warning as a static status block: the container fill
+  is `md/sys/color/error-container`, the label fill is
+  `md/sys/color/on-error-container`, and the `.tree node` `Plugin` variant must
+  not contain `.usage chip` instances inside that block. The writer accepts
+  either `Not used by module` or the legacy `Unused catalog entry` heading while
+  the component is being migrated.
+- If a catalog target contains no model nodes, hide that target section and
+  resize/re-stack its parent sections. For example, an included build with no
+  `plugins` catalog must not leave an empty `gradlePlugins.plugins` section in
+  Figma.
 - Create missing `.tree node` instances by cloning a compatible existing node
   from the same visual section, then applying generated model values.
 - Create missing top-level tree sections when a new top-level library group or

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -143,43 +143,45 @@ For each section:
   usage content.
 - Control each usage block through its own component boolean on `.artifact` and
   `.artifacts bundle`: `Show applied by plugin`, `Show used by module`,
-  `Show configured as tool` where the component supports tooling rows, and
-  `Show unused catalog entry` forced to `false` by the writer. `Show configured
-  as tool` controls the visible `Tool artifacts` section; it is not the required
-  heading text. Do not use one aggregate boolean to show multiple usage blocks.
+  and `Show configured as tool` where the component supports tooling rows.
+  `Show configured as tool` controls the visible `Tool artifacts` section; it
+  is not the required heading text. `.artifact` and `.artifacts bundle` do not
+  expose an unused-entry boolean. Do not use one aggregate boolean to show
+  multiple usage blocks.
 - `.artifact` and `.artifacts bundle` must not expose the legacy aggregate
   `Show consumer modules` property. Their usage block visibility is derived
   only from model data and the granular booleans above.
 - Direct artifact entries and bundles with no direct `requiredByModules`, no
   `providedByConventionPlugins`, and no `configuredByConventionPlugins` are
   invalid catalog data. `checkFigmaCatalogUsage` must fail in CI before the
-  model can be merged, so visual sync must not render `Unused catalog entry`
-  for `.artifact` or `.artifacts bundle`.
+  model can be merged, so `.artifact` and `.artifacts bundle` must not render
+  or expose an unused-entry block.
 - Update `Used by module` instances for `.artifacts bundle` entries from
   the bundle `requiredByModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry. Child `.artifact`
   instances inside a bundle must not show their own `Used by module` section.
-- Update `Used by module` instances for plugin tree nodes from
+- Update `Applied by module` instances for plugin tree nodes from
   `appliedToModules` plus the modules listed by each
   `providedByConventionPlugins.requiredByModules` entry.
-- For plugin tree nodes, hide `Used by module` and
+- For plugin tree nodes, hide `Applied by module` and
   `Used by convention plugin` when their source lists are empty. Plugin catalog
   entries with no `appliedToModules` and no `providedByConventionPlugins` are
   invalid catalog data and must be rejected by `checkFigmaCatalogUsage`.
 - Leaf nodes in `waterMyPlants.customGradlePlugins` are an inventory of
   repository-owned Gradle plugins, not dependency catalog entries. They may be
   present even when no module consumes them yet. When such a leaf has no
-  effective consumers, show the static warning block `Not used by module`
+  effective consumers, show the static warning block `No module applies it`
   instead of `Unused catalog entry`.
 - Control plugin usage blocks through their own component boolean on `.tree
-  node` `Plugin`: `Show used by module`, `Show used by convention plugin`, and
-  `Show unused catalog entry` for the custom-plugin warning block. Do not expose
+  node` `Plugin`: `Show applied by module`,
+  `Show used by convention plugin`, and
+  `Show unused` for the custom-plugin warning block. Do not expose
   the legacy aggregate `Show consumer module` property.
 - In `.tree node` `Plugin`, usage blocks are direct children of the component:
-  `.usage block type=used-by-module`, `.usage block
-  type=used-by-convention-plugin`, and `.usage block
-  type=unused-catalog-entry` for the custom-plugin warning, each controlled by
-  its own boolean. Do not require a wrapper frame named `content`.
+  `.usage block type=applied-by-module`, `.usage block
+  type=used-by-convention-plugin`, plus a static `No module applies it` status
+  block for the custom-plugin warning, each controlled by its own boolean. Do
+  not require a wrapper frame named `content`.
 - Parent components must expose every usage section in their template. The sync
   decides visibility on each generated instance from the model data by setting
   the granular boolean and the direct block visibility for that section.
@@ -188,7 +190,7 @@ For each section:
   instances.
 - Represent shared usage sections with `.usage block`. The supported `type`
   variants are `applied-by-plugin`, `used-by-module`,
-  `used-by-convention-plugin`, and `unused-catalog-entry`.
+  `used-by-convention-plugin`, and `applied-by-module`.
 - `.usage chip` exposes only two `kind` variants: `module` for modules that
   require or apply an item, and `convention-plugin` for Gradle convention
   plugins that provide dependencies to production modules or configure tooling
@@ -202,8 +204,9 @@ For each section:
   is `md/sys/color/error-container`, the label fill is
   `md/sys/color/on-error-container`, and the `.tree node` `Plugin` variant must
   not contain `.usage chip` instances inside that block. The writer accepts
-  either `Not used by module` or the legacy `Unused catalog entry` heading while
-  the component is being migrated.
+  `No module applies it`; legacy `Not used by module` and
+  `Unused catalog entry` headings are accepted only to clean up sections still
+  being migrated.
 - If a catalog target contains no model nodes, hide that target section and
   resize/re-stack its parent sections. For example, an included build with no
   `plugins` catalog must not leave an empty `gradlePlugins.plugins` section in
@@ -233,8 +236,9 @@ Use `.tree node` component:
   `https://www.figma.com/design/YBZXsd8oyGLbcI2KWxJvRK/Water-My-Plants?node-id=63069-678`
 - Use the `Library` variant for libraries.
 - Use the `Plugin` variant for plugins.
-- The `Plugin` variant exposes granular usage booleans: `Show used by module`,
-  `Show used by convention plugin`, and `Show unused catalog entry`.
+- The `Plugin` variant exposes granular usage booleans:
+  `Show applied by module`, `Show used by convention plugin`, and
+  `Show unused`.
 - The `Plugin` variant must not expose the legacy aggregate
   `Show consumer module` switch. Visual correctness comes from the granular
   booleans and the `.usage block` visibility.

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageCheckRequest.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageCheckRequest.kt
@@ -1,0 +1,13 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.catalog
+
+import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
+import java.io.File
+
+/**
+ * Input snapshot for checking whether declared dependency catalogs contain
+ * entries that are not consumed by the repository.
+ */
+internal data class CatalogUsageCheckRequest(
+    val projectRootDirectory: File,
+    val includedBuilds: List<FigmaDesignModelIncludedBuildSource>
+)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageCheckResult.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageCheckResult.kt
@@ -1,0 +1,19 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.catalog
+
+/**
+ * Result of checking declared dependency catalogs for entries that are not used.
+ */
+internal data class CatalogUsageCheckResult(
+    val unusedEntries: List<UnusedCatalogEntry>
+) {
+    val isSuccessful: Boolean = unusedEntries.isEmpty()
+}
+
+/**
+ * One declared catalog entry that has no module, convention plugin, or tooling
+ * usage in the repository.
+ */
+internal data class UnusedCatalogEntry(
+    val catalogName: String,
+    val entry: String
+)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageChecker.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageChecker.kt
@@ -1,0 +1,140 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.catalog
+
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
+import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
+import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSource
+import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
+import com.marmatsan.figmaDesignSync.domain.port.gradle.IncludedBuildSource
+import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Verifies that dependency catalogs only declare entries that are used by the
+ * repository.
+ *
+ * This checker intentionally scopes itself to dependency catalogs. Repository
+ * owned custom Gradle plugin inventories are documentation, not dependency
+ * catalogs, so they may contain plugins that no module applies yet.
+ */
+@Inject
+internal class CatalogUsageChecker(
+    private val projectCatalogTreesPort: ProjectCatalogTreesPort
+) {
+    fun check(request: CatalogUsageCheckRequest): CatalogUsageCheckResult {
+        val includedBuilds = request.includedBuilds.map(FigmaDesignModelIncludedBuildSource::toDomainSource)
+        val conventionPluginIncludedBuilds = includedBuilds.filter(IncludedBuildSource::publishesConventionPlugins)
+        val unusedEntries = mutableListOf<UnusedCatalogEntry>()
+
+        val dependencyDslSource = ProjectCatalogTreeSource.DependenciesDslVersionAliases(
+            rootDirPath = request.projectRootDirectory.absolutePath,
+            conventionPluginIncludedBuilds = conventionPluginIncludedBuilds
+        )
+        unusedEntries += projectCatalogTreesPort
+            .readLibraryTree(dependencyDslSource)
+            .unusedEntries(catalogName = "waterMyPlants.libraries")
+        unusedEntries += projectCatalogTreesPort
+            .readPluginTree(dependencyDslSource)
+            .unusedEntries(catalogName = "waterMyPlants.plugins")
+
+        request.includedBuilds
+            .filter(FigmaDesignModelIncludedBuildSource::publishesCatalogs)
+            .forEach { includedBuild ->
+                val source = ProjectCatalogTreeSource.IncludedBuildSettings(
+                    includedBuild = includedBuild.toDomainSource()
+                )
+                unusedEntries += projectCatalogTreesPort
+                    .readLibraryTree(source)
+                    .unusedEntries(catalogName = "${includedBuild.modelName}.libraries")
+                unusedEntries += projectCatalogTreesPort
+                    .readPluginTree(source)
+                    .unusedEntries(catalogName = "${includedBuild.modelName}.plugins")
+            }
+
+        return CatalogUsageCheckResult(unusedEntries = unusedEntries.sortedWith(compareBy(
+            UnusedCatalogEntry::catalogName,
+            UnusedCatalogEntry::entry
+        )))
+    }
+}
+
+private fun LibraryCatalogTree.unusedEntries(catalogName: String): List<UnusedCatalogEntry> =
+    roots.flatMap { root -> root.unusedEntries(catalogName = catalogName) }
+
+private fun LibraryCatalogNode.unusedEntries(
+    catalogName: String,
+    parentGroup: String = ""
+): List<UnusedCatalogEntry> {
+    val groupPath = listOf(parentGroup, group)
+        .filter(String::isNotBlank)
+        .joinToString(".")
+
+    return entries
+        .filterNot(LibraryCatalogEntry::hasUsage)
+        .map { entry ->
+            UnusedCatalogEntry(
+                catalogName = catalogName,
+                entry = entry.catalogPath(groupPath)
+            )
+        } + children.flatMap { child ->
+        child.unusedEntries(
+            catalogName = catalogName,
+            parentGroup = groupPath
+        )
+    }
+}
+
+private fun LibraryCatalogEntry.hasUsage(): Boolean =
+    when (this) {
+        is LibraryCatalogEntry.Artifact ->
+            requiredByModules.isNotEmpty() ||
+                providedByConventionPlugins.isNotEmpty() ||
+                configuredByConventionPlugins.isNotEmpty()
+
+        is LibraryCatalogEntry.ArtifactsBundle ->
+            requiredByModules.isNotEmpty() ||
+                providedByConventionPlugins.isNotEmpty()
+    }
+
+private fun LibraryCatalogEntry.catalogPath(groupPath: String): String =
+    when (this) {
+        is LibraryCatalogEntry.Artifact -> "$groupPath:$artifact"
+        is LibraryCatalogEntry.ArtifactsBundle -> "$groupPath bundle '$alias'"
+    }
+
+private fun PluginCatalogTree.unusedEntries(catalogName: String): List<UnusedCatalogEntry> =
+    roots.flatMap { root -> root.unusedEntries(catalogName = catalogName) }
+
+private fun PluginCatalogNode.unusedEntries(
+    catalogName: String,
+    parentId: String = ""
+): List<UnusedCatalogEntry> {
+    val pluginId = listOf(parentId, id)
+        .filter(String::isNotBlank)
+        .joinToString(".")
+    val currentEntry = if (isCatalogEntry && !hasUsage) {
+        listOf(
+            UnusedCatalogEntry(
+                catalogName = catalogName,
+                entry = pluginId
+            )
+        )
+    } else {
+        emptyList()
+    }
+
+    return currentEntry + children.flatMap { child ->
+        child.unusedEntries(
+            catalogName = catalogName,
+            parentId = pluginId
+        )
+    }
+}
+
+private val PluginCatalogNode.isCatalogEntry: Boolean
+    get() = version != null
+
+private val PluginCatalogNode.hasUsage: Boolean
+    get() = appliedToModules.isNotEmpty() || providedByConventionPlugins.isNotEmpty()

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
@@ -9,6 +9,7 @@ import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModulesPort
 import com.marmatsan.figmaDesignSync.domain.port.versions.RepositoryVersionsPort
+import com.marmatsan.figmaDesignSync.plugin.checker.catalog.CatalogUsageChecker
 import com.marmatsan.figmaDesignSync.plugin.checker.sync.FigmaTrunkSyncChecker
 import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelGenerator
 import me.tatarka.inject.annotations.Component
@@ -32,6 +33,11 @@ internal abstract class figmaDesignSyncComponent {
      * Service used by `checkFigmaTrunkSync`.
      */
     abstract val trunkSyncChecker: FigmaTrunkSyncChecker
+
+    /**
+     * Service used by `checkFigmaCatalogUsage`.
+     */
+    abstract val catalogUsageChecker: CatalogUsageChecker
 
     /**
      * Provides the narrow Figma API client used only by the sync checker.

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
@@ -1,11 +1,14 @@
 package com.marmatsan.figmaDesignSync.plugin.gradle
 
 import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
+import com.marmatsan.figmaDesignSync.plugin.task.catalog.CheckFigmaCatalogUsageTask
 import com.marmatsan.figmaDesignSync.plugin.task.generate.GenerateFigmaDesignModelTask
 import com.marmatsan.figmaDesignSync.plugin.task.sync.CheckFigmaTrunkSyncTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 
 /**
@@ -20,10 +23,40 @@ import org.gradle.kotlin.dsl.register
 @Suppress("unused")
 class FigmaDesignSyncGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        project.pluginManager.apply("base")
+
         val extension = project.extensions.create<figmaDesignSyncExtension>("figmaDesignSync")
 
         extension.designModelMetadataNodeUrl.convention(FIGMA_PAGE_URL)
         val includedBuildSources = extension.includedBuildSources(project)
+
+        val checkFigmaCatalogUsage = project.tasks.register<CheckFigmaCatalogUsageTask>("checkFigmaCatalogUsage") {
+            group = "verification"
+            description = "Checks that dependency catalog entries rendered in Figma are used by the repository."
+
+            rootSettingsFile.set(extension.rootSettingsFile)
+            includedBuildSettingsFiles.from(
+                includedBuildSources.map { sources -> sources.map { source -> source.settingsFile } }
+            )
+            includedBuildModelNames.set(
+                includedBuildSources.map { sources -> sources.map { source -> source.modelName } }
+            )
+            includedBuildModulePathPrefixes.set(
+                includedBuildSources.map { sources -> sources.map { source -> source.modulePathPrefix } }
+            )
+            includedBuildPublishesCatalogs.set(
+                includedBuildSources.map { sources -> sources.map { source -> source.publishesCatalogs } }
+            )
+            includedBuildPublishesConventionPlugins.set(
+                includedBuildSources.map { sources -> sources.map { source -> source.publishesConventionPlugins } }
+            )
+            projectRootDirectory.set(project.layout.projectDirectory)
+            includedBuildSourcesProvider = includedBuildSources
+        }
+
+        project.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
+            dependsOn(checkFigmaCatalogUsage)
+        }
 
         project.tasks.register<GenerateFigmaDesignModelTask>("generateFigmaDesignModel") {
             group = "documentation"

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/catalog/CheckFigmaCatalogUsageTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/catalog/CheckFigmaCatalogUsageTask.kt
@@ -1,0 +1,79 @@
+package com.marmatsan.figmaDesignSync.plugin.task.catalog
+
+import com.marmatsan.figmaDesignSync.plugin.checker.catalog.CatalogUsageCheckRequest
+import com.marmatsan.figmaDesignSync.plugin.di.create
+import com.marmatsan.figmaDesignSync.plugin.di.figmaDesignSyncComponent
+import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Gradle verification task that fails when dependency catalogs declare entries
+ * not used by any module, convention plugin, or tool configuration.
+ */
+abstract class CheckFigmaCatalogUsageTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val rootSettingsFile: RegularFileProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val includedBuildSettingsFiles: ConfigurableFileCollection
+
+    @get:Input
+    abstract val includedBuildModelNames: ListProperty<String>
+
+    @get:Input
+    abstract val includedBuildModulePathPrefixes: ListProperty<String>
+
+    @get:Input
+    abstract val includedBuildPublishesCatalogs: ListProperty<Boolean>
+
+    @get:Input
+    abstract val includedBuildPublishesConventionPlugins: ListProperty<Boolean>
+
+    @get:Internal
+    abstract val projectRootDirectory: DirectoryProperty
+
+    @get:Internal
+    internal var includedBuildSourcesProvider: Provider<List<FigmaDesignModelIncludedBuildSource>>? = null
+
+    @TaskAction
+    fun checkCatalogUsage() {
+        val result = figmaDesignSyncComponent::class.create().catalogUsageChecker.check(
+            CatalogUsageCheckRequest(
+                projectRootDirectory = projectRootDirectory.get().asFile,
+                includedBuilds = includedBuildSources()
+            )
+        )
+
+        if (!result.isSuccessful) {
+            throw GradleException(
+                buildString {
+                    appendLine("Unused dependency catalog entries found.")
+                    appendLine("Remove each entry or make it used by a module, convention plugin, or tool configuration:")
+                    result.unusedEntries.forEach { entry ->
+                        appendLine("- ${entry.catalogName}: ${entry.entry}")
+                    }
+                }.trimEnd()
+            )
+        }
+
+        logger.lifecycle("All dependency catalog entries are used.")
+    }
+
+    private fun includedBuildSources(): List<FigmaDesignModelIncludedBuildSource> =
+        includedBuildSourcesProvider?.get().orEmpty()
+}

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageCheckerTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/catalog/CatalogUsageCheckerTest.kt
@@ -1,0 +1,222 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.catalog
+
+import com.marmatsan.figmaDesignSync.domain.model.catalog.CatalogVersion
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginConfigurationUsage
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogEntry.ConventionPluginUsage
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
+import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
+import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
+import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSource
+import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
+import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+
+internal class CatalogUsageCheckerTest : FunSpec({
+
+    test("check reports unused entries from dependency DSL and included-build catalogs") {
+        // GIVEN
+        val rootDir = Files.createTempDirectory("catalog-usage-check").toFile()
+        val checker = CatalogUsageChecker(
+            projectCatalogTreesPort = FakeProjectCatalogTreesPort()
+        )
+
+        // WHEN
+        val result = checker.check(
+            CatalogUsageCheckRequest(
+                projectRootDirectory = rootDir,
+                includedBuilds = listOf(
+                    FigmaDesignModelIncludedBuildSource(
+                        modelName = "gradlePlugins",
+                        settingsFile = rootDir.resolve("repo/gradle-plugins/settings.gradle.kts"),
+                        rootDirectory = rootDir.resolve("repo/gradle-plugins"),
+                        modulePathPrefix = ":gradle-plugins",
+                        publishesCatalogs = true,
+                        publishesConventionPlugins = true
+                    )
+                )
+            )
+        )
+
+        // THEN
+        result.unusedEntries shouldBe listOf(
+            UnusedCatalogEntry(
+                catalogName = "gradlePlugins.libraries",
+                entry = "io.ktor:ktor-client-core"
+            ),
+            UnusedCatalogEntry(
+                catalogName = "gradlePlugins.plugins",
+                entry = "org.jetbrains.dokka"
+            ),
+            UnusedCatalogEntry(
+                catalogName = "waterMyPlants.libraries",
+                entry = "androidx.datastore:datastore"
+            ),
+            UnusedCatalogEntry(
+                catalogName = "waterMyPlants.plugins",
+                entry = "com.google.protobuf"
+            )
+        )
+    }
+})
+
+private class FakeProjectCatalogTreesPort : ProjectCatalogTreesPort {
+    override fun readLibraryTree(source: ProjectCatalogTreeSource): LibraryCatalogTree =
+        when (source) {
+            is ProjectCatalogTreeSource.DependenciesDslVersionAliases -> LibraryCatalogTree(
+                roots = listOf(
+                    LibraryCatalogNode(
+                        group = "androidx",
+                        children = listOf(
+                            LibraryCatalogNode(
+                                group = "datastore",
+                                entries = listOf(
+                                    LibraryCatalogEntry.Artifact(
+                                        artifact = "datastore",
+                                        version = CatalogVersion("datastoreVersion")
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    LibraryCatalogNode(
+                        group = "com",
+                        children = listOf(
+                            LibraryCatalogNode(
+                                group = "google",
+                                children = listOf(
+                                    LibraryCatalogNode(
+                                        group = "protobuf",
+                                        entries = listOf(
+                                            LibraryCatalogEntry.Artifact(
+                                                artifact = "protobuf-kotlin",
+                                                version = CatalogVersion("protobufLibraryVersion"),
+                                                providedByConventionPlugins = listOf(
+                                                    ConventionPluginUsage(
+                                                        pluginId = "com.marmatsan.protobuf",
+                                                        pluginModule = ":gradle-plugins:protobuf"
+                                                    )
+                                                )
+                                            ),
+                                            LibraryCatalogEntry.Artifact(
+                                                artifact = "protoc",
+                                                version = CatalogVersion("protobufLibraryVersion"),
+                                                configuredByConventionPlugins = listOf(
+                                                    ConventionPluginConfigurationUsage(
+                                                        pluginId = "com.marmatsan.protobuf",
+                                                        pluginModule = ":gradle-plugins:protobuf",
+                                                        target = "protobuf.protoc.artifact"
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            is ProjectCatalogTreeSource.IncludedBuildSettings -> LibraryCatalogTree(
+                roots = listOf(
+                    LibraryCatalogNode(
+                        group = "io",
+                        children = listOf(
+                            LibraryCatalogNode(
+                                group = "ktor",
+                                entries = listOf(
+                                    LibraryCatalogEntry.Artifact(
+                                        artifact = "ktor-client-core",
+                                        version = CatalogVersion(null)
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            is ProjectCatalogTreeSource.CustomGradleConventionPlugins,
+            is ProjectCatalogTreeSource.CustomGradlePlugins ->
+                error("Custom Gradle plugin inventories are not dependency catalogs")
+        }
+
+    override fun readPluginTree(source: ProjectCatalogTreeSource): PluginCatalogTree =
+        when (source) {
+            is ProjectCatalogTreeSource.DependenciesDslVersionAliases -> PluginCatalogTree(
+                roots = listOf(
+                    PluginCatalogNode(
+                        id = "com",
+                        children = listOf(
+                            PluginCatalogNode(
+                                id = "google",
+                                children = listOf(
+                                    PluginCatalogNode(
+                                        id = "protobuf",
+                                        version = CatalogVersion("protobufPluginVersion")
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    PluginCatalogNode(
+                        id = "org",
+                        children = listOf(
+                            PluginCatalogNode(
+                                id = "jetbrains",
+                                children = listOf(
+                                    PluginCatalogNode(
+                                        id = "kotlin",
+                                        children = listOf(
+                                            PluginCatalogNode(
+                                                id = "plugin",
+                                                children = listOf(
+                                                    PluginCatalogNode(
+                                                        id = "compose",
+                                                        version = CatalogVersion("kotlinVersion"),
+                                                        providedByConventionPlugins = listOf(
+                                                            PluginCatalogNode.ConventionPluginUsage(
+                                                                pluginId = "com.marmatsan.compose",
+                                                                pluginModule = ":gradle-plugins:compose"
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            is ProjectCatalogTreeSource.IncludedBuildSettings -> PluginCatalogTree(
+                roots = listOf(
+                    PluginCatalogNode(
+                        id = "org",
+                        children = listOf(
+                            PluginCatalogNode(
+                                id = "jetbrains",
+                                children = listOf(
+                                    PluginCatalogNode(
+                                        id = "dokka",
+                                        version = CatalogVersion("dokkaVersion")
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            is ProjectCatalogTreeSource.CustomGradleConventionPlugins,
+            is ProjectCatalogTreeSource.CustomGradlePlugins ->
+                error("Custom Gradle plugin inventories are not dependency catalogs")
+        }
+}

--- a/repo/figma-design-sync/settings.gradle.kts
+++ b/repo/figma-design-sync/settings.gradle.kts
@@ -139,12 +139,6 @@ dependencyResolutionManagement {
                 artifact = "kotest-assertions-core"
             ).version(version("kotestVersion"))
 
-            // MockK
-            library(
-                alias = "io.mockk",
-                group = "io.mockk",
-                artifact = "mockk"
-            ).version(version("mockkVersion"))
         }
 
         create("plugins") {

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -44,10 +44,10 @@ export const TREE_NODE_PROPS = {
   showPluginVersion: "Show plugin version#58719:0",
   showArtifacts: "Show artifacts#63079:0",
   pluginVersion: "Plugin version#63081:2",
-  showUsedByModule: "Show used by module",
+  showAppliedByModule: "Show applied by module",
   showUsedByConventionPlugin: "Show used by convention plugin",
-  showUnusedCatalogEntry: "Show unused catalog entry",
-  showIsGradleConventionPlugin: "Show is a gradle plugin#63112:4",
+  showUnused: "Show unused",
+  showIsGradlePlugin: "Show is a gradle plugin#63112:4",
   type: "Type",
 };
 
@@ -58,7 +58,6 @@ export const ARTIFACT_PROPS = {
   showAppliedByPlugin: "Show applied by plugin",
   showUsedByModule: "Show used by module",
   showConfiguredAsTool: "Show configured as tool",
-  showUnusedCatalogEntry: "Show unused catalog entry",
 };
 
 export const ARTIFACTS_BUNDLE_PROPS = {
@@ -67,7 +66,6 @@ export const ARTIFACTS_BUNDLE_PROPS = {
   showVersion: "With version",
   showAppliedByPlugin: "Show applied by plugin",
   showUsedByModule: "Show used by module",
-  showUnusedCatalogEntry: "Show unused catalog entry",
 };
 
 export const ARTIFACT_INSTANCE_NAME = ".artifact";
@@ -104,13 +102,14 @@ export const CATALOG_TREE_TARGETS: CatalogTreeTarget[] = [
     name: "waterMyPlants.customGradleConventionPlugins",
     sectionNodeId: "63216:6907",
     type: "Plugin",
-    gradleConventionPluginNodes: true,
+    gradlePluginNodes: true,
     nodes: (designModel) => designModel.content?.catalogs?.waterMyPlants?.customGradleConventionPlugins,
   },
   {
     name: "waterMyPlants.customGradlePlugins",
     sectionNodeId: "63330:551",
     type: "Plugin",
+    gradlePluginNodes: true,
     warnWhenUnused: true,
     nodes: (designModel) => designModel.content?.catalogs?.waterMyPlants?.customGradlePlugins,
   },

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -111,6 +111,7 @@ export const CATALOG_TREE_TARGETS: CatalogTreeTarget[] = [
     name: "waterMyPlants.customGradlePlugins",
     sectionNodeId: "63330:551",
     type: "Plugin",
+    warnWhenUnused: true,
     nodes: (designModel) => designModel.content?.catalogs?.waterMyPlants?.customGradlePlugins,
   },
   {

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -8,7 +8,7 @@ export type CatalogTreeTarget = {
   sectionNodeId: string;
   type: CatalogTreeType;
   nodes: (designModel: DesignModel) => any[] | undefined;
-  gradleConventionPluginNodes?: boolean;
+  gradlePluginNodes?: boolean;
   warnWhenUnused?: boolean;
 };
 

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -9,6 +9,7 @@ export type CatalogTreeTarget = {
   type: CatalogTreeType;
   nodes: (designModel: DesignModel) => any[] | undefined;
   gradleConventionPluginNodes?: boolean;
+  warnWhenUnused?: boolean;
 };
 
 export type FlattenedCatalogNode = Record<string, any> & {

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -72,6 +72,16 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     const sectionNodeId = options.sectionNodeOverrides?.[target.name] || target.sectionNodeId;
     const section = await requireSection(sectionNodeId);
     unlockSectionTreeForMutation(section, mutatedNodeIds);
+
+    if (!isPartialRootSync && scopedModelNodes.length === 0) {
+      hideEmptyCatalogTreeSection(section, mutatedNodeIds);
+      stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds);
+      resizeAncestorSectionsToFit(section, mutatedNodeIds);
+      lockOnlyRootSection(section, mutatedNodeIds);
+      continue;
+    }
+
+    showCatalogTreeSection(section, mutatedNodeIds);
     const instancesByLabel = collectTreeNodeInstancesByLabel(section, target.type);
     let connectors = collectTreeConnectors(section);
 
@@ -191,6 +201,20 @@ export function filterModelRoots(target, modelNodes, rootFilter) {
   }
 
   return filteredNodes;
+}
+
+function hideEmptyCatalogTreeSection(section, mutatedNodeIds) {
+  if (section.visible === false) return;
+
+  section.visible = false;
+  mutatedNodeIds.push(section.id);
+}
+
+function showCatalogTreeSection(section, mutatedNodeIds) {
+  if (section.visible !== false) return;
+
+  section.visible = true;
+  mutatedNodeIds.push(section.id);
 }
 
 function rootLabel(target, node) {

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -34,7 +34,6 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
     const requiredByModules = artifact.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(artifact.providedByConventionPlugins || []);
     const configuredByConventionPlugins = artifact.configuredByConventionPlugins || [];
-    const showUnusedCatalogEntry = false;
     artifactInstance.visible = true;
     syncArtifactIdentity(artifactInstance, artifact, mutatedNodeIds);
     syncStructuralSeparators(artifactInstance, mutatedNodeIds);
@@ -54,12 +53,6 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       artifactInstance,
       ARTIFACT_PROPS.showUsedByModule,
       requiredByModules.length > 0,
-      mutatedNodeIds
-    );
-    setBooleanComponentProperty(
-      artifactInstance,
-      ARTIFACT_PROPS.showUnusedCatalogEntry,
-      showUnusedCatalogEntry,
       mutatedNodeIds
     );
     mutatedNodeIds.push(artifactInstance.id);
@@ -83,7 +76,6 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       mutatedNodeIds
     );
     setUsageBlockVisible(artifactInstance, USED_BY_MODULE_HEADING, requiredByModules.length > 0, mutatedNodeIds);
-    setUsageBlockVisible(artifactInstance, UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry, mutatedNodeIds);
     syncDirectUsageSeparators(artifactInstance, mutatedNodeIds);
     assertUsageSurface(
       artifactInstance,
@@ -91,7 +83,6 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
         [APPLIED_BY_PLUGIN_HEADING, providedByConventionPlugins.length > 0],
         [TOOL_ARTIFACTS_HEADING, configuredByConventionPlugins.length > 0],
         [USED_BY_MODULE_HEADING, requiredByModules.length > 0],
-        [UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry],
       ]
     );
   }
@@ -114,7 +105,6 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
     const bundle = bundles[index];
     const requiredByModules = bundle.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(bundle.providedByConventionPlugins || []);
-    const showUnusedCatalogEntry = false;
     bundleInstance.visible = true;
     syncBundleIdentity(bundleInstance, bundle, mutatedNodeIds);
     syncBundleArtifactInstances(bundleInstance, bundle.artifacts || [], mutatedNodeIds);
@@ -129,12 +119,6 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
       bundleInstance,
       ARTIFACTS_BUNDLE_PROPS.showUsedByModule,
       requiredByModules.length > 0,
-      mutatedNodeIds
-    );
-    setBooleanComponentProperty(
-      bundleInstance,
-      ARTIFACTS_BUNDLE_PROPS.showUnusedCatalogEntry,
-      showUnusedCatalogEntry,
       mutatedNodeIds
     );
     mutatedNodeIds.push(bundleInstance.id);
@@ -158,16 +142,12 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
     setUsageBlockVisible(bundleInstance, USED_BY_MODULE_HEADING, requiredByModules.length > 0, mutatedNodeIds, {
       excludeArtifactDescendants: true,
     });
-    setUsageBlockVisible(bundleInstance, UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry, mutatedNodeIds, {
-      excludeArtifactDescendants: true,
-    });
     syncDirectUsageSeparators(bundleInstance, mutatedNodeIds, { excludeArtifactDescendants: true });
     assertUsageSurface(
       bundleInstance,
       [
         [APPLIED_BY_PLUGIN_HEADING, providedByConventionPlugins.length > 0],
         [USED_BY_MODULE_HEADING, requiredByModules.length > 0],
-        [UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry],
       ],
       { excludeArtifactDescendants: true }
     );
@@ -255,16 +235,9 @@ function syncBundleArtifactInstances(bundleInstance, artifacts, mutatedNodeIds) 
       false,
       mutatedNodeIds
     );
-    setBooleanComponentProperty(
-      artifactInstance,
-      ARTIFACT_PROPS.showUnusedCatalogEntry,
-      false,
-      mutatedNodeIds
-    );
     setUsageBlockVisible(artifactInstance, APPLIED_BY_PLUGIN_HEADING, false, mutatedNodeIds);
     setUsageBlockVisible(artifactInstance, TOOL_ARTIFACTS_HEADING, false, mutatedNodeIds);
     setUsageBlockVisible(artifactInstance, USED_BY_MODULE_HEADING, false, mutatedNodeIds);
-    setUsageBlockVisible(artifactInstance, UNUSED_CATALOG_ENTRY_HEADING, false, mutatedNodeIds);
     syncDirectUsageSeparators(artifactInstance, mutatedNodeIds);
     assertUsageSurface(
       artifactInstance,
@@ -272,7 +245,6 @@ function syncBundleArtifactInstances(bundleInstance, artifacts, mutatedNodeIds) 
         [APPLIED_BY_PLUGIN_HEADING, false],
         [TOOL_ARTIFACTS_HEADING, false],
         [USED_BY_MODULE_HEADING, false],
-        [UNUSED_CATALOG_ENTRY_HEADING, false],
       ]
     );
   }
@@ -313,13 +285,13 @@ export async function updatePluginUsageBlocks(
   mutatedNodeIds
 ) {
   const providedByConventionPluginChips = usageChipsForConventionPlugins(providedByConventionPlugins || []);
-  const showUsedByModule = appliedToModules.length > 0;
+  const showAppliedByModule = appliedToModules.length > 0;
   const showUsedByConventionPlugin = providedByConventionPluginChips.length > 0;
 
   setBooleanComponentProperty(
     root,
-    TREE_NODE_PROPS.showUsedByModule,
-    showUsedByModule,
+    TREE_NODE_PROPS.showAppliedByModule,
+    showAppliedByModule,
     mutatedNodeIds
   );
   setBooleanComponentProperty(
@@ -330,7 +302,7 @@ export async function updatePluginUsageBlocks(
   );
   setBooleanComponentProperty(
     root,
-    TREE_NODE_PROPS.showUnusedCatalogEntry,
+    TREE_NODE_PROPS.showUnused,
     showUnusedPluginWarning,
     mutatedNodeIds
   );
@@ -344,18 +316,18 @@ export async function updatePluginUsageBlocks(
   setUsageBlockVisible(root, USED_BY_CONVENTION_PLUGIN_HEADING, showUsedByConventionPlugin, mutatedNodeIds);
   await updateConsumerModuleInstances(
     root,
-    USED_BY_MODULE_HEADING,
+    APPLIED_BY_MODULE_HEADING,
     appliedToModules,
     mutatedNodeIds
   );
-  setUsageBlockVisible(root, USED_BY_MODULE_HEADING, showUsedByModule, mutatedNodeIds);
+  setUsageBlockVisible(root, APPLIED_BY_MODULE_HEADING, showAppliedByModule, mutatedNodeIds);
   setUsageBlockVisible(root, UNUSED_PLUGIN_WARNING_HEADINGS, showUnusedPluginWarning, mutatedNodeIds);
   syncDirectUsageSeparators(root, mutatedNodeIds);
   assertUsageSurface(
     root,
     [
       [USED_BY_CONVENTION_PLUGIN_HEADING, showUsedByConventionPlugin],
-      [USED_BY_MODULE_HEADING, showUsedByModule],
+      [APPLIED_BY_MODULE_HEADING, showAppliedByModule],
       [UNUSED_PLUGIN_WARNING_HEADINGS, showUnusedPluginWarning],
     ]
   );
@@ -861,17 +833,20 @@ const MODULE_VERTICAL_PADDING = 6;
 const STRUCTURAL_SEPARATOR_FRAME_NAME = "separator";
 const USAGE_SEPARATOR_FRAME_NAME = "usage separator";
 const APPLIED_BY_PLUGIN_HEADING = "Applied by plugin";
+const APPLIED_BY_MODULE_HEADING = "Applied by module";
 const USED_BY_MODULE_HEADING = "Used by module";
 const USED_BY_CONVENTION_PLUGIN_HEADING = "Used by convention plugin";
 const TOOL_ARTIFACTS_HEADING = "Tool artifacts";
 const UNUSED_CATALOG_ENTRY_HEADING = "Unused catalog entry";
-const UNUSED_PLUGIN_WARNING_HEADING = "Not used by module";
+const UNUSED_PLUGIN_WARNING_HEADING = "No module applies it";
 const UNUSED_PLUGIN_WARNING_HEADINGS = [
   UNUSED_PLUGIN_WARNING_HEADING,
+  "Not used by module",
   UNUSED_CATALOG_ENTRY_HEADING,
 ];
 const USAGE_BLOCK_HEADINGS = [
   APPLIED_BY_PLUGIN_HEADING,
+  APPLIED_BY_MODULE_HEADING,
   USED_BY_MODULE_HEADING,
   USED_BY_CONVENTION_PLUGIN_HEADING,
   TOOL_ARTIFACTS_HEADING,
@@ -881,6 +856,7 @@ const USAGE_BLOCK_HEADINGS = [
 const USAGE_BLOCK_FRAME_NAMES = new Set([
   ".usage block",
   "applied by plugin",
+  "applied by module",
   "used by module",
   "used by convention plugin",
   "configured as tool",
@@ -889,5 +865,6 @@ const USAGE_BLOCK_FRAME_NAMES = new Set([
   "applied by",
   "tool artifacts",
   "unused catalog entry",
+  "no module applies it",
   "not used by module",
 ]);

--- a/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -34,7 +34,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
     const requiredByModules = artifact.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(artifact.providedByConventionPlugins || []);
     const configuredByConventionPlugins = artifact.configuredByConventionPlugins || [];
-    const isUnused = isUnusedCatalogEntry(artifact);
+    const showUnusedCatalogEntry = false;
     artifactInstance.visible = true;
     syncArtifactIdentity(artifactInstance, artifact, mutatedNodeIds);
     syncStructuralSeparators(artifactInstance, mutatedNodeIds);
@@ -59,7 +59,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
     setBooleanComponentProperty(
       artifactInstance,
       ARTIFACT_PROPS.showUnusedCatalogEntry,
-      isUnused,
+      showUnusedCatalogEntry,
       mutatedNodeIds
     );
     mutatedNodeIds.push(artifactInstance.id);
@@ -83,7 +83,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
       mutatedNodeIds
     );
     setUsageBlockVisible(artifactInstance, USED_BY_MODULE_HEADING, requiredByModules.length > 0, mutatedNodeIds);
-    setUsageBlockVisible(artifactInstance, UNUSED_CATALOG_ENTRY_HEADING, isUnused, mutatedNodeIds);
+    setUsageBlockVisible(artifactInstance, UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry, mutatedNodeIds);
     syncDirectUsageSeparators(artifactInstance, mutatedNodeIds);
     assertUsageSurface(
       artifactInstance,
@@ -91,7 +91,7 @@ export async function updateLibraryArtifactConsumerModules(root, artifacts, muta
         [APPLIED_BY_PLUGIN_HEADING, providedByConventionPlugins.length > 0],
         [TOOL_ARTIFACTS_HEADING, configuredByConventionPlugins.length > 0],
         [USED_BY_MODULE_HEADING, requiredByModules.length > 0],
-        [UNUSED_CATALOG_ENTRY_HEADING, isUnused],
+        [UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry],
       ]
     );
   }
@@ -114,7 +114,7 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
     const bundle = bundles[index];
     const requiredByModules = bundle.requiredByModules || [];
     const providedByConventionPlugins = usageChipsForConventionPlugins(bundle.providedByConventionPlugins || []);
-    const isUnused = !hasConsumerUsage(bundle);
+    const showUnusedCatalogEntry = false;
     bundleInstance.visible = true;
     syncBundleIdentity(bundleInstance, bundle, mutatedNodeIds);
     syncBundleArtifactInstances(bundleInstance, bundle.artifacts || [], mutatedNodeIds);
@@ -134,7 +134,7 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
     setBooleanComponentProperty(
       bundleInstance,
       ARTIFACTS_BUNDLE_PROPS.showUnusedCatalogEntry,
-      isUnused,
+      showUnusedCatalogEntry,
       mutatedNodeIds
     );
     mutatedNodeIds.push(bundleInstance.id);
@@ -158,7 +158,7 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
     setUsageBlockVisible(bundleInstance, USED_BY_MODULE_HEADING, requiredByModules.length > 0, mutatedNodeIds, {
       excludeArtifactDescendants: true,
     });
-    setUsageBlockVisible(bundleInstance, UNUSED_CATALOG_ENTRY_HEADING, isUnused, mutatedNodeIds, {
+    setUsageBlockVisible(bundleInstance, UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry, mutatedNodeIds, {
       excludeArtifactDescendants: true,
     });
     syncDirectUsageSeparators(bundleInstance, mutatedNodeIds, { excludeArtifactDescendants: true });
@@ -167,7 +167,7 @@ export async function updateLibraryBundleConsumerModules(root, bundles, mutatedN
       [
         [APPLIED_BY_PLUGIN_HEADING, providedByConventionPlugins.length > 0],
         [USED_BY_MODULE_HEADING, requiredByModules.length > 0],
-        [UNUSED_CATALOG_ENTRY_HEADING, isUnused],
+        [UNUSED_CATALOG_ENTRY_HEADING, showUnusedCatalogEntry],
       ],
       { excludeArtifactDescendants: true }
     );
@@ -309,7 +309,7 @@ export async function updatePluginUsageBlocks(
   root,
   appliedToModules,
   providedByConventionPlugins,
-  isUnused,
+  showUnusedPluginWarning,
   mutatedNodeIds
 ) {
   const providedByConventionPluginChips = usageChipsForConventionPlugins(providedByConventionPlugins || []);
@@ -331,7 +331,7 @@ export async function updatePluginUsageBlocks(
   setBooleanComponentProperty(
     root,
     TREE_NODE_PROPS.showUnusedCatalogEntry,
-    isUnused,
+    showUnusedPluginWarning,
     mutatedNodeIds
   );
 
@@ -349,14 +349,14 @@ export async function updatePluginUsageBlocks(
     mutatedNodeIds
   );
   setUsageBlockVisible(root, USED_BY_MODULE_HEADING, showUsedByModule, mutatedNodeIds);
-  setUsageBlockVisible(root, UNUSED_CATALOG_ENTRY_HEADING, isUnused, mutatedNodeIds);
+  setUsageBlockVisible(root, UNUSED_PLUGIN_WARNING_HEADINGS, showUnusedPluginWarning, mutatedNodeIds);
   syncDirectUsageSeparators(root, mutatedNodeIds);
   assertUsageSurface(
     root,
     [
       [USED_BY_CONVENTION_PLUGIN_HEADING, showUsedByConventionPlugin],
       [USED_BY_MODULE_HEADING, showUsedByModule],
-      [UNUSED_CATALOG_ENTRY_HEADING, isUnused],
+      [UNUSED_PLUGIN_WARNING_HEADINGS, showUnusedPluginWarning],
     ]
   );
 }
@@ -457,15 +457,15 @@ async function setToolArtifactUsageInstance(toolArtifactUsageInstance, usage, mu
 
 function setUsageBlockVisible(
   root,
-  heading,
+  headingOrHeadings,
   visible,
   mutatedNodeIds,
   options: ConsumerModuleOptions = {}
 ) {
-  const usageBlock = findUsageBlock(root, heading, options);
+  const usageBlock = findUsageBlock(root, headingOrHeadings, options);
   if (!usageBlock) {
     if (visible) {
-      throw new Error(`Node '${root.id}' is missing '${heading}' usage block.`);
+      throw new Error(`Node '${root.id}' is missing '${headingLabel(headingOrHeadings)}' usage block.`);
     }
     return;
   }
@@ -473,23 +473,26 @@ function setUsageBlockVisible(
   setNodeVisible(usageBlock, visible, mutatedNodeIds);
 }
 
-function findUsageBlock(root, heading, options: ConsumerModuleOptions = {}) {
-  const blockName = heading.toLowerCase();
+function findUsageBlock(root, headingOrHeadings, options: ConsumerModuleOptions = {}) {
+  const headings = headingsOf(headingOrHeadings);
+  const blockNames = headings.map((heading) => heading.toLowerCase());
   const directBlock = childrenOf(root)
     .find((child) =>
-      child.name === blockName &&
+      blockNames.includes(child.name) &&
       !isExcludedByOptions(child, root, options)
     );
   if (directBlock) return directBlock;
 
   const namedBlock = root.findAllWithCriteria({ types: ["FRAME"] })
     .find((frame) =>
-      frame.name === blockName &&
+      blockNames.includes(frame.name) &&
       !isExcludedByOptions(frame, root, options)
     );
   if (namedBlock) return namedBlock;
 
-  const headingNode = findUsageChipHeading(root, heading, options);
+  const headingNode = headings
+    .map((heading) => findUsageChipHeading(root, heading, options))
+    .find(Boolean);
   if (!headingNode) return undefined;
 
   return nearestAncestorNamedUsageBlock(headingNode, root) ||
@@ -518,6 +521,7 @@ function syncDirectUsageSeparators(root, mutatedNodeIds, options: ConsumerModule
   const children = childrenOf(root);
   const usageBlockIds = new Set(
     [...USAGE_BLOCK_HEADINGS]
+      .flatMap(headingsOf)
       .map((heading) => findUsageBlock(root, heading, options))
       .filter(Boolean)
       .map((usageBlock) => usageBlock.id)
@@ -788,21 +792,36 @@ function setTextComponentProperty(instance, propertyName, value, mutatedNodeIds)
 }
 
 function assertUsageSurface(instance, expectedBlocks, options: ConsumerModuleOptions = {}) {
-  for (const [heading, expectedVisible] of expectedBlocks) {
-    const usageBlock = findUsageBlock(instance, heading, options);
+  for (const [headingOrHeadings, expectedVisible] of expectedBlocks) {
+    const usageBlock = findUsageBlock(instance, headingOrHeadings, options);
     const actualVisible = usageBlock?.visible === true;
     if (actualVisible !== expectedVisible) {
       throw new Error(
-        `Node '${instance.id}' has '${heading}' usage block visible='${actualVisible}', expected '${expectedVisible}'.`
+        `Node '${instance.id}' has '${headingLabel(headingOrHeadings)}' usage block ` +
+          `visible='${actualVisible}', expected '${expectedVisible}'.`
       );
     }
-    if (heading === UNUSED_CATALOG_ENTRY_HEADING && actualVisible && hasVisibleUsageChip(usageBlock)) {
+    if (isUnusedStatusHeading(headingOrHeadings) && actualVisible && hasVisibleUsageChip(usageBlock)) {
       throw new Error(
-        `Node '${instance.id}' has visible '${USAGE_CHIP_INSTANCE_NAME}' instances inside '${heading}'. ` +
-          "The unused catalog entry state must be rendered as a static status block."
+        `Node '${instance.id}' has visible '${USAGE_CHIP_INSTANCE_NAME}' instances inside ` +
+          `'${headingLabel(headingOrHeadings)}'. The unused status must be rendered as a static status block.`
       );
     }
   }
+}
+
+function headingsOf(headingOrHeadings) {
+  return Array.isArray(headingOrHeadings) ? headingOrHeadings : [headingOrHeadings];
+}
+
+function headingLabel(headingOrHeadings) {
+  return headingsOf(headingOrHeadings).join("' or '");
+}
+
+function isUnusedStatusHeading(headingOrHeadings) {
+  return headingsOf(headingOrHeadings).some((heading) =>
+    heading === UNUSED_CATALOG_ENTRY_HEADING || heading === UNUSED_PLUGIN_WARNING_HEADING
+  );
 }
 
 function hasVisibleUsageChip(usageBlock) {
@@ -837,16 +856,6 @@ function usageChipsForConventionPlugins(providedByConventionPlugins) {
   }));
 }
 
-function isUnusedCatalogEntry(entry) {
-  return entry.isCatalogEntry === true && !hasConsumerUsage(entry);
-}
-
-function hasConsumerUsage(entry) {
-  return (entry.requiredByModules || []).length > 0 ||
-    (entry.providedByConventionPlugins || []).length > 0 ||
-    (entry.configuredByConventionPlugins || []).length > 0;
-}
-
 const MODULE_HORIZONTAL_PADDING = 26;
 const MODULE_VERTICAL_PADDING = 6;
 const STRUCTURAL_SEPARATOR_FRAME_NAME = "separator";
@@ -856,12 +865,18 @@ const USED_BY_MODULE_HEADING = "Used by module";
 const USED_BY_CONVENTION_PLUGIN_HEADING = "Used by convention plugin";
 const TOOL_ARTIFACTS_HEADING = "Tool artifacts";
 const UNUSED_CATALOG_ENTRY_HEADING = "Unused catalog entry";
+const UNUSED_PLUGIN_WARNING_HEADING = "Not used by module";
+const UNUSED_PLUGIN_WARNING_HEADINGS = [
+  UNUSED_PLUGIN_WARNING_HEADING,
+  UNUSED_CATALOG_ENTRY_HEADING,
+];
 const USAGE_BLOCK_HEADINGS = [
   APPLIED_BY_PLUGIN_HEADING,
   USED_BY_MODULE_HEADING,
   USED_BY_CONVENTION_PLUGIN_HEADING,
   TOOL_ARTIFACTS_HEADING,
   UNUSED_CATALOG_ENTRY_HEADING,
+  UNUSED_PLUGIN_WARNING_HEADING,
 ];
 const USAGE_BLOCK_FRAME_NAMES = new Set([
   ".usage block",
@@ -874,4 +889,5 @@ const USAGE_BLOCK_FRAME_NAMES = new Set([
   "applied by",
   "tool artifacts",
   "unused catalog entry",
+  "not used by module",
 ]);

--- a/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -109,7 +109,8 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     ...providedByConventionPlugins.flatMap((usage) => usage.requiredByModules || []),
   ]);
   const isGradleConventionPlugin = target?.gradleConventionPluginNodes === true && node.children.length === 0;
-  const isUnusedCatalogEntry = (isPluginCatalogEntry(node) || isGradleConventionPlugin) &&
+  const showUnusedPluginWarning = target?.warnWhenUnused === true &&
+    node.children.length === 0 &&
     effectiveAppliedToModules.length === 0 &&
     providedByConventionPlugins.length === 0;
 
@@ -126,13 +127,13 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     instance,
     effectiveAppliedToModules,
     providedByConventionPlugins,
-    isUnusedCatalogEntry,
+    showUnusedPluginWarning,
     mutatedNodeIds
   );
 
   if (effectiveAppliedToModules.length === 0 &&
     providedByConventionPlugins.length === 0 &&
-    !isUnusedCatalogEntry &&
+    !showUnusedPluginWarning &&
     !isGradleConventionPlugin &&
     !hasVisiblePluginVersion(node)
   ) {
@@ -144,10 +145,6 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
 
 function hasVisiblePluginVersion(node: FlattenedCatalogNode) {
   return node.version?.visible === true && Boolean(node.version?.value);
-}
-
-function isPluginCatalogEntry(node: FlattenedCatalogNode) {
-  return node.version !== null && node.version !== undefined;
 }
 
 function resizeBareTreeNodeToFitLabel(instance, labelName, mutatedNodeIds) {

--- a/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -108,7 +108,7 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     ...appliedToModules,
     ...providedByConventionPlugins.flatMap((usage) => usage.requiredByModules || []),
   ]);
-  const isGradleConventionPlugin = target?.gradleConventionPluginNodes === true && node.children.length === 0;
+  const showGradlePluginBadge = target?.gradlePluginNodes === true && node.children.length === 0;
   const showUnusedPluginWarning = target?.warnWhenUnused === true &&
     node.children.length === 0 &&
     effectiveAppliedToModules.length === 0 &&
@@ -118,7 +118,7 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     [TREE_NODE_PROPS.pluginId]: node.label,
     [TREE_NODE_PROPS.pluginVersion]: versionValue,
     [TREE_NODE_PROPS.showPluginVersion]: node.version?.visible === true && Boolean(node.version?.value),
-    [TREE_NODE_PROPS.showIsGradleConventionPlugin]: isGradleConventionPlugin,
+    [TREE_NODE_PROPS.showIsGradlePlugin]: showGradlePluginBadge,
     [TREE_NODE_PROPS.type]: "Plugin",
   });
   mutatedNodeIds.push(instance.id);
@@ -134,7 +134,7 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
   if (effectiveAppliedToModules.length === 0 &&
     providedByConventionPlugins.length === 0 &&
     !showUnusedPluginWarning &&
-    !isGradleConventionPlugin &&
+    !showGradlePluginBadge &&
     !hasVisiblePluginVersion(node)
   ) {
     resizeBareTreeNodeToFitLabel(instance, "Plugin ID", mutatedNodeIds);


### PR DESCRIPTION
## Summary
- enforce unused dependency catalog entries through CI instead of visual unused blocks on artifacts/bundles
- rename plugin usage visual wording to `Applied by module`
- show repository-owned custom Gradle plugin leaves as Gradle plugins with a `No module applies it` warning when no Android module applies them yet
- update Figma sync runbooks for the new component contract

## Verification
- `npm run build`
- `npm test`
- `.\gradlew.bat check`