### PR TITLE
fix(figma-design-sync): normalize version grid and section reflow

### DIFF
--- a/repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt
+++ b/repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt
@@ -16,11 +16,11 @@ private fun comPluginTree(
     plugin("android") {
         plugin(
             id = "application",
-            version = versions.androidGradlePlugin
+            version = versions.androidGradlePluginVersion
         )
         plugin(
             id = "library",
-            version = versions.androidGradlePlugin
+            version = versions.androidGradlePluginVersion
         )
     }
     plugin("figma") {

--- a/repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/Versions.kt
+++ b/repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/Versions.kt
@@ -6,7 +6,7 @@ import java.util.Properties
 data class Versions(
     val activityComposeLibraryVersion: String,
     val androidCoroutinesLibraryVersion: String,
-    val androidGradlePlugin: String,
+    val androidGradlePluginVersion: String,
     val composeBomLibraryVersion: String,
     val coreKtxLibraryVersion: String,
     val cucumberLibraryVersion: String,
@@ -43,7 +43,7 @@ data class Versions(
             return Versions(
                 activityComposeLibraryVersion = get("activityComposeLibraryVersion"),
                 androidCoroutinesLibraryVersion = get("androidCoroutinesLibraryVersion"),
-                androidGradlePlugin = get("androidGradlePlugin"),
+                androidGradlePluginVersion = get("androidGradlePluginVersion"),
                 composeBomLibraryVersion = get("composeBomLibraryVersion"),
                 coreKtxLibraryVersion = get("coreKtxLibraryVersion"),
                 cucumberLibraryVersion = get("cucumberLibraryVersion"),

--- a/repo/dependency-catalog/versions.properties
+++ b/repo/dependency-catalog/versions.properties
@@ -1,6 +1,6 @@
 ## Main project dependencies
 # com.android.tools.build:gradle; Gradle plugins: com.android.application, com.android.library
-androidGradlePlugin=9.2.1
+androidGradlePluginVersion=9.2.1
 # org.jetbrains.kotlin:kotlin-gradle-plugin; Gradle plugins: org.jetbrains.kotlin.plugin.compose
 kotlinVersion=2.4.0
 ## Libraries

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/dependencies/catalog/DependenciesCatalogTreesReader.kt
@@ -509,7 +509,7 @@ private fun libraryAlias(
 private val CatalogVersionAliases = Versions(
     activityComposeLibraryVersion = "activityComposeLibraryVersion",
     androidCoroutinesLibraryVersion = "androidCoroutinesLibraryVersion",
-    androidGradlePlugin = "androidGradlePlugin",
+    androidGradlePluginVersion = "androidGradlePluginVersion",
     composeBomLibraryVersion = "composeBomLibraryVersion",
     coreKtxLibraryVersion = "coreKtxLibraryVersion",
     cucumberLibraryVersion = "cucumberLibraryVersion",

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/properties/versions/VersionsPropertiesReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/properties/versions/VersionsPropertiesReaderTest.kt
@@ -13,7 +13,7 @@ internal class VersionsPropertiesReaderTest : FunSpec({
             """
             ## Main project dependencies
             # com.android.tools.build:gradle
-            androidGradlePlugin=9.2.1
+            androidGradlePluginVersion=9.2.1
             ## Libraries
             # io.kotest:kotest-runner-junit5
             kotestLibraryVersion=6.2.1

--- a/repo/figma-design-sync/docs/runbooks/dependency-version-naming.md
+++ b/repo/figma-design-sync/docs/runbooks/dependency-version-naming.md
@@ -14,7 +14,7 @@ stable semantic grouping instead of using generic `*Version` keys.
 
 ```properties
 ## Main project dependencies
-androidGradlePlugin=...
+androidGradlePluginVersion=...
 kotlinVersion=...
 ## Libraries
 exampleLibraryVersion=...
@@ -24,14 +24,14 @@ examplePluginVersion=...
 
 Rules:
 
-- `Main project dependencies` contains only `androidGradlePlugin` and
+- `Main project dependencies` contains only `androidGradlePluginVersion` and
   `kotlinVersion`.
 - Library version keys must end with `LibraryVersion`, for example
   `activityComposeLibraryVersion`.
 - Plugin version keys must end with `PluginVersion`, for example
   `kspPluginVersion`.
 - Do not add new generic `*Version` keys to `Libraries` or `Plugins`.
-- If a plugin catalog node uses `androidGradlePlugin` or `kotlinVersion`, keep
+- If a plugin catalog node uses `androidGradlePluginVersion` or `kotlinVersion`, keep
   the version key in `Main project dependencies`; do not duplicate it as a
   plugin-specific key.
 

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -79,7 +79,7 @@ Important generation details:
   `repo/dependency-catalog/versions.properties` so the MCP sync can place
   visual version nodes in the correct frame.
 - `checkFigmaVersionNaming` runs through `.\gradlew.bat check` and enforces
-  the version key format rendered in Figma: only `androidGradlePlugin` and
+  the version key format rendered in Figma: only `androidGradlePluginVersion` and
   `kotlinVersion` live in `Main project dependencies`, library keys end with
   `LibraryVersion`, and plugin keys end with `PluginVersion`.
 - `content.catalogs` contains Water My Plants libraries/plugins, catalog data

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -73,7 +73,7 @@ For each repository version:
   `/<versionKey>`, such as `Libraries/kotestLibraryVersion`.
 - Keep the repository version sections semantically named:
   `Main project dependencies`, `Libraries`, and `Plugins`.
-- Keep `androidGradlePlugin` and `kotlinVersion` in
+- Keep `androidGradlePluginVersion` and `kotlinVersion` in
   `Main project dependencies`. These keys may be referenced by plugin catalog
   nodes, but their source version section remains the main project section.
 - Name library-owned version keys with the `LibraryVersion` suffix.
@@ -85,6 +85,11 @@ For each repository version:
 - Set `Version number` mode to the repository value.
 - Create a missing Figma variable under the matching section folder.
 - Create a missing `.dependency version` instance in the matching visual frame.
+- Layout `.dependency version` instances as a row-major grid with at most two
+  instances per row, 64 px between columns, and 32 px between rows.
+- Stack the visual frames for `Main project dependencies`, `Libraries`, and
+  `Plugins` with 128 px between one frame bottom edge and the next frame top
+  edge.
 - Remove stale `.dependency version` instances whose alias is no longer present
   in that version section, such as old keys left behind after renaming a library
   version to the `LibraryVersion` suffix.
@@ -336,6 +341,10 @@ Layout rules:
 - Stack direct child sections inside touched section containers with 114 px
   between one section bottom edge and the next section top edge. Apply the same
   spacing to ancestor section containers after their children are resized.
+- Reflowed direct child sections must start at the container padding, or below
+  the direct `.Header` plus the section gap when the container has a header.
+  Do not preserve the first child section's previous `y` after deleting an
+  earlier sibling; otherwise removed roots leave a stale top gap.
 - Direct child sections stacked inside the same container must share the same
   left edge. This keeps module sections such as `gradle-plugins` and
   `figma-design-sync` horizontally aligned when they belong to the same parent

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/versions/VersionNamingChecker.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/versions/VersionNamingChecker.kt
@@ -101,7 +101,7 @@ internal class VersionNamingChecker(
             PLUGINS_SECTION
         )
         val MAIN_PROJECT_DEPENDENCIES_KEYS = listOf(
-            "androidGradlePlugin",
+            "androidGradlePluginVersion",
             "kotlinVersion"
         )
     }

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/DesignModelSteps.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/DesignModelSteps.kt
@@ -126,7 +126,7 @@ class DesignModelSteps : En {
                 ?.keys
                 ?.toList() shouldBe listOf(
                     "activityComposeLibraryVersion",
-                    "androidGradlePlugin",
+                    "androidGradlePluginVersion",
                     "kotlinVersion",
                     "kspPluginVersion"
                 )
@@ -232,7 +232,7 @@ private object FakeRepositoryVersionsPort : RepositoryVersionsPort {
         mapOf(
             "activityComposeLibraryVersion" to "1.13.0",
             "kotlinVersion" to "2.4.0",
-            "androidGradlePlugin" to "9.2.1",
+            "androidGradlePluginVersion" to "9.2.1",
             "kspPluginVersion" to "2.3.9"
         )
 
@@ -241,7 +241,7 @@ private object FakeRepositoryVersionsPort : RepositoryVersionsPort {
             RepositoryVersionSection(
                 name = "Main project dependencies",
                 versions = mapOf(
-                    "androidGradlePlugin" to "9.2.1",
+                    "androidGradlePluginVersion" to "9.2.1",
                     "kotlinVersion" to "2.4.0"
                 )
             ),

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/GradleTaskSteps.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/GradleTaskSteps.kt
@@ -195,7 +195,7 @@ class GradleTaskSteps : En {
         resolve("repo/dependency-catalog/versions.properties").writeText(
             """
             ## Main project dependencies
-            androidGradlePlugin=9.2.1
+            androidGradlePluginVersion=9.2.1
             kotlinVersion=2.4.0
             """.trimIndent()
         )

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/versions/VersionNamingCheckerTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/versions/VersionNamingCheckerTest.kt
@@ -17,7 +17,7 @@ internal class VersionNamingCheckerTest : FunSpec({
                     RepositoryVersionSection(
                         name = "Main project dependencies",
                         versions = mapOf(
-                            "androidGradlePlugin" to "9.2.1",
+                            "androidGradlePluginVersion" to "9.2.1",
                             "kotlinVersion" to "2.4.0"
                         )
                     ),
@@ -59,7 +59,7 @@ internal class VersionNamingCheckerTest : FunSpec({
                     RepositoryVersionSection(
                         name = "Main project dependencies",
                         versions = mapOf(
-                            "androidGradlePlugin" to "9.2.1",
+                            "androidGradlePluginVersion" to "9.2.1",
                             "kotlinVersion" to "2.4.0",
                             "kspPluginVersion" to "2.3.9"
                         )
@@ -79,8 +79,8 @@ internal class VersionNamingCheckerTest : FunSpec({
         result.violations.map(VersionNamingViolation::message) shouldBe listOf(
             "Expected version sections in order: Main project dependencies, Libraries, Plugins. " +
                 "Found: Libraries, Main project dependencies, Plugins.",
-            "Main project dependencies must declare only androidGradlePlugin, kotlinVersion. " +
-                "Found: androidGradlePlugin, kotlinVersion, kspPluginVersion.",
+            "Main project dependencies must declare only androidGradlePluginVersion, kotlinVersion. " +
+                "Found: androidGradlePluginVersion, kotlinVersion, kspPluginVersion.",
             "Libraries version key 'activityComposeVersion' must end with 'LibraryVersion'.",
             "Plugins version key 'dokkaVersion' must end with 'PluginVersion'."
         )

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -70,7 +70,7 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
             ?.keys
             ?.toList() shouldBe listOf(
                 "activityComposeLibraryVersion",
-                "androidGradlePlugin",
+                "androidGradlePluginVersion",
                 "kotlinVersion",
                 "kspPluginVersion"
             )
@@ -269,7 +269,7 @@ private object FakeRepositoryVersionsPort : RepositoryVersionsPort {
         mapOf(
             "activityComposeLibraryVersion" to "1.13.0",
             "kotlinVersion" to "2.4.0",
-            "androidGradlePlugin" to "9.2.1",
+            "androidGradlePluginVersion" to "9.2.1",
             "kspPluginVersion" to "2.3.9"
         )
 
@@ -278,7 +278,7 @@ private object FakeRepositoryVersionsPort : RepositoryVersionsPort {
             RepositoryVersionSection(
                 name = "Main project dependencies",
                 versions = mapOf(
-                    "androidGradlePlugin" to "9.2.1",
+                    "androidGradlePluginVersion" to "9.2.1",
                     "kotlinVersion" to "2.4.0"
                 )
             ),

--- a/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
@@ -7,7 +7,7 @@
   "content": {
     "versions": {
       "activityComposeLibraryVersion": "1.9.3",
-      "androidGradlePlugin": "8.9.1",
+      "androidGradlePluginVersion": "8.9.1",
       "dokkaPluginVersion": "2.0.0",
       "kspPluginVersion": "2.1.10-1.0.31"
     },
@@ -98,7 +98,7 @@
                     "id": "android",
                     "version": {
                       "visible": true,
-                      "value": "androidGradlePlugin"
+                      "value": "androidGradlePluginVersion"
                     },
                     "appliedToModules": [
                       ":app",

--- a/repo/figma-design-sync/tools/fixtures/visual/versions.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/versions.design-model.json
@@ -7,7 +7,7 @@
   "content": {
     "versions": {
       "activityComposeLibraryVersion": "1.9.3",
-      "androidGradlePlugin": "8.9.1",
+      "androidGradlePluginVersion": "8.9.1",
       "dokkaPluginVersion": "2.0.0",
       "kotlinVersion": "2.1.10",
       "kspPluginVersion": "2.1.10-1.0.31"
@@ -16,7 +16,7 @@
       {
         "name": "Main project dependencies",
         "versions": {
-          "androidGradlePlugin": "8.9.1",
+          "androidGradlePluginVersion": "8.9.1",
           "kotlinVersion": "2.1.10"
         }
       },

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -21,6 +21,7 @@ import {
   removeCatalogTreeSectionFills,
   resizeAncestorSectionsToFit,
   resizeNodeToFit,
+  stackChildSectionsFromPadding,
   stackAncestorSectionSiblingsWithGap,
   stackDescendantSectionsWithGap,
   unlockSectionTreeForMutation,
@@ -268,7 +269,8 @@ function removeEmptyCatalogTreeTarget(target, section, mutatedNodeIds) {
   section.remove();
 
   if (parentSection) {
-    stackDescendantSectionsWithGap(parentSection, mutatedNodeIds);
+    stackChildSectionsFromPadding(parentSection, mutatedNodeIds);
+    resizeNodeToFit(parentSection, parentSection.children.filter((child) => child.visible !== false), mutatedNodeIds);
     stackAncestorSectionSiblingsWithGap(parentSection, mutatedNodeIds);
     resizeAncestorSectionsToFit(parentSection, mutatedNodeIds);
     lockOnlyRootSection(parentSection, mutatedNodeIds);

--- a/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
@@ -125,6 +125,10 @@ export function resizeNodeToFit(node, children, mutatedNodeIds, padding = 100) {
   }
 }
 
+export function stackChildSectionsFromPadding(parent, mutatedNodeIds, gap = SECTION_SIBLING_GAP, padding = 100) {
+  stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap, padding);
+}
+
 export function resizeAncestorSectionsToFit(node, mutatedNodeIds, padding = 100) {
   let current = node.parent;
 
@@ -248,14 +252,14 @@ function stackConfiguredPageSectionsWithGap(section, mutatedNodeIds, gap = PAREN
   }
 }
 
-function stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap) {
+function stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap, startY = firstSectionStartY(parent)) {
   const sections = directChildSections(parent)
     .sort((first, second) => first.y - second.y || first.x - second.x);
 
-  if (sections.length < 2) return;
+  if (sections.length === 0) return;
 
   const alignedX = sections[0].x;
-  let nextY = sections[0].y;
+  let nextY = startY;
   for (const section of sections) {
     if (Math.abs(section.x - alignedX) > 0.01) {
       section.x = alignedX;
@@ -267,6 +271,20 @@ function stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap) {
     }
     nextY = section.y + section.height + gap;
   }
+}
+
+function firstSectionStartY(parent) {
+  const nonSectionVisibleChildren = parent.children
+    .filter((child) => child.type !== "SECTION" && child.visible !== false);
+
+  if (nonSectionVisibleChildren.length === 0) {
+    return 100;
+  }
+
+  return Math.max(
+    100,
+    Math.max(...nonSectionVisibleChildren.map((child) => child.y + child.height + SECTION_SIBLING_GAP))
+  );
 }
 
 function directChildSections(parent) {

--- a/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
@@ -22,6 +22,11 @@ import {
 } from "./figma-node-gateway";
 import { collectText } from "./figma-text-gateway";
 
+const DEPENDENCY_VERSION_MAX_COLUMNS = 2;
+const DEPENDENCY_VERSION_COLUMN_GAP = 64;
+const DEPENDENCY_VERSION_ROW_GAP = 32;
+const VERSION_SECTION_GAP = 128;
+
 export class FigmaVersionSyncGateway implements VersionSyncGateway {
   async syncVersions(designModel: DesignModel) {
     const versionSections = requireVersionSections(designModel);
@@ -35,6 +40,7 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
     const createdVariables = [];
     const createdInstances = [];
     const updatedVersions = [];
+    const syncedParents = [];
 
     for (const section of versionSections) {
       const target = VERSION_SECTION_TARGETS[section.name];
@@ -44,10 +50,11 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
 
       const parent = await requireFrame(target.parentNodeId);
       const entries = Object.entries(section.versions);
+      const orderedVersionKeys = entries.map(([versionKey]) => versionKey);
       const existingInstances = findDependencyVersionInstances(parent);
       const instancePlan = planDependencyVersionInstanceSync(
         existingInstances,
-        entries.map(([versionKey]) => versionKey),
+        orderedVersionKeys,
         readDependencyVersionKey
       );
 
@@ -77,11 +84,8 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
         let instance = instancePlan.existingInstancesByVersionKey.get(versionKey);
         if (!instance) {
           instance = dependencyVersionComponent.createInstance();
-          const position = nextDependencyVersionPosition(parent);
 
           parent.appendChild(instance);
-          instance.x = position.x;
-          instance.y = position.y;
 
           mutatedNodeIds.push(instance.id);
           createdInstances.push(versionKey);
@@ -91,9 +95,18 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
         mutatedNodeIds.push(variable.id);
       }
 
+      layoutDependencyVersionGrid(parent, orderedVersionKeys, readDependencyVersionKey, mutatedNodeIds);
       resizeNodeToFit(parent, parent.children.filter((child) => child.visible !== false), mutatedNodeIds);
-      stackAncestorSectionSiblingsWithGap(parent, mutatedNodeIds);
-      resizeAncestorSectionsToFit(parent, mutatedNodeIds);
+      syncedParents.push(parent);
+    }
+
+    stackVersionSectionFrames(syncedParents, mutatedNodeIds);
+    for (const parent of syncedParents) {
+      resizeNodeToFit(parent, parent.children.filter((child) => child.visible !== false), mutatedNodeIds);
+    }
+    if (syncedParents[0]) {
+      stackAncestorSectionSiblingsWithGap(syncedParents[0], mutatedNodeIds);
+      resizeAncestorSectionsToFit(syncedParents[0], mutatedNodeIds);
     }
 
     return {
@@ -158,32 +171,68 @@ function readDependencyVersionKey(instance) {
     .find(Boolean);
 }
 
-function nextDependencyVersionPosition(parent): { x: number; y: number } {
-  const instances = parent.children
-    .filter((child) => child.type === "INSTANCE" && DEPENDENCY_VERSION_INSTANCE_NAMES.includes(child.name))
-    .sort((first, second) => first.y - second.y || first.x - second.x);
-
-  if (instances.length === 0) {
-    return { x: 0, y: 0 };
-  }
-
-  const columnXs: number[] = [...new Set<number>(instances.map((instance) => Math.round(instance.x)))]
-    .sort((first, second) => first - second)
-    .slice(0, 2);
-
-  if (columnXs.length === 1) {
-    columnXs.push(columnXs[0] + Math.round(instances[0].width) + 64);
-  }
-
-  const nextColumnIndex = instances.length % columnXs.length;
-  const columnInstances = instances.filter((instance) => Math.round(instance.x) === columnXs[nextColumnIndex]);
-  const lastInColumn = columnInstances.at(-1);
-  const rowGap = 64;
+export function dependencyVersionGridPosition(index: number, itemWidth: number, rowHeights: number[]): { x: number; y: number } {
+  const column = index % DEPENDENCY_VERSION_MAX_COLUMNS;
+  const row = Math.floor(index / DEPENDENCY_VERSION_MAX_COLUMNS);
+  const y = rowHeights
+    .slice(0, row)
+    .reduce((sum, height) => sum + height + DEPENDENCY_VERSION_ROW_GAP, 0);
 
   return {
-    x: columnXs[nextColumnIndex],
-    y: lastInColumn ? lastInColumn.y + lastInColumn.height + rowGap : 0,
+    x: column * (itemWidth + DEPENDENCY_VERSION_COLUMN_GAP),
+    y,
   };
+}
+
+function layoutDependencyVersionGrid(parent, orderedVersionKeys, readVersionKey, mutatedNodeIds) {
+  const instancesByVersionKey = new Map(
+    findDependencyVersionInstances(parent)
+      .map((instance) => [readVersionKey(instance), instance])
+      .filter(([versionKey]) => Boolean(versionKey))
+  );
+  const orderedInstances = orderedVersionKeys
+    .map((versionKey) => instancesByVersionKey.get(versionKey))
+    .filter(Boolean);
+
+  if (orderedInstances.length === 0) return;
+
+  const columnWidth = Math.max(...orderedInstances.map((instance) => instance.width));
+  const rowHeights = [];
+  for (let index = 0; index < orderedInstances.length; index += DEPENDENCY_VERSION_MAX_COLUMNS) {
+    rowHeights.push(
+      Math.max(...orderedInstances.slice(index, index + DEPENDENCY_VERSION_MAX_COLUMNS).map((instance) => instance.height))
+    );
+  }
+
+  orderedInstances.forEach((instance, index) => {
+    const position = dependencyVersionGridPosition(index, columnWidth, rowHeights);
+    if (Math.abs(instance.x - position.x) > 0.01) {
+      instance.x = position.x;
+      mutatedNodeIds.push(instance.id);
+    }
+    if (Math.abs(instance.y - position.y) > 0.01) {
+      instance.y = position.y;
+      mutatedNodeIds.push(instance.id);
+    }
+  });
+}
+
+function stackVersionSectionFrames(frames, mutatedNodeIds) {
+  if (frames.length < 2) return;
+
+  const alignedX = frames[0].x;
+  let nextY = frames[0].y;
+  for (const frame of frames) {
+    if (Math.abs(frame.x - alignedX) > 0.01) {
+      frame.x = alignedX;
+      mutatedNodeIds.push(frame.id);
+    }
+    if (Math.abs(frame.y - nextY) > 0.01) {
+      frame.y = nextY;
+      mutatedNodeIds.push(frame.id);
+    }
+    nextY = frame.y + frame.height + VERSION_SECTION_GAP;
+  }
 }
 
 function bindDependencyVersionInstance(instance, variable) {

--- a/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
+++ b/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
@@ -5,6 +5,7 @@ import {
   removeEmptyStaleCatalogRootSections,
   removeStaleCatalogNodes,
 } from "../src/figma/figma-catalog-tree-sync-gateway";
+import { stackChildSectionsFromPadding } from "../src/figma/figma-node-gateway";
 
 const target = { name: "waterMyPlants.libraries" };
 
@@ -145,6 +146,34 @@ test("stale empty root section cleanup can remove empty roots outside a partial 
   assert.deepEqual(section.children.map((child) => child.name), ["com", "io"]);
 });
 
+test("child section reflow normalizes the first remaining root to container padding", () => {
+  const mutatedNodeIds = [];
+  const section = parentSection([
+    positionedChildSection("io", 100, 1458, 2353, 1898),
+    positionedChildSection("me", 100, 3470, 948, 1445),
+    positionedChildSection("org", 100, 5029, 1690, 1445),
+  ]);
+
+  stackChildSectionsFromPadding(section, mutatedNodeIds);
+
+  assert.equal(section.children[0].y, 100);
+  assert.equal(section.children[1].y, 2112);
+  assert.equal(section.children[2].y, 3671);
+  assert.deepEqual(mutatedNodeIds, ["io-id", "me-id", "org-id"]);
+});
+
+test("child section reflow normalizes a single remaining root", () => {
+  const mutatedNodeIds = [];
+  const section = parentSection([
+    positionedChildSection("org", 100, 5029, 1690, 1445),
+  ]);
+
+  stackChildSectionsFromPadding(section, mutatedNodeIds);
+
+  assert.equal(section.children[0].y, 100);
+  assert.deepEqual(mutatedNodeIds, ["org-id"]);
+});
+
 function catalogNode(label: string, parentPath: string[] = []) {
   return {
     label,
@@ -206,5 +235,20 @@ function childSection(name: string, childIds: string[]) {
         this.parent.children.splice(index, 1);
       }
     },
+  };
+}
+
+function positionedChildSection(name: string, x: number, y: number, width: number, height: number) {
+  return {
+    id: `${name}-id`,
+    name,
+    type: "SECTION",
+    visible: true,
+    x,
+    y,
+    width,
+    height,
+    children: [],
+    parent: null,
   };
 }

--- a/repo/figma-design-sync/tools/tests/version-sync-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/version-sync-plan.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { planDependencyVersionInstanceSync } from "../src/figma/figma-version-sync-gateway";
+import {
+  dependencyVersionGridPosition,
+  planDependencyVersionInstanceSync,
+} from "../src/figma/figma-version-sync-gateway";
 
 test("version sync removes stale renamed dependency versions and exact duplicates", () => {
   const instances = [
@@ -28,6 +31,16 @@ test("version sync removes stale renamed dependency versions and exact duplicate
     plan.duplicateInstances.map((instance) => instance.id),
     ["duplicate-current-library-name"]
   );
+});
+
+test("dependency version grid positions two items per row with documented gaps", () => {
+  const rowHeights = [40, 52, 36];
+
+  assert.deepEqual(dependencyVersionGridPosition(0, 300, rowHeights), { x: 0, y: 0 });
+  assert.deepEqual(dependencyVersionGridPosition(1, 300, rowHeights), { x: 364, y: 0 });
+  assert.deepEqual(dependencyVersionGridPosition(2, 300, rowHeights), { x: 0, y: 72 });
+  assert.deepEqual(dependencyVersionGridPosition(3, 300, rowHeights), { x: 364, y: 72 });
+  assert.deepEqual(dependencyVersionGridPosition(4, 300, rowHeights), { x: 0, y: 156 });
 });
 
 function dependencyVersion(id: string, versionKey: string) {

--- a/repo/gradle-plugins/AGENTS.md
+++ b/repo/gradle-plugins/AGENTS.md
@@ -35,7 +35,7 @@ This directory contains Gradle convention plugins used by the rest of the projec
 - Plugin dependency trees are in `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/PluginTrees.kt`.
 - When adding a new version key, update `repo/dependency-catalog/src/main/kotlin/com/marmatsan/dependencies/Versions.kt` and the tree definitions that consume it.
 - Version keys under `Libraries` must end with `LibraryVersion`; version keys
-  under `Plugins` must end with `PluginVersion`; only `androidGradlePlugin` and
+  under `Plugins` must end with `PluginVersion`; only `androidGradlePluginVersion` and
   `kotlinVersion` belong under `Main project dependencies`.
 - Run `.\gradlew.bat checkFigmaVersionNaming checkFigmaCatalogUsage` after
   adding or moving dependency catalog entries.

--- a/repo/gradle-plugins/settings.gradle.kts
+++ b/repo/gradle-plugins/settings.gradle.kts
@@ -41,7 +41,7 @@ dependencyResolutionManagement {
                 alias = "com.android.tools.build.gradle",
                 group = "com.android.tools.build",
                 artifact = "gradle"
-            ).version(version("androidGradlePlugin"))
+            ).version(version("androidGradlePluginVersion"))
 
             library(
                 alias = "com.google.protobuf.gradle.plugin",


### PR DESCRIPTION
## Summary

- Normalize catalog child-section reflow after stale root removal so deleted roots do not leave top gaps in Figma.
- Render dependency versions in a deterministic two-column grid with documented spacing.
- Rename the main Android Gradle Plugin version key to `androidGradlePluginVersion` across catalog code, fixtures, checks, and documentation.

## Validation

- `npm run test` in `repo/figma-design-sync/tools`
- `npm run build` in `repo/figma-design-sync/tools`
- `./gradlew.bat check`
- `git diff --check`

## Figma sync

This changes generated model content, so the official Figma sync must run after merge from TeamCity's `main` artifact.