### PR TITLE
fix(figma-design-sync): bind version sync to rebuilt sections

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -73,6 +73,12 @@ For each repository version:
   `/<versionKey>`, such as `Libraries/kotestLibraryVersion`.
 - Keep the repository version sections semantically named:
   `Main project dependencies`, `Libraries`, and `Plugins`.
+- Map those semantic sections to the visual subsections named `main versions`,
+  `library versions`, and `plugin versions` in Figma. These subsection node ids
+  are part of `figma-config.ts`; update them whenever the `.dependency version`
+  component area is rebuilt manually. The version visual containers may be
+  Figma `SECTION` nodes or `FRAME` nodes as long as they own the direct
+  `.dependency version` instances.
 - Keep `androidGradlePluginVersion` and `kotlinVersion` in
   `Main project dependencies`. These keys may be referenced by plugin catalog
   nodes, but their source version section remains the main project section.

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -31,15 +31,15 @@ export const CONNECTOR_TEMPLATE_NAME = "simple-solid_arrow";
 
 export const VERSION_SECTION_TARGETS = {
   "Main project dependencies": {
-    parentNodeId: "63075:634",
+    parentNodeId: "64247:3827",
     variableFolder: "Main project dependencies",
   },
   Libraries: {
-    parentNodeId: "63075:644",
+    parentNodeId: "64247:3853",
     variableFolder: "Libraries",
   },
   Plugins: {
-    parentNodeId: "63075:804",
+    parentNodeId: "64247:3854",
     variableFolder: "Plugins",
   },
 };

--- a/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
@@ -53,6 +53,14 @@ export async function requireFrame(nodeId) {
   return node;
 }
 
+export async function requireFrameOrSection(nodeId) {
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node || (node.type !== "FRAME" && node.type !== "SECTION")) {
+    throw new Error(`Expected '${nodeId}' to be a FRAME or SECTION.`);
+  }
+  return node;
+}
+
 export async function requirePage(nodeId) {
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node || node.type !== "PAGE") {

--- a/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
@@ -12,7 +12,7 @@ import type { VersionSyncGateway } from "../ports/sync-gateways";
 import {
   loadVariablesByVersionKey,
   requireComponent,
-  requireFrame,
+  requireFrameOrSection,
   requireModeId,
   requireVariableCollection,
   resizeAncestorSectionsToFit,
@@ -48,7 +48,7 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
         throw new Error(`No Figma target configured for version section '${section.name}'.`);
       }
 
-      const parent = await requireFrame(target.parentNodeId);
+      const parent = await requireFrameOrSection(target.parentNodeId);
       const entries = Object.entries(section.versions);
       const orderedVersionKeys = entries.map(([versionKey]) => versionKey);
       const existingInstances = findDependencyVersionInstances(parent);

--- a/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -32,7 +32,7 @@ import type {
 import { filterModelRoots } from "./figma-catalog-tree-sync-gateway";
 import {
   requireComponent,
-  requireFrame,
+  requireFrameOrSection,
   requireModeId,
   requirePage,
   requireSection,
@@ -75,7 +75,7 @@ async function checkVersionContract(checkedComponents, checkedSections, checkedV
   checkedComponents.push(`${projectVersionComponent.name}:${projectVersionComponent.id}`);
 
   for (const [sectionName, sectionTarget] of Object.entries(VERSION_SECTION_TARGETS)) {
-    const sectionFrame = await requireFrame(sectionTarget.parentNodeId);
+    const sectionFrame = await requireFrameOrSection(sectionTarget.parentNodeId);
     checkedSections.push(`${sectionName}:${sectionFrame.id}`);
   }
 }


### PR DESCRIPTION
## Summary

- Rebinds the Figma version sync targets to the rebuilt visual subsections: `main versions`, `library versions`, and `plugin versions`.
- Allows version visual containers to be either `FRAME` or `SECTION` nodes while keeping stricter node contracts elsewhere.
- Documents the version visual container contract in the visual sync runbook.

## Validation

- `npm run test` in `repo/figma-design-sync/tools`
- `npm run build` in `repo/figma-design-sync/tools`
- `./gradlew.bat check`
- staged Figma MCP `preflight` against the official TeamCity design model `sha256:f0609f52d3e1ec8d7b04fd6096d5e2941007ce09856474e9253fe43b99afce20`
