### PR TITLE
fix(figma-design-sync): normalize section layout contracts

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -92,7 +92,9 @@ For each repository version:
 - Create a missing Figma variable under the matching section folder.
 - Create a missing `.dependency version` instance in the matching visual frame.
 - Layout `.dependency version` instances as a row-major grid with at most two
-  instances per row, 64 px between columns, and 32 px between rows.
+  instances per row, 64 px between columns, and 32 px between rows. Start the
+  grid 100 px from the visual section's top and left edges, then resize the
+  section after layout so all four edges keep the same 100 px padding.
 - Stack the visual frames for `Main project dependencies`, `Libraries`, and
   `Plugins` with 128 px between one frame bottom edge and the next frame top
   edge.
@@ -106,6 +108,17 @@ For each repository version:
 
 The sync must fail without writing metadata if the design model contains an
 unknown version section.
+
+Every Figma `SECTION` managed or created by the visual sync must use a single
+stroke bound to `md/sys/color/outline`, aligned `INSIDE`, with weight `2`. The
+sync reapplies this contract to existing catalog and version sections so legacy
+or manually changed strokes are normalized on the next targeted sync.
+
+Direct child sections are positioned 100 px from their parent section's left
+edge before the parent is resized to fit. This keeps the left padding equal to
+the 100 px right and bottom padding added by the resize operation, including the
+`gradle-plugins` and `figma-design-sync` sections inside the repository tooling
+catalog container.
 
 ## Catalog Tree Sync
 

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -6,6 +6,7 @@ export const VERSIONS_COLLECTION_NAME = "repo\\dependency-catalog\\versions.prop
 export const VERSIONS_COLLECTION_NAMES = [VERSIONS_COLLECTION_NAME];
 export const VERSION_ALIAS_MODE_NAME = "Version alias";
 export const VERSION_NUMBER_MODE_NAME = "Version number";
+export const OUTLINE_COLOR_VARIABLE_NAME = "md/sys/color/outline";
 export const DEPENDENCY_VERSION_COMPONENT_ID = "63075:591";
 export const PROJECT_VERSION_COMPONENT_ID = DEPENDENCY_VERSION_COMPONENT_ID;
 export const DEPENDENCY_VERSION_INSTANCE_NAMES = [".dependency version", ".project version"];

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -16,11 +16,14 @@ import {
   treeNodeLayoutNode,
 } from "./figma-connector-gateway";
 import {
+  applyAncestorSectionStrokeContract,
+  applySectionStrokeContractTree,
   findSection,
   lockOnlyRootSection,
   removeCatalogTreeSectionFills,
   resizeAncestorSectionsToFit,
   resizeNodeToFit,
+  requireOutlineColorVariable,
   stackChildSectionsFromPadding,
   stackAncestorSectionSiblingsWithGap,
   stackDescendantSectionsWithGap,
@@ -42,6 +45,7 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
   const removedCatalogConnectors = [];
   const mutatedNodeIds = [];
   const componentCache = new Map();
+  const outlineVariable = await requireOutlineColorVariable();
   const targetNames = new Set(options.targetNames || CATALOG_TREE_TARGETS.map((target) => target.name));
   const targets = CATALOG_TREE_TARGETS.filter((target) =>
     targetNames.has(target.name) || (target.aliases || []).some((alias) => targetNames.has(alias))
@@ -93,6 +97,8 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
       throw new Error(`Expected '${sectionNodeId}' to be a SECTION.`);
     }
     unlockSectionTreeForMutation(section, mutatedNodeIds);
+    applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
+    applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
 
     if (!isPartialRootSync && scopedModelNodes.length === 0) {
       removedCatalogNodes.push(...removeEmptyCatalogTreeTarget(target, section, mutatedNodeIds));
@@ -192,6 +198,8 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds);
     resizeAncestorSectionsToFit(section, mutatedNodeIds);
     removeCatalogTreeSectionFills(section, mutatedNodeIds);
+    applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
+    applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
     lockOnlyRootSection(section, mutatedNodeIds);
   }
 

--- a/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
@@ -1,9 +1,13 @@
 import type { CatalogTreeType } from "../domain/design-model";
 import {
+  OUTLINE_COLOR_VARIABLE_NAME,
   PARENT_SECTION_NODE_IDS,
   PARENT_SECTION_SIBLING_GAP,
   SECTION_SIBLING_GAP,
 } from "../config/figma-config";
+
+const SECTION_STROKE_WEIGHT = 2;
+const SECTION_STROKE_ALIGN = "INSIDE";
 
 export async function requireVariableCollection(nameOrNames) {
   const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
@@ -35,6 +39,15 @@ export async function loadVariablesByVersionKey(collection) {
   }
 
   return variables;
+}
+
+export async function requireOutlineColorVariable() {
+  const variables = await figma.variables.getLocalVariablesAsync("COLOR");
+  const variable = variables.find((candidate) => candidate.name === OUTLINE_COLOR_VARIABLE_NAME);
+  if (!variable) {
+    throw new Error(`Color variable '${OUTLINE_COLOR_VARIABLE_NAME}' was not found.`);
+  }
+  return variable;
 }
 
 export async function requireComponent(nodeId) {
@@ -111,6 +124,57 @@ export function removeCatalogTreeSectionFills(section, mutatedNodeIds) {
   }
 }
 
+export function applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds) {
+  const sections = [
+    section,
+    ...section.findAllWithCriteria({ types: ["SECTION"] }),
+  ];
+
+  for (const candidate of sections) {
+    applySectionStrokeContract(candidate, outlineVariable, mutatedNodeIds);
+  }
+}
+
+export function applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds) {
+  let current = section.parent;
+
+  while (current && current.type === "SECTION") {
+    applySectionStrokeContract(current, outlineVariable, mutatedNodeIds);
+    current = current.parent;
+  }
+}
+
+export function sectionStrokeContractSatisfied(section, outlineVariableId) {
+  if (section.strokeAlign !== SECTION_STROKE_ALIGN || section.strokeWeight !== SECTION_STROKE_WEIGHT) {
+    return false;
+  }
+  if (!Array.isArray(section.strokes) || section.strokes.length !== 1) return false;
+
+  const stroke = section.strokes[0];
+  return stroke.type === "SOLID" && stroke.boundVariables?.color?.id === outlineVariableId;
+}
+
+function applySectionStrokeContract(section, outlineVariable, mutatedNodeIds) {
+  if (sectionStrokeContractSatisfied(section, outlineVariable.id)) return;
+
+  const existingSolidStroke = section.strokes.find((stroke) => stroke.type === "SOLID");
+  const stroke = figma.variables.setBoundVariableForPaint(
+    {
+      type: "SOLID",
+      color: existingSolidStroke?.color || { r: 0, g: 0, b: 0 },
+      opacity: 1,
+      visible: true,
+      blendMode: "NORMAL",
+    },
+    "color",
+    outlineVariable
+  );
+  section.strokes = [stroke];
+  section.strokeAlign = SECTION_STROKE_ALIGN;
+  section.strokeWeight = SECTION_STROKE_WEIGHT;
+  mutatedNodeIds.push(section.id);
+}
+
 export function resizeNodeToFit(node, children, mutatedNodeIds, padding = 100) {
   const visibleChildren = children.filter((child) => child && child.visible !== false);
   if (visibleChildren.length === 0) return;
@@ -134,7 +198,7 @@ export function resizeNodeToFit(node, children, mutatedNodeIds, padding = 100) {
 }
 
 export function stackChildSectionsFromPadding(parent, mutatedNodeIds, gap = SECTION_SIBLING_GAP, padding = 100) {
-  stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap, padding);
+  stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap, padding, padding);
 }
 
 export function resizeAncestorSectionsToFit(node, mutatedNodeIds, padding = 100) {
@@ -260,23 +324,30 @@ function stackConfiguredPageSectionsWithGap(section, mutatedNodeIds, gap = PAREN
   }
 }
 
-function stackDirectChildSectionsWithGap(parent, mutatedNodeIds, gap, startY = firstSectionStartY(parent)) {
+function stackDirectChildSectionsWithGap(
+  parent,
+  mutatedNodeIds,
+  gap,
+  startY = firstSectionStartY(parent),
+  startX = 100
+) {
   const sections = directChildSections(parent)
     .sort((first, second) => first.y - second.y || first.x - second.x);
 
   if (sections.length === 0) return;
 
-  const alignedX = sections[0].x;
   let nextY = startY;
   for (const section of sections) {
-    if (Math.abs(section.x - alignedX) > 0.01) {
-      section.x = alignedX;
-      mutatedNodeIds.push(section.id);
+    let positionChanged = false;
+    if (Math.abs(section.x - startX) > 0.01) {
+      section.x = startX;
+      positionChanged = true;
     }
     if (Math.abs(section.y - nextY) > 0.01) {
       section.y = nextY;
-      mutatedNodeIds.push(section.id);
+      positionChanged = true;
     }
+    if (positionChanged) mutatedNodeIds.push(section.id);
     nextY = section.y + section.height + gap;
   }
 }

--- a/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts
@@ -10,10 +10,13 @@ import {
 import type { DesignModel } from "../domain/design-model";
 import type { VersionSyncGateway } from "../ports/sync-gateways";
 import {
+  applyAncestorSectionStrokeContract,
+  applySectionStrokeContractTree,
   loadVariablesByVersionKey,
   requireComponent,
   requireFrameOrSection,
   requireModeId,
+  requireOutlineColorVariable,
   requireVariableCollection,
   resizeAncestorSectionsToFit,
   resizeNodeToFit,
@@ -25,6 +28,7 @@ import { collectText } from "./figma-text-gateway";
 const DEPENDENCY_VERSION_MAX_COLUMNS = 2;
 const DEPENDENCY_VERSION_COLUMN_GAP = 64;
 const DEPENDENCY_VERSION_ROW_GAP = 32;
+const DEPENDENCY_VERSION_SECTION_PADDING = 100;
 const VERSION_SECTION_GAP = 128;
 
 export class FigmaVersionSyncGateway implements VersionSyncGateway {
@@ -34,6 +38,7 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
     const versionAliasModeId = requireModeId(collection, VERSION_ALIAS_MODE_NAME);
     const versionNumberModeId = requireModeId(collection, VERSION_NUMBER_MODE_NAME);
     const dependencyVersionComponent = await requireComponent(DEPENDENCY_VERSION_COMPONENT_ID);
+    const outlineVariable = await requireOutlineColorVariable();
 
     const variables = await loadVariablesByVersionKey(collection);
     const mutatedNodeIds = [];
@@ -103,10 +108,12 @@ export class FigmaVersionSyncGateway implements VersionSyncGateway {
     stackVersionSectionFrames(syncedParents, mutatedNodeIds);
     for (const parent of syncedParents) {
       resizeNodeToFit(parent, parent.children.filter((child) => child.visible !== false), mutatedNodeIds);
+      applySectionStrokeContractTree(parent, outlineVariable, mutatedNodeIds);
     }
     if (syncedParents[0]) {
       stackAncestorSectionSiblingsWithGap(syncedParents[0], mutatedNodeIds);
       resizeAncestorSectionsToFit(syncedParents[0], mutatedNodeIds);
+      applyAncestorSectionStrokeContract(syncedParents[0], outlineVariable, mutatedNodeIds);
     }
 
     return {
@@ -179,8 +186,8 @@ export function dependencyVersionGridPosition(index: number, itemWidth: number, 
     .reduce((sum, height) => sum + height + DEPENDENCY_VERSION_ROW_GAP, 0);
 
   return {
-    x: column * (itemWidth + DEPENDENCY_VERSION_COLUMN_GAP),
-    y,
+    x: DEPENDENCY_VERSION_SECTION_PADDING + column * (itemWidth + DEPENDENCY_VERSION_COLUMN_GAP),
+    y: DEPENDENCY_VERSION_SECTION_PADDING + y,
   };
 }
 

--- a/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -34,6 +34,7 @@ import {
   requireComponent,
   requireFrameOrSection,
   requireModeId,
+  requireOutlineColorVariable,
   requirePage,
   requireSection,
   requireVariableCollection,
@@ -73,6 +74,8 @@ async function checkVersionContract(checkedComponents, checkedSections, checkedV
 
   const projectVersionComponent = await requireComponent(PROJECT_VERSION_COMPONENT_ID);
   checkedComponents.push(`${projectVersionComponent.name}:${projectVersionComponent.id}`);
+  const outlineVariable = await requireOutlineColorVariable();
+  checkedVariables.push(outlineVariable.name);
 
   for (const [sectionName, sectionTarget] of Object.entries(VERSION_SECTION_TARGETS)) {
     const sectionFrame = await requireFrameOrSection(sectionTarget.parentNodeId);

--- a/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
+++ b/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
@@ -149,13 +149,14 @@ test("stale empty root section cleanup can remove empty roots outside a partial 
 test("child section reflow normalizes the first remaining root to container padding", () => {
   const mutatedNodeIds = [];
   const section = parentSection([
-    positionedChildSection("io", 100, 1458, 2353, 1898),
-    positionedChildSection("me", 100, 3470, 948, 1445),
-    positionedChildSection("org", 100, 5029, 1690, 1445),
+    positionedChildSection("io", 0, 1458, 2353, 1898),
+    positionedChildSection("me", 0, 3470, 948, 1445),
+    positionedChildSection("org", 0, 5029, 1690, 1445),
   ]);
 
   stackChildSectionsFromPadding(section, mutatedNodeIds);
 
+  assert.deepEqual(section.children.map((child) => child.x), [100, 100, 100]);
   assert.equal(section.children[0].y, 100);
   assert.equal(section.children[1].y, 2112);
   assert.equal(section.children[2].y, 3671);
@@ -165,11 +166,12 @@ test("child section reflow normalizes the first remaining root to container padd
 test("child section reflow normalizes a single remaining root", () => {
   const mutatedNodeIds = [];
   const section = parentSection([
-    positionedChildSection("org", 100, 5029, 1690, 1445),
+    positionedChildSection("org", 0, 5029, 1690, 1445),
   ]);
 
   stackChildSectionsFromPadding(section, mutatedNodeIds);
 
+  assert.equal(section.children[0].x, 100);
   assert.equal(section.children[0].y, 100);
   assert.deepEqual(mutatedNodeIds, ["org-id"]);
 });

--- a/repo/figma-design-sync/tools/tests/version-sync-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/version-sync-plan.test.ts
@@ -4,6 +4,7 @@ import {
   dependencyVersionGridPosition,
   planDependencyVersionInstanceSync,
 } from "../src/figma/figma-version-sync-gateway";
+import { sectionStrokeContractSatisfied } from "../src/figma/figma-node-gateway";
 
 test("version sync removes stale renamed dependency versions and exact duplicates", () => {
   const instances = [
@@ -33,14 +34,30 @@ test("version sync removes stale renamed dependency versions and exact duplicate
   );
 });
 
-test("dependency version grid positions two items per row with documented gaps", () => {
+test("dependency version grid keeps equal section padding and documented gaps", () => {
   const rowHeights = [40, 52, 36];
 
-  assert.deepEqual(dependencyVersionGridPosition(0, 300, rowHeights), { x: 0, y: 0 });
-  assert.deepEqual(dependencyVersionGridPosition(1, 300, rowHeights), { x: 364, y: 0 });
-  assert.deepEqual(dependencyVersionGridPosition(2, 300, rowHeights), { x: 0, y: 72 });
-  assert.deepEqual(dependencyVersionGridPosition(3, 300, rowHeights), { x: 364, y: 72 });
-  assert.deepEqual(dependencyVersionGridPosition(4, 300, rowHeights), { x: 0, y: 156 });
+  assert.deepEqual(dependencyVersionGridPosition(0, 300, rowHeights), { x: 100, y: 100 });
+  assert.deepEqual(dependencyVersionGridPosition(1, 300, rowHeights), { x: 464, y: 100 });
+  assert.deepEqual(dependencyVersionGridPosition(2, 300, rowHeights), { x: 100, y: 172 });
+  assert.deepEqual(dependencyVersionGridPosition(3, 300, rowHeights), { x: 464, y: 172 });
+  assert.deepEqual(dependencyVersionGridPosition(4, 300, rowHeights), { x: 100, y: 256 });
+});
+
+test("section stroke contract requires the bound outline variable, inside alignment, and weight two", () => {
+  const compliantSection = {
+    strokeAlign: "INSIDE",
+    strokeWeight: 2,
+    strokes: [{
+      type: "SOLID",
+      boundVariables: { color: { id: "outline-variable" } },
+    }],
+  };
+
+  assert.equal(sectionStrokeContractSatisfied(compliantSection, "outline-variable"), true);
+  assert.equal(sectionStrokeContractSatisfied({ ...compliantSection, strokeWeight: 1 }, "outline-variable"), false);
+  assert.equal(sectionStrokeContractSatisfied({ ...compliantSection, strokeAlign: "CENTER" }, "outline-variable"), false);
+  assert.equal(sectionStrokeContractSatisfied(compliantSection, "another-variable"), false);
 });
 
 function dependencyVersion(id: string, versionKey: string) {


### PR DESCRIPTION
## What changed

- keep 100 px padding on every edge of dependency version sections
- bind every managed section stroke to `md/sys/color/outline` with inside alignment and weight 2
- reposition direct child sections 100 px from their parent before resize-to-fit
- document and test the visual section contract

## Why

The sync positioned some content at `x = 0` and `y = 0`, so resize-to-fit only produced padding on the right and bottom. Existing sections could also retain legacy unbound strokes with weight 1.

## Impact

The next official Figma sync will normalize existing catalog and version sections and will apply the same contract to newly generated sections.

## Verification

- `npm run test`
- `npm run build`
- `./gradlew check`
- `git diff --check`
