### PR TITLE
feat(figma-design-sync): document continuous integration visually

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -91,6 +91,8 @@ requests.
 The pipeline:
 
 - triggers after `CI` finishes successfully on `<default>`;
+- generates `.teamcity/target/generated-configs` from the versioned Kotlin DSL
+  before each model generation or hash verification;
 - generates `build/reports/figma-sync/design-model.json` from `main`;
 - sets `FIGMA_DESIGN_SYNC_OFFICIAL=true` and `FIGMA_DESIGN_SYNC_BRANCH` so the
   Gradle task can verify it is running under the official Figma Sync pipeline;

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -2,6 +2,10 @@
 
 This directory is the source of truth for TeamCity project settings.
 
+The contract used to derive the Figma representation of CI from these settings
+is documented in
+[`docs/ci/visual-model-contract.md`](../docs/ci/visual-model-contract.md).
+
 ## Branching Workflow
 
 Change `.teamcity/settings.kts` on the short-lived branch:

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -127,6 +127,10 @@ object WaterMyPlantsFigmaSync : Pipeline({
 
         steps {
             step(PipelineScriptStep {
+                name = "Generate effective TeamCity configuration"
+                scriptContent = """.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate"""
+            })
+            step(PipelineScriptStep {
                 name = "Generate Figma design model"
                 scriptContent = """.\gradlew.bat generateFigmaDesignModel"""
             })
@@ -148,6 +152,10 @@ object WaterMyPlantsFigmaSync : Pipeline({
         }
 
         steps {
+            step(PipelineScriptStep {
+                name = "Generate effective TeamCity configuration"
+                scriptContent = """.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate"""
+            })
             step(PipelineScriptStep {
                 name = "Verify Figma sync metadata"
                 scriptContent = """.\gradlew.bat checkFigmaTrunkSync"""

--- a/docs/ci/external-topology-validation.md
+++ b/docs/ci/external-topology-validation.md
@@ -1,0 +1,28 @@
+# External CI Topology Validation
+
+Use this runbook to validate `docs/ci/external-topology.yaml` against the active
+services. The review is manual because Cloudflare, GitHub, TeamCity, and Figma
+configuration is not fully represented by repository code.
+
+## Validation Procedure
+
+1. Confirm the public TeamCity UI route uses Cloudflare Access and Cloudflare
+   Tunnel.
+2. Confirm TeamCity CLI requests require Cloudflare Service Auth and a TeamCity
+   access token.
+3. Confirm the dedicated GitHub App webhook path bypasses interactive Access,
+   validates the webhook signature, and reaches TeamCity through the tunnel.
+4. Confirm TeamCity obtains sources and publishes checks through the GitHub App.
+5. Confirm the TeamCity server dispatches both pipelines to the expected build
+   agent and that Figma Sync remains restricted to `main`.
+6. Confirm the build agent can read Figma metadata and that visual writes still
+   require an operator-approved Codex/MCP action.
+7. Compare every node and connection in the YAML with the verified state.
+8. Update `validation.lastValidatedOn` only after all checks pass.
+9. Run `.\gradlew.bat checkCiExternalTopologyFreshness` and the normal
+   repository checks.
+
+Do not record tokens, secrets, concrete account identifiers, personal names, or
+layout coordinates in the topology file. The freshness task is intentionally
+non-blocking: an expired date produces a visible CI warning but does not prevent
+a merge.

--- a/docs/ci/external-topology.yaml
+++ b/docs/ci/external-topology.yaml
@@ -1,0 +1,186 @@
+schemaVersion: 1
+
+validation:
+  lastValidatedOn: "2026-07-14"
+  warnAfterDays: 90
+
+nodes:
+  - id: operator
+    type: actor
+    name: Operator
+    description: Initiates and verifies manual CI and visual documentation actions.
+
+  - id: browser
+    type: system
+    name: Browser
+    description: Provides interactive access to the TeamCity user interface.
+
+  - id: teamcity-cli
+    type: system
+    name: TeamCity CLI
+    description: Provides authenticated command-line access to TeamCity.
+
+  - id: github-repository
+    type: system
+    name: GitHub Repository
+    description: Stores the reviewed source code and receives CI checks and statuses.
+
+  - id: github-app
+    type: system
+    name: GitHub App
+    description: Integrates GitHub repository events and credentials with TeamCity.
+
+  - id: cloudflare-access
+    type: system
+    name: Cloudflare Access
+    description: Applies user, service, and webhook access policies at the public boundary.
+
+  - id: cloudflare-tunnel
+    type: system
+    name: Cloudflare Tunnel
+    description: Routes approved HTTPS traffic to the private TeamCity origin.
+
+  - id: teamcity-server
+    type: system
+    name: TeamCity Server
+    description: Orchestrates pipelines, schedules work, and publishes repository checks.
+
+  - id: build-agent
+    type: system
+    name: Build Agent
+    description: Executes repository build, verification, and design model commands.
+
+  - id: codex-mcp-client
+    type: system
+    name: Codex/MCP Client
+    description: Applies operator-approved visual changes through the Figma MCP integration.
+
+  - id: figma-api
+    type: system
+    name: Figma API
+    description: Exposes design metadata and authorized document write operations.
+
+  - id: figma-design-document
+    type: system
+    name: Figma Design Document
+    description: Contains the derived visual representation of the repository CI contract.
+
+connections:
+  - id: browser-teamcity-access
+    source: browser
+    target: cloudflare-access
+    label: Open TeamCity UI
+    description: Starts an interactive TeamCity session through the public HTTPS hostname.
+    protocol: HTTPS
+    authentication:
+      - Cloudflare user authentication
+    policy: Allow
+    automation: manual
+
+  - id: cli-teamcity-access
+    source: teamcity-cli
+    target: cloudflare-access
+    label: Call TeamCity API
+    description: Authenticates non-browser TeamCity CLI requests at both access boundaries.
+    protocol: HTTPS
+    authentication:
+      - Cloudflare Service Auth
+      - TeamCity access token
+    policy: Service Auth
+    automation: manual
+
+  - id: github-webhook-ingress
+    source: github-app
+    target: cloudflare-access
+    label: Deliver GitHub webhook
+    description: Sends supported repository events to the dedicated TeamCity webhook endpoint.
+    protocol: HTTPS
+    authentication:
+      - GitHub webhook signature
+    policy: Bypass
+    path: /app/webhooks/githubapp
+    automation: automatic
+
+  - id: cloudflare-origin-routing
+    source: cloudflare-access
+    target: cloudflare-tunnel
+    label: Route approved traffic
+    description: Routes allowed, service-authenticated, and bypassed requests to the tunnel.
+    protocol: Cloudflare Tunnel
+    automation: automatic
+
+  - id: teamcity-origin-delivery
+    source: cloudflare-tunnel
+    target: teamcity-server
+    label: Reach private TeamCity origin
+    description: Delivers approved requests without exposing the TeamCity origin directly.
+    automation: automatic
+
+  - id: github-source-checkout
+    source: teamcity-server
+    target: github-repository
+    label: Obtain repository sources
+    description: Resolves revisions and obtains the repository sources required by CI.
+    protocol: HTTPS
+    authentication:
+      - GitHub App installation token
+    automation: automatic
+
+  - id: github-check-publication
+    source: teamcity-server
+    target: github-repository
+    label: Publish checks and statuses
+    description: Publishes TeamCity CI results for pull requests and post-merge documentation.
+    protocol: HTTPS
+    authentication:
+      - GitHub App installation token
+    automation: automatic
+
+  - id: teamcity-job-dispatch
+    source: teamcity-server
+    target: build-agent
+    label: Schedule build work
+    description: Assigns eligible pipeline jobs to the build agent.
+    automation: automatic
+
+  - id: teamcity-build-results
+    source: build-agent
+    target: teamcity-server
+    label: Return results and artifacts
+    description: Returns build output, verification results, and declared artifacts.
+    automation: automatic
+
+  - id: figma-metadata-read
+    source: build-agent
+    target: figma-api
+    label: Read design metadata
+    description: Reads the Figma state required by repository-owned synchronization checks.
+    protocol: HTTPS
+    authentication:
+      - Figma access token
+    automation: automatic
+
+  - id: operator-visual-sync
+    source: operator
+    target: codex-mcp-client
+    label: Request visual synchronization
+    description: Starts an operator-approved synchronization using the official design model.
+    automation: manual
+    annotation: The official artifact may be staged through a temporary MCP transport.
+
+  - id: mcp-figma-write
+    source: codex-mcp-client
+    target: figma-api
+    label: Apply visual changes
+    description: Creates or updates native Figma nodes from the repository design model.
+    protocol: HTTPS
+    authentication:
+      - Figma MCP authorization
+    automation: operator-assisted
+
+  - id: figma-document-update
+    source: figma-api
+    target: figma-design-document
+    label: Update visual documentation
+    description: Persists the approved CI documentation changes in the Figma document.
+    automation: operator-assisted

--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -1,0 +1,170 @@
+# CI Visual Model Contract
+
+## Purpose
+
+The Figma CI documentation represents the current, verifiable repository and
+infrastructure contract. It does not describe planned deployment environments,
+future automation, live build results, or runtime metrics.
+
+The parent Figma section is named:
+
+```text
+Continuous Integration and Design Documentation
+```
+
+It contains two levels of detail:
+
+1. `Overview`
+2. `Pull Request Integration`
+3. `Post-merge Design Documentation`
+4. `Infrastructure and Access`
+
+All visual labels and descriptions use English.
+
+## Sources Of Truth
+
+The visual model aggregates sources without duplicating their ownership:
+
+- `.teamcity/settings.kts` owns pipelines, jobs, triggers, branch filters,
+  commands, artifacts, and GitHub status publishers.
+- TeamCity generated configuration is an unversioned extraction input. Files
+  under `.teamcity/target/generated-configs` must not be committed.
+- `docs/ci/external-topology.yaml` owns external systems and connections that
+  are not represented by TeamCity DSL, including Cloudflare access and tunnel
+  boundaries, user and CLI access, the GitHub webhook ingress, and the external
+  MCP-operated Figma write.
+- The generated `design-model.json` aggregates both sources for the visual sync.
+- Figma is derived documentation and is not a source of CI configuration.
+
+The external topology YAML must not duplicate TeamCity pipeline or job
+definitions. It must not contain tokens, secrets, credential references,
+account identifiers, personal names, or visual layout coordinates.
+
+## Visual Reading Levels
+
+### Overview
+
+The overview contains two distinct journeys:
+
+- Pull request integration: branch push, pull request, CI verification, GitHub
+  check, merge gate, and merge to `main`.
+- Post-merge design documentation: successful CI on `main`, Figma Sync model
+  generation and verification, the external operator and Codex/MCP write, and
+  the verification rerun.
+
+Cloudflare appears as a simplified boundary in the overview. Its policies and
+authentication paths belong in `Infrastructure and Access`.
+
+### Operational Detail
+
+Operational sections show:
+
+- exact pipeline, job, check, and artifact names;
+- a separate short description for each named element;
+- triggers and branch conditions;
+- summarized commands such as `Gradle check` and `Generate design model`;
+- relevant artifacts and published GitHub checks;
+- links from section headers and operational nodes to canonical files on
+  GitHub `main`.
+
+Links should target files rather than line numbers so that routine source edits
+do not break them. Literal command content remains in the linked TeamCity DSL.
+
+## Current Systems And Entities
+
+The model distinguishes these entities when they participate in a flow:
+
+- operator;
+- browser;
+- TeamCity CLI;
+- GitHub Repository;
+- GitHub App;
+- Pull Request;
+- `main` branch;
+- Cloudflare Access;
+- Cloudflare Tunnel;
+- TeamCity Server;
+- Build Agent;
+- TeamCity pipelines, jobs, checks, and merge gate;
+- `design-model.json` as a relevant artifact;
+- Codex/MCP client;
+- Figma API;
+- Figma Design Document.
+
+Short-lived branches are represented by the push connection instead of a
+dedicated visual entity. Artifacts become independent visual entities only when
+they form a contract between systems.
+
+## Connection Contract
+
+Connections are directed and describe their purpose. In particular, the model
+must not collapse these GitHub and TeamCity interactions into one bidirectional
+connection:
+
+1. GitHub sends the HTTPS webhook to TeamCity through the public webhook path,
+   the Cloudflare bypass policy, and Cloudflare Tunnel.
+2. TeamCity obtains repository sources from GitHub.
+3. TeamCity publishes checks and statuses to GitHub.
+
+The detailed infrastructure view also distinguishes:
+
+- browser access through Cloudflare Access user authentication;
+- TeamCity CLI access through Cloudflare Service Auth followed by TeamCity
+  token authentication;
+- TeamCity Server scheduling work on the Build Agent;
+- the Build Agent returning build results and artifacts;
+- TeamCity reading Figma metadata through the Figma API;
+- the operator initiating Codex/MCP and the client writing the Figma document.
+
+Cloudflare `Allow`, `Service Auth`, and `Bypass` policies are connection
+attributes, not independent systems. Connections may contain protocol,
+authentication type, automation mode, branch condition, and a concise purpose,
+but never concrete credentials.
+
+## Post-merge Verification Loop
+
+The current Figma process must be shown as a loop, not as an automatic TeamCity
+write:
+
+```text
+Generate main design model
+  -> design-model.json
+  -> Check Figma trunk sync
+  -> mismatch
+  -> Operator
+  -> Codex/MCP client
+  -> Figma Design Document
+  -> manual rerun
+  -> Check Figma trunk sync
+```
+
+The manual rerun is interface-independent: it may be requested through the
+TeamCity UI or CLI. The current temporary transport mechanism used to stage the
+official artifact for MCP is represented as a technical annotation on the
+handoff connection, not as another domain artifact.
+
+`TeamCity CI` participates in the pull request merge gate. `TeamCity Figma
+Sync` is a post-merge documentation status and must not be represented as a pull
+request requirement.
+
+## External Topology Validation
+
+The external topology is versioned and compared manually with the active
+GitHub, Cloudflare, TeamCity, and Figma configuration. The YAML records the date
+of the last validation, but not the operator identity. The validation date is
+repository metadata and is not rendered in Figma.
+
+CI emits a non-blocking warning when more than 90 days have passed since the
+recorded validation. The operational runbook must describe how to verify each
+external connection before updating that date.
+
+## Excluded Content
+
+The visual model excludes:
+
+- test and production deployment stages that are not implemented;
+- future or target architecture;
+- live build status, timestamps, durations, and historical metrics;
+- raw tokens, secrets, IDs, account details, and personal names;
+- Figma coordinates, colors, dimensions, and component property bindings;
+- manually duplicated TeamCity pipelines or jobs in the external topology.

--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -36,6 +36,15 @@ The visual model aggregates sources without duplicating their ownership:
 - The generated `design-model.json` aggregates both sources for the visual sync.
 - Figma is derived documentation and is not a source of CI configuration.
 
+The generated JSON stores this aggregate under `content.ci`:
+
+- `externalTopology` contains the versioned YAML topology;
+- `teamCity` contains the effective generated pipelines and VCS roots.
+
+The official TeamCity jobs must run `teamcity-configs:generate` before Gradle
+generates the model or checks its hash. Gradle consumes the generated directory
+as a declared input; it does not invoke Maven implicitly.
+
 The external topology YAML must not duplicate TeamCity pipeline or job
 definitions. It must not contain tokens, secrets, credential references,
 account identifiers, personal names, or visual layout coordinates.
@@ -157,6 +166,9 @@ repository metadata and is not rendered in Figma.
 CI emits a non-blocking warning when more than 90 days have passed since the
 recorded validation. The operational runbook must describe how to verify each
 external connection before updating that date.
+
+The executable warning is `checkCiExternalTopologyFreshness`, wired into the
+root Gradle `check` lifecycle.
 
 ## Excluded Content
 

--- a/repo/dependency-catalog/versions.properties
+++ b/repo/dependency-catalog/versions.properties
@@ -72,6 +72,10 @@ protobufLibraryVersion=4.35.1
 # Consumer: repo/figma-design-sync
 serializationLibraryVersion=1.11.0
 
+# org.snakeyaml:snakeyaml-engine
+# Consumer: repo/figma-design-sync
+snakeYamlLibraryVersion=3.0.1
+
 
 ## Plugins
 

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -26,14 +26,19 @@ used by CI.
 ## Package Layout
 
 - `domain/model/catalog`: catalog tree, node, entry, and version models.
+- `domain/model/ci`: external topology and effective TeamCity configuration
+  models used by CI documentation.
 - `domain/model/figma`: Figma references used by domain requests.
 - `domain/model/modules`: module dependency models included in the generated
   design model.
 - `domain/port/catalog`, `domain/port/modules`, and `domain/port/versions`:
   source ports used to build the generated design model.
+- `domain/port/ci`: path-based sources and ports for external topology and
+  effective TeamCity configuration.
 - `data/datasource/catalog`, `data/datasource/modules`, and
   `data/datasource/versions`: implementations of domain ports grouped by
   capability.
+- `data/datasource/ci`: filesystem adapters for CI documentation sources.
 - `data/figma/client`: Figma API client and client exceptions.
 - `data/figma/dto`: serializable Figma API response and node DTOs.
 - `data/figma/common`: shared Figma URL helpers.
@@ -43,6 +48,8 @@ used by CI.
   types and the concrete `WaterMyPlantsCatalog` facade to domain catalog
   models. Keep both module dependencies explicit.
 - `data/properties/versions`: readers for version properties files.
+- `data/teamcity/configuration`: readers for TeamCity generated YAML and XML.
+- `data/yaml/ci`: YAML 1.2 reader for the versioned external topology.
 - `plugin/generator`: design model JSON generation and hash calculation.
 - `plugin/checker/versions`: Gradle-facing adapter that verifies repository
   version section and suffix naming before CI can merge catalog changes.

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -72,6 +72,9 @@ used by CI.
 - `checkFigmaVersionNaming`: fails when
   `repo/dependency-catalog/versions.properties` does not use the Figma version
   naming contract. This task is wired into the root `check` lifecycle.
+- `checkCiExternalTopologyFreshness`: emits a non-blocking warning after the
+  validation window in `docs/ci/external-topology.yaml` expires. This task is
+  wired into the root `check` lifecycle.
 - `checkFigmaTrunkSync`: compares the generated model hash with Figma shared
   plugin data.
 - Treat `figmaDesignSync` as a CI-owned verification step. Developers may run it

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -57,6 +57,8 @@ The model is generated from repository source files, not from Figma:
 | Root `settings.gradle.kts` | Main project module discovery. |
 | Included-build `settings.gradle.kts` files | Included-build catalog and module discovery. |
 | Gradle build files | Module dependency edges and applied plugin usage. |
+| `docs/ci/external-topology.yaml` | Versioned external systems, access boundaries, and directed connections. |
+| `.teamcity/target/generated-configs` | Effective pipelines, jobs, triggers, artifacts, checks, and VCS roots generated from `.teamcity/settings.kts`. |
 
 The default included-build sources are configured by the `figmaDesignSync`
 Gradle extension:
@@ -84,6 +86,7 @@ The stable `content` object contains:
 | `catalogs` | Library, plugin, custom Gradle plugin, and convention plugin trees. |
 | `modules` | Repository module paths discovered from the root project and included builds. |
 | `moduleDependencies` | Module dependency edges grouped by source build. |
+| `ci` | External CI topology and effective TeamCity configuration. |
 
 Figma visual code must treat this JSON as the source of truth. Manual visual
 changes in Figma are acceptable only when they are component contract changes;
@@ -104,11 +107,13 @@ Task responsibilities:
 |------|----------------|
 | `checkFigmaVersionNaming` | Fails when version keys do not follow the Figma naming contract. |
 | `checkFigmaCatalogUsage` | Fails when catalog entries are declared but unused according to the repository usage contract. |
+| `checkCiExternalTopologyFreshness` | Emits a non-blocking warning when the external topology has not been manually validated within its configured window. |
 | `generateFigmaDesignModel` | Generates the official JSON artifact inside TeamCity `Figma Sync` on `main`; do not run it as a local publication path. |
 | `checkFigmaTrunkSync` | Compares the generated `modelHash` with Figma shared plugin metadata inside the official pipeline. |
 
-`checkFigmaVersionNaming` and `checkFigmaCatalogUsage` are wired into the root
-Gradle `check` lifecycle, so the TeamCity `Verify` step runs them through:
+`checkFigmaVersionNaming`, `checkFigmaCatalogUsage`, and
+`checkCiExternalTopologyFreshness` are wired into the root Gradle `check`
+lifecycle, so the TeamCity `Verify` step runs them through:
 
 ```powershell
 .\gradlew.bat check
@@ -119,11 +124,12 @@ Gradle `check` lifecycle, so the TeamCity `Verify` step runs them through:
 The strict flow is:
 
 1. Merge code changes through a pull request after TeamCity CI passes.
-2. Let TeamCity run on `main` and generate the official `design-model.json`.
-3. Use the official artifact as the visual sync input.
-4. Run the MCP `preflight` target when Figma component contracts changed.
-5. Run the MCP visual write step against Figma.
-6. Verify `checkFigmaTrunkSync` so Figma metadata matches `main`.
+2. Let TeamCity generate the effective configuration from `.teamcity/settings.kts`.
+3. Let the same job generate the official `design-model.json` from those effective files.
+4. Use the official artifact as the visual sync input.
+5. Run the MCP `preflight` target when Figma component contracts changed.
+6. Run the MCP visual write step against Figma.
+7. Verify `checkFigmaTrunkSync` so Figma metadata matches `main`.
 
 Do not create official design-model metadata from a feature branch. Branch-local
 visual iteration may reuse an official `main` artifact for layout debugging, but

--- a/repo/figma-design-sync/data/build.gradle.kts
+++ b/repo/figma-design-sync/data/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.io.ktor.client.content.negotiation)
     implementation(libs.io.ktor.serialization.kotlinx.json)
     implementation(libs.org.jetbrains.kotlinx.serialization.json)
+    implementation(libs.org.snakeyaml.engine)
 
     // Kotest
     testImplementation(libs.io.kotest.runner.junit5)

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/ci/CiExternalTopologyDataSource.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/ci/CiExternalTopologyDataSource.kt
@@ -1,0 +1,19 @@
+package com.marmatsan.figmaDesignSync.data.datasource.ci
+
+import com.marmatsan.figmaDesignSync.data.yaml.ci.CiExternalTopologyYamlReader
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import me.tatarka.inject.annotations.Inject
+import java.io.File
+
+/**
+ * Filesystem adapter for the versioned external CI topology.
+ */
+@Inject
+class CiExternalTopologyDataSource(
+    private val reader: CiExternalTopologyYamlReader
+) : CiExternalTopologyPort {
+    override fun readTopology(source: CiExternalTopologySource): CiExternalTopology =
+        reader.read(File(source.path))
+}

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/ci/TeamCityConfigurationDataSource.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/ci/TeamCityConfigurationDataSource.kt
@@ -1,0 +1,19 @@
+package com.marmatsan.figmaDesignSync.data.datasource.ci
+
+import com.marmatsan.figmaDesignSync.data.teamcity.configuration.TeamCityGeneratedConfigurationReader
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
+import me.tatarka.inject.annotations.Inject
+import java.io.File
+
+/**
+ * Filesystem adapter for effective TeamCity generated configuration.
+ */
+@Inject
+class TeamCityConfigurationDataSource(
+    private val reader: TeamCityGeneratedConfigurationReader
+) : TeamCityConfigurationPort {
+    override fun readConfiguration(source: TeamCityGeneratedConfigurationSource): TeamCityConfiguration =
+        reader.read(File(source.directoryPath))
+}

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReader.kt
@@ -1,0 +1,270 @@
+package com.marmatsan.figmaDesignSync.data.teamcity.configuration
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityPipeline
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityTrigger
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityVcsRoot
+import me.tatarka.inject.annotations.Inject
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Reads the effective YAML and XML emitted by the TeamCity Kotlin DSL.
+ */
+@Inject
+class TeamCityGeneratedConfigurationReader {
+    fun read(directory: File): TeamCityConfiguration {
+        require(directory.isDirectory) {
+            "TeamCity generated configuration directory does not exist: ${directory.path}"
+        }
+
+        val pipelineDirectories = directory
+            .walkTopDown()
+            .filter { file -> file.isFile && file.name == PIPELINE_FILE_NAME }
+            .map(File::getParentFile)
+            .toList()
+
+        return TeamCityConfiguration(
+            pipelines = pipelineDirectories
+                .map(::readPipeline)
+                .sortedBy(TeamCityPipeline::id),
+            vcsRoots = directory
+                .walkTopDown()
+                .filter { file ->
+                    file.isFile &&
+                        file.extension == XML_EXTENSION &&
+                        file.parentFile.name == VCS_ROOTS_DIRECTORY_NAME
+                }
+                .map(::readVcsRoot)
+                .toList()
+                .sortedBy(TeamCityVcsRoot::id)
+        )
+    }
+
+    private fun readPipeline(directory: File): TeamCityPipeline {
+        val projectDocument = readXml(directory.resolve(PROJECT_CONFIG_FILE_NAME))
+        val buildTypeFiles = directory.resolve(BUILD_TYPES_DIRECTORY_NAME)
+            .listFiles { file -> file.isFile && file.extension == XML_EXTENSION }
+            ?.sortedBy(File::getName)
+            .orEmpty()
+
+        return TeamCityPipeline(
+            id = directory.name,
+            name = projectDocument.documentElement
+                .getElementsByTagName(NAME_ELEMENT)
+                .item(0)
+                ?.textContent
+                ?.trim()
+                .orEmpty(),
+            triggers = buildTypeFiles.flatMap { file -> readTriggers(readXml(file)) },
+            jobs = readJobs(directory.resolve(PIPELINE_FILE_NAME))
+        )
+    }
+
+    private fun readTriggers(document: Document): List<TeamCityTrigger> {
+        val triggers = document.getElementsByTagName(BUILD_TRIGGER_ELEMENT)
+        return (0 until triggers.length).map { index ->
+            val trigger = triggers.item(index) as Element
+            val parameters = trigger
+                .getElementsByTagName(PARAM_ELEMENT)
+                .let { nodes ->
+                    (0 until nodes.length).associate { parameterIndex ->
+                        val parameter = nodes.item(parameterIndex) as Element
+                        parameter.getAttribute(NAME_ATTRIBUTE) to parameter.getAttribute(VALUE_ATTRIBUTE)
+                    }
+                }
+
+            when (val type = trigger.getAttribute(TYPE_ATTRIBUTE)) {
+                VCS_TRIGGER_TYPE -> TeamCityTrigger(
+                    type = TeamCityTrigger.Type.Vcs,
+                    branchFilter = parameters[BRANCH_FILTER_PARAMETER],
+                    dependencyPipelineId = null,
+                    afterSuccessfulBuildOnly = null
+                )
+
+                BUILD_DEPENDENCY_TRIGGER_TYPE -> TeamCityTrigger(
+                    type = TeamCityTrigger.Type.PipelineFinish,
+                    branchFilter = parameters[BRANCH_FILTER_PARAMETER],
+                    dependencyPipelineId = parameters[DEPENDS_ON_PARAMETER],
+                    afterSuccessfulBuildOnly = parameters[AFTER_SUCCESS_PARAMETER]?.toBooleanStrict()
+                )
+
+                else -> error("Unsupported TeamCity trigger type '$type'")
+            }
+        }
+    }
+
+    private fun readJobs(file: File): List<TeamCityJob> {
+        val root = readYaml(file)
+        return root.requiredMap(JOBS_KEY).map { (jobId, value) ->
+            val job = value.asStringMap("job '$jobId'")
+            TeamCityJob(
+                id = jobId,
+                name = job.requiredString(NAME_KEY),
+                steps = job.optionalList(STEPS_KEY).map(::readStep),
+                repositoryIds = job.optionalList(REPOSITORIES_KEY).map { repository ->
+                    repository.asStringMap("repository").keys.single()
+                },
+                artifacts = job.optionalList(FILES_PUBLICATION_KEY).map(::readArtifact),
+                dependencies = job.optionalList(DEPENDENCIES_KEY).map(::readDependency),
+                publishedChecks = job.optionalList(FEATURES_KEY)
+                    .map { feature -> feature.asStringMap("feature") }
+                    .filter { feature -> feature.optionalString(TYPE_KEY) == STATUS_PUBLISHER_TYPE }
+                    .map { feature ->
+                        TeamCityJob.PublishedCheck(
+                            name = feature.requiredString(CHECK_NAME_KEY)
+                        )
+                    }
+            )
+        }
+    }
+
+    private fun readStep(value: Any?): TeamCityJob.Step {
+        val step = value.asStringMap("step")
+        return TeamCityJob.Step(
+            id = step.requiredString(ID_KEY),
+            name = step.requiredString(NAME_KEY),
+            command = step.requiredString(SCRIPT_CONTENT_KEY)
+        )
+    }
+
+    private fun readArtifact(value: Any?): TeamCityJob.Artifact {
+        val artifact = value.asStringMap("artifact")
+        return TeamCityJob.Artifact(
+            path = artifact.requiredString(PATH_KEY),
+            publish = artifact.requiredBoolean(PUBLISH_ARTIFACT_KEY),
+            shareWithJobs = artifact.requiredBoolean(SHARE_WITH_JOBS_KEY)
+        )
+    }
+
+    private fun readDependency(value: Any?): TeamCityJob.Dependency {
+        val dependency = value.asStringMap("dependency")
+        require(dependency.size == 1) { "Expected one TeamCity dependency per list item" }
+        val (jobId, configurationValue) = dependency.entries.single()
+        val configuration = configurationValue.asStringMap("dependency '$jobId'")
+        return TeamCityJob.Dependency(
+            jobId = jobId,
+            artifactPaths = configuration.optionalList(FILES_KEY).map { artifactPath ->
+                artifactPath as? String ?: error("Expected TeamCity dependency artifact path")
+            }
+        )
+    }
+
+    private fun readVcsRoot(file: File): TeamCityVcsRoot {
+        val document = readXml(file)
+        val root = document.documentElement
+        val parameters = root.getElementsByTagName(PARAM_ELEMENT).let { nodes ->
+            (0 until nodes.length).associate { index ->
+                val parameter = nodes.item(index) as Element
+                parameter.getAttribute(NAME_ATTRIBUTE) to parameter.getAttribute(VALUE_ATTRIBUTE)
+                    .ifEmpty { parameter.textContent.trim() }
+            }
+        }
+
+        return TeamCityVcsRoot(
+            id = file.nameWithoutExtension,
+            name = root.getElementsByTagName(NAME_ELEMENT).item(0).textContent.trim(),
+            url = parameters.getValue(URL_PARAMETER),
+            defaultBranchRef = parameters.getValue(BRANCH_PARAMETER),
+            branchSpec = parameters.getValue(BRANCH_SPEC_PARAMETER)
+                .lineSequence()
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .toList()
+        )
+    }
+
+    private fun readYaml(file: File): Map<String, Any?> {
+        val settings = LoadSettings.builder()
+            .setLabel(file.path)
+            .build()
+        return file.inputStream().use { input ->
+            Load(settings).loadFromInputStream(input)
+        }.asStringMap(file.name)
+    }
+
+    private fun readXml(file: File): Document {
+        require(file.isFile) { "TeamCity generated file does not exist: ${file.path}" }
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+            isXIncludeAware = false
+            isExpandEntityReferences = false
+        }
+        return factory.newDocumentBuilder().parse(file)
+    }
+
+    private fun Any?.asStringMap(context: String): Map<String, Any?> {
+        val source = this as? Map<*, *> ?: error("Expected YAML mapping for $context")
+        return source.entries.associate { (key, value) ->
+            val stringKey = key as? String ?: error("Expected string key in $context")
+            stringKey to value
+        }
+    }
+
+    private fun Map<String, Any?>.requiredMap(key: String): Map<String, Any?> =
+        get(key).asStringMap(key)
+
+    private fun Map<String, Any?>.optionalList(key: String): List<Any?> =
+        when (val value = get(key)) {
+            null -> emptyList()
+            is List<*> -> value
+            else -> error("Expected YAML list '$key'")
+        }
+
+    private fun Map<String, Any?>.requiredString(key: String): String =
+        get(key) as? String ?: error("Expected YAML string '$key'")
+
+    private fun Map<String, Any?>.optionalString(key: String): String? =
+        get(key)?.let { value -> value as? String ?: error("Expected YAML string '$key'") }
+
+    private fun Map<String, Any?>.requiredBoolean(key: String): Boolean =
+        get(key) as? Boolean ?: error("Expected YAML boolean '$key'")
+
+    private companion object {
+        const val PIPELINE_FILE_NAME = "pipeline.yml"
+        const val PROJECT_CONFIG_FILE_NAME = "project-config.xml"
+        const val BUILD_TYPES_DIRECTORY_NAME = "buildTypes"
+        const val VCS_ROOTS_DIRECTORY_NAME = "vcsRoots"
+        const val XML_EXTENSION = "xml"
+        const val NAME_ELEMENT = "name"
+        const val BUILD_TRIGGER_ELEMENT = "build-trigger"
+        const val PARAM_ELEMENT = "param"
+        const val NAME_ATTRIBUTE = "name"
+        const val VALUE_ATTRIBUTE = "value"
+        const val TYPE_ATTRIBUTE = "type"
+        const val VCS_TRIGGER_TYPE = "vcsTrigger"
+        const val BUILD_DEPENDENCY_TRIGGER_TYPE = "buildDependencyTrigger"
+        const val BRANCH_FILTER_PARAMETER = "branchFilter"
+        const val DEPENDS_ON_PARAMETER = "dependsOn"
+        const val AFTER_SUCCESS_PARAMETER = "afterSuccessfulBuildOnly"
+        const val URL_PARAMETER = "url"
+        const val BRANCH_PARAMETER = "branch"
+        const val BRANCH_SPEC_PARAMETER = "branchSpec"
+        const val JOBS_KEY = "jobs"
+        const val NAME_KEY = "name"
+        const val STEPS_KEY = "steps"
+        const val REPOSITORIES_KEY = "repositories"
+        const val FILES_PUBLICATION_KEY = "files-publication"
+        const val DEPENDENCIES_KEY = "dependencies"
+        const val FEATURES_KEY = "features"
+        const val TYPE_KEY = "type"
+        const val ID_KEY = "id"
+        const val SCRIPT_CONTENT_KEY = "script-content"
+        const val PATH_KEY = "path"
+        const val PUBLISH_ARTIFACT_KEY = "publish-artifact"
+        const val SHARE_WITH_JOBS_KEY = "share-with-jobs"
+        const val FILES_KEY = "files"
+        const val STATUS_PUBLISHER_TYPE = "commit-status-publisher"
+        const val CHECK_NAME_KEY = "build_custom_name"
+    }
+}

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiExternalTopologyYamlReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiExternalTopologyYamlReader.kt
@@ -1,0 +1,107 @@
+package com.marmatsan.figmaDesignSync.data.yaml.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConnection
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import me.tatarka.inject.annotations.Inject
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+import java.time.LocalDate
+
+/**
+ * Parses the repository-owned external CI topology YAML.
+ */
+@Inject
+class CiExternalTopologyYamlReader {
+    fun read(file: File): CiExternalTopology {
+        val settings = LoadSettings.builder()
+            .setLabel(file.path)
+            .build()
+        val root = file.inputStream().use { input ->
+            Load(settings).loadFromInputStream(input)
+        }.asStringMap("root")
+
+        val validation = root.requiredMap("validation")
+
+        return CiExternalTopology(
+            schemaVersion = root.requiredInt("schemaVersion"),
+            validation = CiExternalTopology.Validation(
+                lastValidatedOn = LocalDate.parse(validation.requiredString("lastValidatedOn")),
+                warnAfterDays = validation.requiredInt("warnAfterDays")
+            ),
+            nodes = root.requiredList("nodes").map(::readNode),
+            connections = root.requiredList("connections").map(::readConnection)
+        )
+    }
+
+    private fun readNode(value: Any?): CiNode {
+        val node = value.asStringMap("node")
+        val serializedType = node.requiredString("type")
+        val type = CiNode.Type.entries.singleOrNull { candidate ->
+            candidate.serializedName == serializedType
+        } ?: error("Unsupported CI node type '$serializedType'")
+
+        return CiNode(
+            id = node.requiredString("id"),
+            type = type,
+            name = node.requiredString("name"),
+            description = node.requiredString("description")
+        )
+    }
+
+    private fun readConnection(value: Any?): CiConnection {
+        val connection = value.asStringMap("connection")
+        val serializedAutomation = connection.requiredString("automation")
+        val automation = CiConnection.Automation.entries.singleOrNull { candidate ->
+            candidate.serializedName == serializedAutomation
+        } ?: error("Unsupported CI connection automation '$serializedAutomation'")
+
+        return CiConnection(
+            id = connection.requiredString("id"),
+            sourceNodeId = connection.requiredString("source"),
+            targetNodeId = connection.requiredString("target"),
+            label = connection.requiredString("label"),
+            description = connection.requiredString("description"),
+            protocol = connection.optionalString("protocol"),
+            authentication = connection.optionalStringList("authentication"),
+            policy = connection.optionalString("policy"),
+            path = connection.optionalString("path"),
+            automation = automation,
+            annotation = connection.optionalString("annotation")
+        )
+    }
+
+    private fun Any?.asStringMap(context: String): Map<String, Any?> {
+        val source = this as? Map<*, *> ?: error("Expected YAML mapping for $context")
+        return source.entries.associate { (key, value) ->
+            val stringKey = key as? String ?: error("Expected string key in $context")
+            stringKey to value
+        }
+    }
+
+    private fun Map<String, Any?>.requiredMap(key: String): Map<String, Any?> =
+        get(key).asStringMap(key)
+
+    private fun Map<String, Any?>.requiredList(key: String): List<Any?> =
+        get(key) as? List<*> ?: error("Expected YAML list '$key'")
+
+    private fun Map<String, Any?>.requiredString(key: String): String =
+        get(key) as? String ?: error("Expected YAML string '$key'")
+
+    private fun Map<String, Any?>.optionalString(key: String): String? =
+        get(key)?.let { value -> value as? String ?: error("Expected YAML string '$key'") }
+
+    private fun Map<String, Any?>.requiredInt(key: String): Int =
+        (get(key) as? Number)?.toInt() ?: error("Expected YAML integer '$key'")
+
+    private fun Map<String, Any?>.optionalStringList(key: String): List<String> =
+        when (val value = get(key)) {
+            null -> emptyList()
+            is List<*> -> value.map { item ->
+                item as? String ?: error("Expected string value in YAML list '$key'")
+            }
+
+            else -> error("Expected YAML list '$key'")
+        }
+}

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReaderTest.kt
@@ -1,0 +1,112 @@
+package com.marmatsan.figmaDesignSync.data.teamcity.configuration
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityTrigger
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Files
+
+internal class TeamCityGeneratedConfigurationReaderTest : FunSpec({
+
+    test("read assembles pipelines jobs triggers artifacts checks and VCS roots") {
+        // GIVEN
+        val root = Files.createTempDirectory("teamcity-generated").toFile()
+        val pipeline = root.resolve("Root_Ci").apply { mkdirs() }
+        pipeline.resolve("project-config.xml").writeText(
+            """
+            <project>
+              <name>CI</name>
+            </project>
+            """.trimIndent()
+        )
+        pipeline.resolve("pipeline.yml").writeText(
+            """
+            version: 1
+            jobs:
+              verify:
+                name: Verify
+                steps:
+                  - script-content: .\gradlew.bat check
+                    name: Run Gradle check
+                    id: RUNNER_1
+                    type: script
+                features:
+                  - type: commit-status-publisher
+                    build_custom_name: TeamCity CI
+                repositories:
+                  - Root_GitHub:
+                      enabled: true
+                      path: ""
+                files-publication:
+                  - path: build/report.json
+                    publish-artifact: true
+                    share-with-jobs: true
+                dependencies:
+                  - prepare:
+                      files:
+                        - build/input.json
+            """.trimIndent()
+        )
+        pipeline.resolve("buildTypes").mkdirs()
+        pipeline.resolve("buildTypes/Root_Ci.xml").writeText(
+            """
+            <build-type>
+              <settings>
+                <build-triggers>
+                  <build-trigger id="TRIGGER_1" type="vcsTrigger">
+                    <parameters>
+                      <param name="branchFilter" value="+:*" />
+                    </parameters>
+                  </build-trigger>
+                </build-triggers>
+              </settings>
+            </build-type>
+            """.trimIndent()
+        )
+        writeVcsRoot(root)
+
+        // WHEN
+        val configuration = TeamCityGeneratedConfigurationReader().read(root)
+
+        // THEN
+        val actualPipeline = configuration.pipelines.single()
+        actualPipeline.id shouldBe "Root_Ci"
+        actualPipeline.name shouldBe "CI"
+        actualPipeline.triggers.single() shouldBe TeamCityTrigger(
+            type = TeamCityTrigger.Type.Vcs,
+            branchFilter = "+:*",
+            dependencyPipelineId = null,
+            afterSuccessfulBuildOnly = null
+        )
+
+        val job = actualPipeline.jobs.single()
+        job.id shouldBe "verify"
+        job.name shouldBe "Verify"
+        job.steps.single().command shouldBe ".\\gradlew.bat check"
+        job.repositoryIds shouldBe listOf("Root_GitHub")
+        job.artifacts.single().path shouldBe "build/report.json"
+        job.dependencies.single().artifactPaths shouldBe listOf("build/input.json")
+        job.publishedChecks.single().name shouldBe "TeamCity CI"
+
+        val vcsRoot = configuration.vcsRoots.single()
+        vcsRoot.id shouldBe "Root_GitHub"
+        vcsRoot.name shouldBe "water-my-plants"
+        vcsRoot.defaultBranchRef shouldBe "refs/heads/main"
+        vcsRoot.branchSpec shouldBe listOf("#! fallbackToDefault: false", "+:refs/heads/(*)")
+    }
+})
+
+private fun writeVcsRoot(root: File) {
+    val vcsRoots = root.resolve("Root/vcsRoots").apply { mkdirs() }
+    vcsRoots.resolve("Root_GitHub.xml").writeText(
+        """
+        <vcs-root type="jetbrains.git">
+          <name>water-my-plants</name>
+          <param name="branch" value="refs/heads/main" />
+          <param name="branchSpec"><![CDATA[#! fallbackToDefault: false
+        +:refs/heads/(*)]]></param>
+          <param name="url" value="https://github.com/marmatsan/water-my-plants.git" />
+        </vcs-root>
+        """.trimIndent()
+    )
+}

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiExternalTopologyYamlReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiExternalTopologyYamlReaderTest.kt
@@ -1,0 +1,100 @@
+package com.marmatsan.figmaDesignSync.data.yaml.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConnection
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.time.LocalDate
+
+internal class CiExternalTopologyYamlReaderTest : FunSpec({
+
+    test("read maps versioned nodes connections and validation metadata") {
+        // GIVEN
+        val file = Files.createTempFile("external-topology", ".yaml").toFile().apply {
+            writeText(
+                """
+                schemaVersion: 1
+                validation:
+                  lastValidatedOn: "2026-07-14"
+                  warnAfterDays: 90
+                nodes:
+                  - id: operator
+                    type: actor
+                    name: Operator
+                    description: Starts the manual flow.
+                  - id: teamcity-server
+                    type: system
+                    name: TeamCity Server
+                    description: Orchestrates CI.
+                connections:
+                  - id: operator-teamcity
+                    source: operator
+                    target: teamcity-server
+                    label: Start build
+                    description: Requests a build through TeamCity.
+                    protocol: HTTPS
+                    authentication:
+                      - TeamCity access token
+                    policy: Service Auth
+                    automation: manual
+                    annotation: The interface may be the UI or CLI.
+                """.trimIndent()
+            )
+        }
+
+        // WHEN
+        val topology = CiExternalTopologyYamlReader().read(file)
+
+        // THEN
+        topology.schemaVersion shouldBe 1
+        topology.validation.lastValidatedOn shouldBe LocalDate.of(2026, 7, 14)
+        topology.validation.warnAfterDays shouldBe 90
+        topology.nodes.map(CiNode::id) shouldBe listOf("operator", "teamcity-server")
+        topology.connections.single() shouldBe CiConnection(
+            id = "operator-teamcity",
+            sourceNodeId = "operator",
+            targetNodeId = "teamcity-server",
+            label = "Start build",
+            description = "Requests a build through TeamCity.",
+            protocol = "HTTPS",
+            authentication = listOf("TeamCity access token"),
+            policy = "Service Auth",
+            path = null,
+            automation = CiConnection.Automation.Manual,
+            annotation = "The interface may be the UI or CLI."
+        )
+    }
+
+    test("read rejects connections to unknown nodes") {
+        // GIVEN
+        val file = Files.createTempFile("invalid-external-topology", ".yaml").toFile().apply {
+            writeText(
+                """
+                schemaVersion: 1
+                validation:
+                  lastValidatedOn: "2026-07-14"
+                  warnAfterDays: 90
+                nodes:
+                  - id: operator
+                    type: actor
+                    name: Operator
+                    description: Starts the manual flow.
+                connections:
+                  - id: missing-target
+                    source: operator
+                    target: teamcity-server
+                    label: Start build
+                    description: Invalid endpoint.
+                    automation: manual
+                """.trimIndent()
+            )
+        }
+
+        // WHEN / THEN
+        shouldThrow<IllegalArgumentException> {
+            CiExternalTopologyYamlReader().read(file)
+        }.message shouldBe "Unknown CI connection target 'teamcity-server'"
+    }
+})

--- a/repo/figma-design-sync/docs/bdd/README.md
+++ b/repo/figma-design-sync/docs/bdd/README.md
@@ -89,6 +89,8 @@ Gherkin steps.
 | `repository catalog trees are available`       | `water-my-plants-catalog` trees and configured included-build settings catalogs through `ProjectCatalogTreesPort` | `FakeProjectCatalogTreesPort` in `DesignModelSteps.kt`       |
 | `repository project modules are available`     | `settings.gradle.kts` and configured included-build settings files through `ProjectModulesPort`                     | `FakeProjectModulesPort` in `DesignModelSteps.kt`            |
 | `repository module dependencies are available` | Project `build.gradle.kts` dependency blocks through `ProjectModuleDependenciesPort`                         | `FakeProjectModuleDependenciesPort` in `DesignModelSteps.kt` |
+| `the external CI topology is available`         | `docs/ci/external-topology.yaml` through `CiExternalTopologyPort`                                            | `FakeCiExternalTopologyPort` in `DesignModelSteps.kt`        |
+| `the effective TeamCity configuration is available` | `.teamcity/target/generated-configs` through `TeamCityConfigurationPort`                                  | `FakeTeamCityConfigurationPort` in `DesignModelSteps.kt`     |
 | `the design model is generated`                | `FigmaDesignModelGenerator` producing the in-memory design model                                             | Direct generator call from `DesignModelSteps.kt`             |
 | `generateFigmaDesignModel runs`                | Gradle task writing `build/reports/figma-sync/design-model.json`                                             | Temporary Gradle project assembled by `GradleTaskSteps.kt`   |
 
@@ -114,6 +116,8 @@ The contract has these inputs:
 | Catalog trees            | Water My Plants declarations from `dependency-catalog:water-my-plants-catalog` and configured included-build catalog declarations |
 | Project modules          | Root and configured included-build Gradle settings                                                          |
 | Module dependency graphs | Parsed `build.gradle.kts` dependency blocks for root and configured included-build modules                  |
+| External CI topology     | `docs/ci/external-topology.yaml`                                                                            |
+| Effective TeamCity model | Generated XML and YAML under `.teamcity/target/generated-configs`                                           |
 
 The contract has one main output:
 
@@ -131,12 +135,13 @@ The contract has one main output:
 | `catalogs`           | Dependency and plugin trees for Water My Plants, configured included builds, custom Gradle convention plugins, and plugins, including direct and convention-plugin-provided usage metadata. |
 | `modules`            | Sorted Gradle module paths discovered from root and configured included-build settings files.                            |
 | `moduleDependencies` | Main and configured included-build module dependency edges, grouped by graph scope.                                      |
+| `ci`                 | Versioned external topology plus effective TeamCity pipelines, jobs, triggers, artifacts, checks, and VCS roots.         |
 
 The current executable scenarios assert these guarantees:
 
 - The model contains repository metadata.
-- The model contains `versions`, `versionSections`, `catalogs`, `modules`, and
-  `moduleDependencies`.
+- The model contains `versions`, `versionSections`, `catalogs`, `modules`,
+  `moduleDependencies`, and `ci`.
 - Version keys are sorted.
 - Version sections keep repository order.
 - The model stores a reproducible `modelHash`.

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -68,7 +68,7 @@ The TeamCity artifact JSON contains:
 - `modelHash`
 
 `content` is the stable comparison body. It includes `versions`,
-`versionSections`, `catalogs`, `modules`, and `moduleDependencies`.
+`versionSections`, `catalogs`, `modules`, `moduleDependencies`, and `ci`.
 `modelHash` is calculated from stable model content and excludes `branch`,
 `gitSha`, `generatedAt`, and `modelHash` itself.
 
@@ -126,5 +126,11 @@ Important generation details:
   `projects.domain`. Type-safe accessors are resolved against module build
   directories so camel-case accessors such as `projects.catalogCore` retain
   the declared kebab-case module path `:catalog-core`.
+- `content.ci.externalTopology` comes from
+  `docs/ci/external-topology.yaml`.
+- `content.ci.teamCity` comes from the effective configuration generated under
+  `.teamcity/target/generated-configs`. The official TeamCity jobs run
+  `.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate` before invoking
+  either `generateFigmaDesignModel` or `checkFigmaTrunkSync`.
 - Module dependency graphs are no longer rendered into the deleted Figma
   `dependency of modules` section. They belong in PlantUML architecture docs.

--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -34,6 +34,20 @@ Catalog tree visual targets:
 | `figmaDesignSync.libraries` | `repo/figma-design-sync/settings.gradle.kts` | `63573:260` |
 | `figmaDesignSync.plugins` | `repo/figma-design-sync/settings.gradle.kts` | `63573:346` |
 
+CI documentation visual targets:
+
+| Model target | Source | Figma scope |
+|--------------|--------|-------------|
+| `ci.overview` | `content.ci` aggregate | `Overview` inside page `63153:2876` |
+| `ci.pullRequestIntegration` | Effective `.teamcity/settings.kts` model and branch protection contract | `Pull Request Integration` inside page `63153:2876` |
+| `ci.postMergeDesignDocumentation` | Effective Figma Sync pipeline and the operator/MCP loop | `Post-merge Design Documentation` inside page `63153:2876` |
+| `ci.infrastructureAndAccess` | `docs/ci/external-topology.yaml` | `Infrastructure and Access` inside page `63153:2876` |
+
+The four targets share the parent section `Continuous Integration and Design
+Documentation`. Run one target at a time while iterating; the writer reuses the
+parent and only replaces nodes and connectors managed by the requested child
+section.
+
 ## Execution Order
 
 Run visual updates by granular target. Do not run `metadata` until every visual
@@ -63,7 +77,11 @@ alone when you only want to inspect the contract without changing visuals.
 | 8 | `gradlePlugins.plugins` | Declared catalog target from `repo/gradle-plugins` plugins catalog | Stale hidden section after removing `create("plugins")` | Empty or omitted catalog removes the target section; declared catalog nodes match the settings catalog. |
 | 9 | `figmaDesignSync.libraries` | `repo/figma-design-sync` libraries catalog | Large artifact/bundle update with stale nested component internals | Returned `completedTargets` contains the target and no metadata. |
 | 10 | `figmaDesignSync.plugins` | `repo/figma-design-sync` plugins catalog | Missing plugin tree connector or stale plugin aliases | Returned catalog nodes match the settings catalog. |
-| 11 | `metadata` | Shared plugin sync metadata | Metadata written before visual targets complete | Figma shared plugin data matches the TeamCity artifact. |
+| 11 | `ci.overview` | Simplified PR and post-merge journeys | Generic connector labels or missing check/gate distinction | Trigger, check, gate, merge, artifact, and hash-verification connections have explicit labels. |
+| 12 | `ci.pullRequestIntegration` | Detailed PR pipeline, jobs, checks, and merge gate | Effective TeamCity job or published check missing from Figma | Nodes and summarized steps match `content.ci.teamCity`. |
+| 13 | `ci.postMergeDesignDocumentation` | Official model generation and operator-assisted visual update loop | Automatic Figma write implied, artifact missing, or rerun loop absent | `design-model.json`, the operator/Codex handoff, and `Manual rerun` are visible. |
+| 14 | `ci.infrastructureAndAccess` | GitHub, Cloudflare, TeamCity, Figma, browser, CLI, and operator topology | Connection collapsed or external system duplicated from TeamCity DSL | Nodes and directed connections match `content.ci.externalTopology`. |
+| 15 | `metadata` | Shared plugin sync metadata | Metadata written before visual targets complete | Figma shared plugin data matches the TeamCity artifact. |
 
 ## Subtree Scoped Runs
 

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -61,6 +61,42 @@ Partial root sync is a repair/execution granularity, not a completion signal.
 The official metadata (`gitSha` and `modelHash`) must be written only after all
 required roots and all other official targets have completed successfully.
 
+## CI Documentation Visual Sync
+
+The CI writer reads only `content.ci` from the official `main`
+`design-model.json`. It creates or updates one parent section named
+`Continuous Integration and Design Documentation` on Figma page `63153:2876`
+and exposes four independently runnable targets:
+
+- `ci.overview`;
+- `ci.pullRequestIntegration`;
+- `ci.postMergeDesignDocumentation`;
+- `ci.infrastructureAndAccess`.
+
+Each visual entity is an instance of `.ci node` (`64301:3927`). The writer
+selects the matching mode from the `ci/cd` variable collection: `Actor`,
+`System`, `Git reference`, `Pipeline`, `Job`, `Artifact`, `Check`, or `Gate`.
+It binds the exposed `name`, `description`, `steps`, and `source` text
+properties and controls `show steps` and `show source` from actual model
+content. Commands are summarized for display; the `source` row links to the
+canonical file on GitHub `main`, where the literal DSL remains available.
+
+Every `.ci node` instance is the only child of a managed group. Native Figma
+connectors attach from the bottom of the source group to the top of the target
+group, remain children of the target section, and are inserted behind nodes.
+The writer derives labels from triggers and connection purposes rather than
+using generic continuation text.
+
+Child CI sections have no fill and use the standard outline stroke contract.
+They are stacked with 114 px between sections. The parent owns the only direct
+`.Header`, uses the surface fill and 28 px corner radius, has no stroke, and is
+the only node locked after synchronization. A granular rerun removes and
+recreates only content marked as managed inside the requested child section;
+other CI child sections remain untouched.
+
+Preflight for a CI target validates the destination page, the `.ci node`
+component properties, and all required `ci/cd` modes before visual mutation.
+
 ## Version Visual Sync
 
 The version sync reads `content.versionSections` from `design-model.json` and

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiConnection.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiConnection.kt
@@ -1,0 +1,24 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * Directed external connection between two [CiNode] values.
+ */
+data class CiConnection(
+    val id: String,
+    val sourceNodeId: String,
+    val targetNodeId: String,
+    val label: String,
+    val description: String,
+    val protocol: String?,
+    val authentication: List<String>,
+    val policy: String?,
+    val path: String?,
+    val automation: Automation,
+    val annotation: String?
+) {
+    enum class Automation(val serializedName: String) {
+        Manual("manual"),
+        Automatic("automatic"),
+        OperatorAssisted("operator-assisted")
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiExternalTopology.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiExternalTopology.kt
@@ -1,0 +1,40 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+import java.time.LocalDate
+
+/**
+ * Versioned snapshot of external CI systems and their directed connections.
+ */
+data class CiExternalTopology(
+    val schemaVersion: Int,
+    val validation: Validation,
+    val nodes: List<CiNode>,
+    val connections: List<CiConnection>
+) {
+    init {
+        require(schemaVersion > 0) { "CI topology schemaVersion must be positive" }
+        require(validation.warnAfterDays > 0) { "CI topology warnAfterDays must be positive" }
+
+        val nodeIds = nodes.map(CiNode::id)
+        require(nodeIds.size == nodeIds.toSet().size) { "CI topology node ids must be unique" }
+
+        val connectionIds = connections.map(CiConnection::id)
+        require(connectionIds.size == connectionIds.toSet().size) {
+            "CI topology connection ids must be unique"
+        }
+
+        connections.forEach { connection ->
+            require(connection.sourceNodeId in nodeIds) {
+                "Unknown CI connection source '${connection.sourceNodeId}'"
+            }
+            require(connection.targetNodeId in nodeIds) {
+                "Unknown CI connection target '${connection.targetNodeId}'"
+            }
+        }
+    }
+
+    data class Validation(
+        val lastValidatedOn: LocalDate,
+        val warnAfterDays: Int
+    )
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiNode.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiNode.kt
@@ -1,0 +1,22 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * External entity rendered in the CI documentation model.
+ */
+data class CiNode(
+    val id: String,
+    val type: Type,
+    val name: String,
+    val description: String
+) {
+    enum class Type(val serializedName: String) {
+        Actor("actor"),
+        System("system"),
+        GitReference("git reference"),
+        Pipeline("pipeline"),
+        Job("job"),
+        Artifact("artifact"),
+        Check("check"),
+        Gate("gate")
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityConfiguration.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityConfiguration.kt
@@ -1,0 +1,18 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * Effective TeamCity configuration used as the CI visual model input.
+ */
+data class TeamCityConfiguration(
+    val pipelines: List<TeamCityPipeline>,
+    val vcsRoots: List<TeamCityVcsRoot>
+) {
+    init {
+        require(pipelines.map(TeamCityPipeline::id).let { ids -> ids.size == ids.toSet().size }) {
+            "TeamCity pipeline ids must be unique"
+        }
+        require(vcsRoots.map(TeamCityVcsRoot::id).let { ids -> ids.size == ids.toSet().size }) {
+            "TeamCity VCS root ids must be unique"
+        }
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityJob.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityJob.kt
@@ -1,0 +1,35 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * Effective TeamCity job and the operational details rendered in Figma.
+ */
+data class TeamCityJob(
+    val id: String,
+    val name: String,
+    val steps: List<Step>,
+    val repositoryIds: List<String>,
+    val artifacts: List<Artifact>,
+    val dependencies: List<Dependency>,
+    val publishedChecks: List<PublishedCheck>
+) {
+    data class Step(
+        val id: String,
+        val name: String,
+        val command: String
+    )
+
+    data class Artifact(
+        val path: String,
+        val publish: Boolean,
+        val shareWithJobs: Boolean
+    )
+
+    data class Dependency(
+        val jobId: String,
+        val artifactPaths: List<String>
+    )
+
+    data class PublishedCheck(
+        val name: String
+    )
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityPipeline.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityPipeline.kt
@@ -1,0 +1,11 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * Effective TeamCity pipeline assembled from generated YAML and XML.
+ */
+data class TeamCityPipeline(
+    val id: String,
+    val name: String,
+    val triggers: List<TeamCityTrigger>,
+    val jobs: List<TeamCityJob>
+)

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityTrigger.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityTrigger.kt
@@ -9,8 +9,8 @@ data class TeamCityTrigger(
     val dependencyPipelineId: String?,
     val afterSuccessfulBuildOnly: Boolean?
 ) {
-    enum class Type {
-        Vcs,
-        PipelineFinish
+    enum class Type(val serializedName: String) {
+        Vcs("vcs"),
+        PipelineFinish("pipeline finish")
     }
 }

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityTrigger.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityTrigger.kt
@@ -1,0 +1,16 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * Effective TeamCity pipeline trigger extracted from generated configuration.
+ */
+data class TeamCityTrigger(
+    val type: Type,
+    val branchFilter: String?,
+    val dependencyPipelineId: String?,
+    val afterSuccessfulBuildOnly: Boolean?
+) {
+    enum class Type {
+        Vcs,
+        PipelineFinish
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityVcsRoot.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityVcsRoot.kt
@@ -1,0 +1,12 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+/**
+ * Repository metadata extracted from an effective TeamCity VCS root.
+ */
+data class TeamCityVcsRoot(
+    val id: String,
+    val name: String,
+    val url: String,
+    val defaultBranchRef: String,
+    val branchSpec: List<String>
+)

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiExternalTopologyPort.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiExternalTopologyPort.kt
@@ -1,0 +1,10 @@
+package com.marmatsan.figmaDesignSync.domain.port.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+
+/**
+ * Port for reading the repository-owned external CI topology.
+ */
+interface CiExternalTopologyPort {
+    fun readTopology(source: CiExternalTopologySource): CiExternalTopology
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiExternalTopologySource.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiExternalTopologySource.kt
@@ -1,0 +1,8 @@
+package com.marmatsan.figmaDesignSync.domain.port.ci
+
+/**
+ * Versioned external topology YAML source expressed as a path.
+ */
+data class CiExternalTopologySource(
+    val path: String
+)

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/TeamCityConfigurationPort.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/TeamCityConfigurationPort.kt
@@ -1,0 +1,10 @@
+package com.marmatsan.figmaDesignSync.domain.port.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
+
+/**
+ * Port for reading effective TeamCity generated configuration.
+ */
+interface TeamCityConfigurationPort {
+    fun readConfiguration(source: TeamCityGeneratedConfigurationSource): TeamCityConfiguration
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/TeamCityGeneratedConfigurationSource.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/TeamCityGeneratedConfigurationSource.kt
@@ -1,0 +1,8 @@
+package com.marmatsan.figmaDesignSync.domain.port.ci
+
+/**
+ * TeamCity generated configuration directory expressed as a path.
+ */
+data class TeamCityGeneratedConfigurationSource(
+    val directoryPath: String
+)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiExternalTopologyFreshnessChecker.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiExternalTopologyFreshnessChecker.kt
@@ -1,0 +1,35 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.ci
+
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import java.io.File
+import java.time.LocalDate
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * Evaluates whether the manually verified external CI topology is still fresh.
+ */
+@Inject
+internal class CiExternalTopologyFreshnessChecker(
+    private val ciExternalTopologyPort: CiExternalTopologyPort
+) {
+    fun check(topologyFile: File, currentDate: LocalDate): Result {
+        val topology = ciExternalTopologyPort.readTopology(
+            CiExternalTopologySource(topologyFile.absolutePath)
+        )
+        val warningDate = topology.validation.lastValidatedOn
+            .plusDays(topology.validation.warnAfterDays.toLong())
+
+        return Result(
+            lastValidatedOn = topology.validation.lastValidatedOn,
+            warningDate = warningDate,
+            warningRequired = currentDate.isAfter(warningDate)
+        )
+    }
+
+    data class Result(
+        val lastValidatedOn: LocalDate,
+        val warningDate: LocalDate,
+        val warningRequired: Boolean
+    )
+}

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncCheckRequest.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncCheckRequest.kt
@@ -20,6 +20,8 @@ internal data class FigmaTrunkSyncCheckRequest(
     val generatedAt: Instant,
     val versionsFile: File,
     val rootSettingsFile: File,
+    val ciExternalTopologyFile: File,
+    val teamCityGeneratedConfigurationDirectory: File,
     val projectRootDirectory: File,
     val includedBuilds: List<FigmaDesignModelIncludedBuildSource>
 )

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncChecker.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncChecker.kt
@@ -35,6 +35,8 @@ internal class FigmaTrunkSyncChecker(
                 generatedAt = request.generatedAt,
                 versionsFile = request.versionsFile,
                 rootSettingsFile = request.rootSettingsFile,
+                ciExternalTopologyFile = request.ciExternalTopologyFile,
+                teamCityGeneratedConfigurationDirectory = request.teamCityGeneratedConfigurationDirectory,
                 projectRootDirectory = request.projectRootDirectory,
                 includedBuilds = request.includedBuilds
             )

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
@@ -1,11 +1,15 @@
 package com.marmatsan.figmaDesignSync.plugin.di
 
 import com.marmatsan.figmaDesignSync.data.datasource.catalog.ProjectCatalogTreesDataSource
+import com.marmatsan.figmaDesignSync.data.datasource.ci.CiExternalTopologyDataSource
+import com.marmatsan.figmaDesignSync.data.datasource.ci.TeamCityConfigurationDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.modules.ProjectModuleDependenciesDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.modules.ProjectModulesDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.versions.RepositoryVersionsDataSource
 import com.marmatsan.figmaDesignSync.data.figma.client.FigmaFileContentClient
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModulesPort
 import com.marmatsan.figmaDesignSync.domain.port.versions.RepositoryVersionsPort
@@ -59,6 +63,14 @@ internal abstract class figmaDesignSyncComponent {
 
     @Provides
     protected fun projectCatalogTreesPort(dataSource: ProjectCatalogTreesDataSource): ProjectCatalogTreesPort =
+        dataSource
+
+    @Provides
+    protected fun ciExternalTopologyPort(dataSource: CiExternalTopologyDataSource): CiExternalTopologyPort =
+        dataSource
+
+    @Provides
+    protected fun teamCityConfigurationPort(dataSource: TeamCityConfigurationDataSource): TeamCityConfigurationPort =
         dataSource
 
     @Provides

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
@@ -17,6 +17,7 @@ import com.marmatsan.figmaDesignSync.plugin.checker.catalog.CatalogUsageChecker
 import com.marmatsan.figmaDesignSync.plugin.checker.sync.FigmaTrunkSyncChecker
 import com.marmatsan.figmaDesignSync.plugin.checker.versions.VersionNamingChecker
 import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelGenerator
+import com.marmatsan.figmaDesignSync.plugin.checker.ci.CiExternalTopologyFreshnessChecker
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 
@@ -33,6 +34,11 @@ internal abstract class figmaDesignSyncComponent {
      * Service used by `generateFigmaDesignModel`.
      */
     abstract val designModelGenerator: FigmaDesignModelGenerator
+
+    /**
+     * Service used by the non-blocking external topology freshness check.
+     */
+    abstract val ciExternalTopologyFreshnessChecker: CiExternalTopologyFreshnessChecker
 
     /**
      * Service used by `checkFigmaTrunkSync`.

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerationRequest.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerationRequest.kt
@@ -15,6 +15,9 @@ import java.time.Instant
  * @property generatedAt Timestamp written for traceability.
  * @property versionsFile Source `repo/dependency-catalog/versions.properties` file.
  * @property rootSettingsFile Root `settings.gradle.kts`.
+ * @property ciExternalTopologyFile Versioned external CI topology.
+ * @property teamCityGeneratedConfigurationDirectory Effective TeamCity
+ * configuration generated from `.teamcity/settings.kts`.
  * @property projectRootDirectory Repository root.
  * @property includedBuilds Included builds that contribute catalogs, modules,
  * and module dependency graphs.
@@ -25,6 +28,8 @@ internal data class FigmaDesignModelGenerationRequest(
     val generatedAt: Instant,
     val versionsFile: File,
     val rootSettingsFile: File,
+    val ciExternalTopologyFile: File,
+    val teamCityGeneratedConfigurationDirectory: File,
     val projectRootDirectory: File,
     val includedBuilds: List<FigmaDesignModelIncludedBuildSource>
 )

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
@@ -2,6 +2,10 @@ package com.marmatsan.figmaDesignSync.plugin.generator
 
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSource
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
 import com.marmatsan.figmaDesignSync.domain.port.gradle.IncludedBuildSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesScope
@@ -31,7 +35,9 @@ internal class FigmaDesignModelGenerator(
     private val repositoryVersionsPort: RepositoryVersionsPort,
     private val projectCatalogTreesPort: ProjectCatalogTreesPort,
     private val projectModulesPort: ProjectModulesPort,
-    private val projectModuleDependenciesPort: ProjectModuleDependenciesPort
+    private val projectModuleDependenciesPort: ProjectModuleDependenciesPort,
+    private val ciExternalTopologyPort: CiExternalTopologyPort,
+    private val teamCityConfigurationPort: TeamCityConfigurationPort
 ) {
     /**
      * Generates the complete model and stable model hash for [request].
@@ -89,6 +95,27 @@ internal class FigmaDesignModelGenerator(
                     .toSortedJsonArray()
             )
             put("moduleDependencies", buildModuleDependencies(request))
+            put("ci", buildCi(request))
+        }
+
+    private fun buildCi(request: FigmaDesignModelGenerationRequest) =
+        buildJsonObject {
+            put(
+                "externalTopology",
+                ciExternalTopologyPort
+                    .readTopology(CiExternalTopologySource(request.ciExternalTopologyFile.absolutePath))
+                    .toDesignJson()
+            )
+            put(
+                "teamCity",
+                teamCityConfigurationPort
+                    .readConfiguration(
+                        TeamCityGeneratedConfigurationSource(
+                            request.teamCityGeneratedConfigurationDirectory.absolutePath
+                        )
+                    )
+                    .toDesignJson()
+            )
         }
 
     private fun buildCatalogs(request: FigmaDesignModelGenerationRequest) =
@@ -198,6 +225,6 @@ internal class FigmaDesignModelGenerator(
         }
 
     private companion object {
-        const val SCHEMA_VERSION = 2
+        const val SCHEMA_VERSION = 3
     }
 }

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
@@ -8,6 +8,12 @@ import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityPipeline
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityVcsRoot
 import com.marmatsan.figmaDesignSync.domain.model.modules.ModuleDependency
 import com.marmatsan.figmaDesignSync.domain.model.versions.RepositoryVersionSection
 import kotlinx.serialization.json.JsonArray
@@ -209,3 +215,163 @@ internal fun Collection<ModuleDependency>.toModuleDependenciesJson(): JsonArray 
             }
         }
         .let(::JsonArray)
+
+/**
+ * Converts the versioned external CI topology to its stable model shape.
+ */
+internal fun CiExternalTopology.toDesignJson(): JsonObject =
+    buildJsonObject {
+        put("schemaVersion", schemaVersion)
+        put(
+            "validation",
+            buildJsonObject {
+                put("lastValidatedOn", validation.lastValidatedOn.toString())
+                put("warnAfterDays", validation.warnAfterDays)
+            }
+        )
+        put(
+            "nodes",
+            nodes
+                .sortedBy(CiNode::id)
+                .map { node ->
+                    buildJsonObject {
+                        put("id", node.id)
+                        put("type", node.type.serializedName)
+                        put("name", node.name)
+                        put("description", node.description)
+                    }
+                }
+                .let(::JsonArray)
+        )
+        put(
+            "connections",
+            connections
+                .sortedBy { connection -> connection.id }
+                .map { connection ->
+                    buildJsonObject {
+                        put("id", connection.id)
+                        put("source", connection.sourceNodeId)
+                        put("target", connection.targetNodeId)
+                        put("label", connection.label)
+                        put("description", connection.description)
+                        put("protocol", connection.protocol.toJsonPrimitiveOrNull())
+                        put("authentication", connection.authentication.toSortedJsonArray())
+                        put("policy", connection.policy.toJsonPrimitiveOrNull())
+                        put("path", connection.path.toJsonPrimitiveOrNull())
+                        put("automation", connection.automation.serializedName)
+                        put("annotation", connection.annotation.toJsonPrimitiveOrNull())
+                    }
+                }
+                .let(::JsonArray)
+        )
+    }
+
+/**
+ * Converts effective TeamCity pipelines and VCS roots to stable JSON.
+ */
+internal fun TeamCityConfiguration.toDesignJson(): JsonObject =
+    buildJsonObject {
+        put(
+            "pipelines",
+            pipelines
+                .sortedBy(TeamCityPipeline::id)
+                .map(TeamCityPipeline::toDesignJson)
+                .let(::JsonArray)
+        )
+        put(
+            "vcsRoots",
+            vcsRoots
+                .sortedBy(TeamCityVcsRoot::id)
+                .map { vcsRoot ->
+                    buildJsonObject {
+                        put("id", vcsRoot.id)
+                        put("name", vcsRoot.name)
+                        put("url", vcsRoot.url)
+                        put("defaultBranchRef", vcsRoot.defaultBranchRef)
+                        put("branchSpec", vcsRoot.branchSpec.toJsonArray())
+                    }
+                }
+                .let(::JsonArray)
+        )
+    }
+
+private fun TeamCityPipeline.toDesignJson(): JsonObject =
+    buildJsonObject {
+        put("id", id)
+        put("name", name)
+        put(
+            "triggers",
+            triggers
+                .map { trigger ->
+                    buildJsonObject {
+                        put("type", trigger.type.serializedName)
+                        put("branchFilter", trigger.branchFilter.toJsonPrimitiveOrNull())
+                        put("dependencyPipelineId", trigger.dependencyPipelineId.toJsonPrimitiveOrNull())
+                        put(
+                            "afterSuccessfulBuildOnly",
+                            trigger.afterSuccessfulBuildOnly?.let(::JsonPrimitive) ?: JsonNull
+                        )
+                    }
+                }
+                .let(::JsonArray)
+        )
+        put(
+            "jobs",
+            jobs
+                .sortedBy(TeamCityJob::id)
+                .map(TeamCityJob::toDesignJson)
+                .let(::JsonArray)
+        )
+    }
+
+private fun TeamCityJob.toDesignJson(): JsonObject =
+    buildJsonObject {
+        put("id", id)
+        put("name", name)
+        put(
+            "steps",
+            steps.map { step ->
+                buildJsonObject {
+                    put("id", step.id)
+                    put("name", step.name)
+                    put("command", step.command)
+                }
+            }.let(::JsonArray)
+        )
+        put("repositoryIds", repositoryIds.toSortedJsonArray())
+        put(
+            "artifacts",
+            artifacts
+                .sortedBy(TeamCityJob.Artifact::path)
+                .map { artifact ->
+                    buildJsonObject {
+                        put("path", artifact.path)
+                        put("publish", artifact.publish)
+                        put("shareWithJobs", artifact.shareWithJobs)
+                    }
+                }
+                .let(::JsonArray)
+        )
+        put(
+            "dependencies",
+            dependencies
+                .sortedBy(TeamCityJob.Dependency::jobId)
+                .map { dependency ->
+                    buildJsonObject {
+                        put("jobId", dependency.jobId)
+                        put("artifactPaths", dependency.artifactPaths.toSortedJsonArray())
+                    }
+                }
+                .let(::JsonArray)
+        )
+        put(
+            "publishedChecks",
+            publishedChecks
+                .sortedBy(TeamCityJob.PublishedCheck::name)
+                .map { check -> buildJsonObject { put("name", check.name) } }
+                .let(::JsonArray)
+        )
+    }
+
+private fun String?.toJsonPrimitiveOrNull() =
+    this?.let(::JsonPrimitive) ?: JsonNull

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaCatalogChecksExtension.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaCatalogChecksExtension.kt
@@ -84,6 +84,16 @@ abstract class figmaDesignSyncExtension @Inject constructor(
     val rootSettingsFile: RegularFileProperty = objects.fileProperty()
 
     /**
+     * Versioned external systems and connections rendered in CI documentation.
+     */
+    val ciExternalTopologyFile: RegularFileProperty = objects.fileProperty()
+
+    /**
+     * Effective TeamCity configuration generated from the versioned Kotlin DSL.
+     */
+    val teamCityGeneratedConfigurationDirectory: DirectoryProperty = objects.directoryProperty()
+
+    /**
      * Included builds that contribute repository model data.
      */
     val includedBuilds: NamedDomainObjectContainer<FigmaDesignSyncIncludedBuild> =
@@ -99,6 +109,10 @@ abstract class figmaDesignSyncExtension @Inject constructor(
     init {
         versionsFile.convention(layout.projectDirectory.file("repo/dependency-catalog/versions.properties"))
         rootSettingsFile.convention(layout.projectDirectory.file("settings.gradle.kts"))
+        ciExternalTopologyFile.convention(layout.projectDirectory.file("docs/ci/external-topology.yaml"))
+        teamCityGeneratedConfigurationDirectory.convention(
+            layout.projectDirectory.dir(".teamcity/target/generated-configs")
+        )
         designModelFile.convention(layout.buildDirectory.file("reports/figma-sync/design-model.json"))
 
         includedBuilds.register("dependency-catalog") {

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.plugin.gradle
 
 import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
 import com.marmatsan.figmaDesignSync.plugin.task.catalog.CheckFigmaCatalogUsageTask
+import com.marmatsan.figmaDesignSync.plugin.task.ci.CheckCiExternalTopologyFreshnessTask
 import com.marmatsan.figmaDesignSync.plugin.task.generate.GenerateFigmaDesignModelTask
 import com.marmatsan.figmaDesignSync.plugin.task.sync.CheckFigmaTrunkSyncTask
 import com.marmatsan.figmaDesignSync.plugin.task.versions.CheckFigmaVersionNamingTask
@@ -62,10 +63,18 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
 
             versionsFile.set(extension.versionsFile)
         }
+        val checkCiExternalTopologyFreshness =
+            project.tasks.register<CheckCiExternalTopologyFreshnessTask>("checkCiExternalTopologyFreshness") {
+                group = "verification"
+                description = "Warns when the external CI topology has not been validated recently."
+
+                ciExternalTopologyFile.set(extension.ciExternalTopologyFile)
+            }
 
         project.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
             dependsOn(checkFigmaCatalogUsage)
             dependsOn(checkFigmaVersionNaming)
+            dependsOn(checkCiExternalTopologyFreshness)
         }
 
         project.tasks.register<GenerateFigmaDesignModelTask>("generateFigmaDesignModel") {
@@ -74,6 +83,8 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
 
             versionsFile.set(extension.versionsFile)
             rootSettingsFile.set(extension.rootSettingsFile)
+            ciExternalTopologyFile.set(extension.ciExternalTopologyFile)
+            teamCityGeneratedConfigurationDirectory.set(extension.teamCityGeneratedConfigurationDirectory)
             includedBuildSettingsFiles.from(
                 includedBuildSources.map { sources -> sources.map { source -> source.settingsFile } }
             )
@@ -101,6 +112,8 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
             metadataNodeUrl.set(extension.designModelMetadataNodeUrl)
             versionsFile.set(extension.versionsFile)
             rootSettingsFile.set(extension.rootSettingsFile)
+            ciExternalTopologyFile.set(extension.ciExternalTopologyFile)
+            teamCityGeneratedConfigurationDirectory.set(extension.teamCityGeneratedConfigurationDirectory)
             includedBuildSettingsFiles.from(
                 includedBuildSources.map { sources -> sources.map { source -> source.settingsFile } }
             )

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiExternalTopologyFreshnessTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiExternalTopologyFreshnessTask.kt
@@ -1,0 +1,41 @@
+package com.marmatsan.figmaDesignSync.plugin.task.ci
+
+import com.marmatsan.figmaDesignSync.plugin.di.create
+import com.marmatsan.figmaDesignSync.plugin.di.figmaDesignSyncComponent
+import java.time.LocalDate
+import java.time.ZoneOffset
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Emits a non-blocking warning when external CI topology validation is stale.
+ */
+abstract class CheckCiExternalTopologyFreshnessTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ciExternalTopologyFile: RegularFileProperty
+
+    @TaskAction
+    fun checkFreshness() {
+        val result = figmaDesignSyncComponent::class.create()
+            .ciExternalTopologyFreshnessChecker
+            .check(
+                topologyFile = ciExternalTopologyFile.get().asFile,
+                currentDate = LocalDate.now(ZoneOffset.UTC)
+            )
+
+        if (result.warningRequired) {
+            logger.warn(
+                "External CI topology was last validated on ${result.lastValidatedOn}. " +
+                    "Validate docs/ci/external-topology.yaml against the active services " +
+                    "and update validation.lastValidatedOn."
+            )
+        } else {
+            logger.lifecycle("External CI topology validation is current until ${result.warningDate}.")
+        }
+    }
+}

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/generate/GenerateFigmaDesignModelTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/generate/GenerateFigmaDesignModelTask.kt
@@ -18,6 +18,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -41,6 +42,14 @@ abstract class GenerateFigmaDesignModelTask : DefaultTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val rootSettingsFile: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ciExternalTopologyFile: RegularFileProperty
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val teamCityGeneratedConfigurationDirectory: DirectoryProperty
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -83,6 +92,8 @@ abstract class GenerateFigmaDesignModelTask : DefaultTask() {
                 generatedAt = Instant.now(),
                 versionsFile = versionsFile.get().asFile,
                 rootSettingsFile = rootSettingsFile.get().asFile,
+                ciExternalTopologyFile = ciExternalTopologyFile.get().asFile,
+                teamCityGeneratedConfigurationDirectory = teamCityGeneratedConfigurationDirectory.get().asFile,
                 projectRootDirectory = projectRootDirectory.get().asFile,
                 includedBuilds = includedBuildSources()
             )

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/sync/CheckFigmaTrunkSyncTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/sync/CheckFigmaTrunkSyncTask.kt
@@ -17,6 +17,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -40,6 +41,14 @@ abstract class CheckFigmaTrunkSyncTask : DefaultTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val rootSettingsFile: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ciExternalTopologyFile: RegularFileProperty
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val teamCityGeneratedConfigurationDirectory: DirectoryProperty
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -83,6 +92,8 @@ abstract class CheckFigmaTrunkSyncTask : DefaultTask() {
                 generatedAt = Instant.now(),
                 versionsFile = versionsFile.get().asFile,
                 rootSettingsFile = rootSettingsFile.get().asFile,
+                ciExternalTopologyFile = ciExternalTopologyFile.get().asFile,
+                teamCityGeneratedConfigurationDirectory = teamCityGeneratedConfigurationDirectory.get().asFile,
                 projectRootDirectory = projectRootDirectory.get().asFile,
                 includedBuilds = includedBuildSources()
             )

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/DesignModelSteps.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/DesignModelSteps.kt
@@ -6,10 +6,19 @@ import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityPipeline
 import com.marmatsan.figmaDesignSync.domain.model.modules.ModuleDependency
 import com.marmatsan.figmaDesignSync.domain.model.versions.RepositoryVersionSection
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSource
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModulesPort
@@ -27,6 +36,7 @@ import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
 import java.io.File
 import java.time.Instant
+import java.time.LocalDate
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -39,6 +49,8 @@ class DesignModelSteps : En {
     private var repositoryCatalogTreesAvailable = false
     private var repositoryProjectModulesAvailable = false
     private var repositoryModuleDependenciesAvailable = false
+    private var externalCiTopologyAvailable = false
+    private var effectiveTeamCityConfigurationAvailable = false
     private lateinit var generator: FigmaDesignModelGenerator
     private lateinit var firstResult: FigmaDesignModelGenerationResult
     private lateinit var secondResult: FigmaDesignModelGenerationResult
@@ -61,6 +73,16 @@ class DesignModelSteps : En {
 
         Given("repository module dependencies are available") {
             repositoryModuleDependenciesAvailable = true
+            configureGenerator()
+        }
+
+        Given("the external CI topology is available") {
+            externalCiTopologyAvailable = true
+            configureGenerator()
+        }
+
+        Given("the effective TeamCity configuration is available") {
+            effectiveTeamCityConfigurationAvailable = true
             configureGenerator()
         }
 
@@ -140,6 +162,12 @@ class DesignModelSteps : En {
                 } shouldBe listOf("Main project dependencies", "Libraries", "Plugins")
         }
 
+        Then("the CI model contains external topology and effective TeamCity configuration") {
+            firstResult.content["ci"]!!
+                .jsonObject
+                .keys shouldContainAll listOf("externalTopology", "teamCity")
+        }
+
         Then("the model hash is stored in the generated model") {
             firstResult.modelHash shouldBe firstResult.model["modelHash"]?.jsonPrimitive?.content
         }
@@ -188,7 +216,9 @@ class DesignModelSteps : En {
             repositoryVersionsPort = FakeRepositoryVersionsPort,
             projectCatalogTreesPort = FakeProjectCatalogTreesPort,
             projectModulesPort = FakeProjectModulesPort,
-            projectModuleDependenciesPort = FakeProjectModuleDependenciesPort
+            projectModuleDependenciesPort = FakeProjectModuleDependenciesPort,
+            ciExternalTopologyPort = FakeCiExternalTopologyPort,
+            teamCityConfigurationPort = FakeTeamCityConfigurationPort
         )
     }
 
@@ -197,6 +227,8 @@ class DesignModelSteps : En {
         check(repositoryCatalogTreesAvailable) { "Repository catalog trees are not available." }
         check(repositoryProjectModulesAvailable) { "Repository project modules are not available." }
         check(repositoryModuleDependenciesAvailable) { "Repository module dependencies are not available." }
+        check(externalCiTopologyAvailable) { "External CI topology is not available." }
+        check(effectiveTeamCityConfigurationAvailable) { "Effective TeamCity configuration is not available." }
     }
 
     private fun request(
@@ -209,6 +241,8 @@ class DesignModelSteps : En {
             generatedAt = generatedAt,
             versionsFile = File("versions.properties"),
             rootSettingsFile = File("settings.gradle.kts"),
+            ciExternalTopologyFile = File("docs/ci/external-topology.yaml"),
+            teamCityGeneratedConfigurationDirectory = File(".teamcity/target/generated-configs"),
             projectRootDirectory = File("."),
             includedBuilds = listOf(
                 FigmaDesignModelIncludedBuildSource(
@@ -297,5 +331,50 @@ private object FakeProjectModuleDependenciesPort : ProjectModuleDependenciesPort
                 dependentModule = ":app",
                 dependencyModule = ":core:ui"
             )
+        )
+}
+
+private object FakeCiExternalTopologyPort : CiExternalTopologyPort {
+    override fun readTopology(source: CiExternalTopologySource): CiExternalTopology =
+        CiExternalTopology(
+            schemaVersion = 1,
+            validation = CiExternalTopology.Validation(
+                lastValidatedOn = LocalDate.parse("2026-07-14"),
+                warnAfterDays = 90
+            ),
+            nodes = listOf(
+                CiNode(
+                    id = "operator",
+                    type = CiNode.Type.Actor,
+                    name = "Operator",
+                    description = "Initiates manual CI actions."
+                )
+            ),
+            connections = emptyList()
+        )
+}
+
+private object FakeTeamCityConfigurationPort : TeamCityConfigurationPort {
+    override fun readConfiguration(source: TeamCityGeneratedConfigurationSource): TeamCityConfiguration =
+        TeamCityConfiguration(
+            pipelines = listOf(
+                TeamCityPipeline(
+                    id = "Root_Ci",
+                    name = "CI",
+                    triggers = emptyList(),
+                    jobs = listOf(
+                        TeamCityJob(
+                            id = "verify",
+                            name = "Verify",
+                            steps = emptyList(),
+                            repositoryIds = emptyList(),
+                            artifacts = emptyList(),
+                            dependencies = emptyList(),
+                            publishedChecks = emptyList()
+                        )
+                    )
+                )
+            ),
+            vcsRoots = emptyList()
         )
 }

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/GradleTaskSteps.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/GradleTaskSteps.kt
@@ -85,7 +85,8 @@ class GradleTaskSteps : En {
                 "versionSections",
                 "catalogs",
                 "modules",
-                "moduleDependencies"
+                "moduleDependencies",
+                "ci"
             )
         }
 
@@ -248,6 +249,37 @@ class GradleTaskSteps : En {
         resolve("repo/figma-design-sync/domain/build.gradle.kts").writeText("")
         resolve("repo/figma-design-sync/plugin").mkdirs()
         resolve("repo/figma-design-sync/plugin/build.gradle.kts").writeText("")
+        resolve("docs/ci").mkdirs()
+        resolve("docs/ci/external-topology.yaml").writeText(
+            """
+            schemaVersion: 1
+            validation:
+              lastValidatedOn: "2026-07-14"
+              warnAfterDays: 90
+            nodes:
+              - id: operator
+                type: actor
+                name: Operator
+                description: Initiates manual CI actions.
+            connections: []
+            """.trimIndent()
+        )
+        resolve(".teamcity/target/generated-configs/Root_Ci").mkdirs()
+        resolve(".teamcity/target/generated-configs/Root_Ci/project-config.xml").writeText(
+            """
+            <project>
+              <name>CI</name>
+            </project>
+            """.trimIndent()
+        )
+        resolve(".teamcity/target/generated-configs/Root_Ci/pipeline.yml").writeText(
+            """
+            version: 1
+            jobs:
+              verify:
+                name: Verify
+            """.trimIndent()
+        )
     }
 
     private fun File.initializeGitRepository() {

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiExternalTopologyFreshnessCheckerTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiExternalTopologyFreshnessCheckerTest.kt
@@ -1,0 +1,38 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+internal class CiExternalTopologyFreshnessCheckerTest : FunSpec({
+
+    test("check requests a warning only after the configured validation window") {
+        val checker = CiExternalTopologyFreshnessChecker(FakeCiExternalTopologyPort)
+
+        checker.check(
+            topologyFile = java.io.File("external-topology.yaml"),
+            currentDate = LocalDate.parse("2026-10-12")
+        ).warningRequired shouldBe false
+
+        checker.check(
+            topologyFile = java.io.File("external-topology.yaml"),
+            currentDate = LocalDate.parse("2026-10-13")
+        ).warningRequired shouldBe true
+    }
+})
+
+private object FakeCiExternalTopologyPort : CiExternalTopologyPort {
+    override fun readTopology(source: CiExternalTopologySource): CiExternalTopology =
+        CiExternalTopology(
+            schemaVersion = 1,
+            validation = CiExternalTopology.Validation(
+                lastValidatedOn = LocalDate.parse("2026-07-14"),
+                warnAfterDays = 90
+            ),
+            nodes = emptyList(),
+            connections = emptyList()
+        )
+}

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -8,10 +8,19 @@ import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityPipeline
 import com.marmatsan.figmaDesignSync.domain.model.modules.ModuleDependency
 import com.marmatsan.figmaDesignSync.domain.model.versions.RepositoryVersionSection
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSource
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModulesPort
@@ -22,6 +31,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.io.File
 import java.time.Instant
+import java.time.LocalDate
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -231,6 +241,21 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
         gradlePluginsCatalog?.get("libraries") shouldBe null
         gradlePluginsCatalog?.get("plugins") shouldBe null
     }
+
+    test("generate writes external topology and effective TeamCity configuration") {
+        // WHEN
+        val result = generator().generate(request())
+
+        // THEN
+        result.model["schemaVersion"]?.jsonPrimitive?.content shouldBe "3"
+        val ci = result.model["content"]?.jsonObject?.get("ci")?.jsonObject
+        ci?.get("externalTopology")?.jsonObject
+            ?.get("nodes")?.jsonArray?.single()?.jsonObject
+            ?.get("name")?.jsonPrimitive?.content shouldBe "Operator"
+        ci?.get("teamCity")?.jsonObject
+            ?.get("pipelines")?.jsonArray?.single()?.jsonObject
+            ?.get("name")?.jsonPrimitive?.content shouldBe "CI"
+    }
 })
 
 private fun generator(): FigmaDesignModelGenerator =
@@ -238,7 +263,9 @@ private fun generator(): FigmaDesignModelGenerator =
         repositoryVersionsPort = FakeRepositoryVersionsPort,
         projectCatalogTreesPort = FakeProjectCatalogTreesPort,
         projectModulesPort = FakeProjectModulesPort,
-        projectModuleDependenciesPort = FakeProjectModuleDependenciesPort
+        projectModuleDependenciesPort = FakeProjectModuleDependenciesPort,
+        ciExternalTopologyPort = FakeCiExternalTopologyPort,
+        teamCityConfigurationPort = FakeTeamCityConfigurationPort
     )
 
 private fun request(
@@ -251,6 +278,8 @@ private fun request(
         generatedAt = generatedAt,
         versionsFile = File("versions.properties"),
         rootSettingsFile = File("settings.gradle.kts"),
+        ciExternalTopologyFile = File("docs/ci/external-topology.yaml"),
+        teamCityGeneratedConfigurationDirectory = File(".teamcity/target/generated-configs"),
         projectRootDirectory = File("."),
         includedBuilds = listOf(
             FigmaDesignModelIncludedBuildSource(
@@ -391,5 +420,50 @@ private object FakeProjectModuleDependenciesPort : ProjectModuleDependenciesPort
                 dependentModule = ":app",
                 dependencyModule = ":core:ui"
             )
+        )
+}
+
+private object FakeCiExternalTopologyPort : CiExternalTopologyPort {
+    override fun readTopology(source: CiExternalTopologySource): CiExternalTopology =
+        CiExternalTopology(
+            schemaVersion = 1,
+            validation = CiExternalTopology.Validation(
+                lastValidatedOn = LocalDate.parse("2026-07-14"),
+                warnAfterDays = 90
+            ),
+            nodes = listOf(
+                CiNode(
+                    id = "operator",
+                    type = CiNode.Type.Actor,
+                    name = "Operator",
+                    description = "Initiates manual CI actions."
+                )
+            ),
+            connections = emptyList()
+        )
+}
+
+private object FakeTeamCityConfigurationPort : TeamCityConfigurationPort {
+    override fun readConfiguration(source: TeamCityGeneratedConfigurationSource): TeamCityConfiguration =
+        TeamCityConfiguration(
+            pipelines = listOf(
+                TeamCityPipeline(
+                    id = "Root_Ci",
+                    name = "CI",
+                    triggers = emptyList(),
+                    jobs = listOf(
+                        TeamCityJob(
+                            id = "verify",
+                            name = "Verify",
+                            steps = emptyList(),
+                            repositoryIds = emptyList(),
+                            artifacts = emptyList(),
+                            dependencies = emptyList(),
+                            publishedChecks = emptyList()
+                        )
+                    )
+                )
+            ),
+            vcsRoots = emptyList()
         )
 }

--- a/repo/figma-design-sync/plugin/src/test/resources/com/marmatsan/figmaDesignSync/plugin/bdd/figma-design-model.feature
+++ b/repo/figma-design-sync/plugin/src/test/resources/com/marmatsan/figmaDesignSync/plugin/bdd/figma-design-model.feature
@@ -9,6 +9,8 @@ Feature: Figma design model generation
     And repository catalog trees are available
     And repository project modules are available
     And repository module dependencies are available
+    And the external CI topology is available
+    And the effective TeamCity configuration is available
 
   @domain
   Scenario: Generate the dependency design model
@@ -20,8 +22,10 @@ Feature: Figma design model generation
       | catalogs           |
       | modules            |
       | moduleDependencies |
+      | ci                 |
     And the version keys are sorted
     And the version sections keep repository order
+    And the CI model contains external topology and effective TeamCity configuration
     And the model hash is stored in the generated model
 
   @domain

--- a/repo/figma-design-sync/settings.gradle.kts
+++ b/repo/figma-design-sync/settings.gradle.kts
@@ -82,6 +82,12 @@ dependencyResolutionManagement {
             ).version(version("serializationLibraryVersion"))
 
             library(
+                alias = "org.snakeyaml.engine",
+                group = "org.snakeyaml",
+                artifact = "snakeyaml-engine"
+            ).version(version("snakeYamlLibraryVersion"))
+
+            library(
                 alias = "me.tatarka.inject.kotlin.inject.compiler.ksp",
                 group = "me.tatarka.inject",
                 artifact = "kotlin-inject-compiler-ksp"

--- a/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/catalog-tree.design-model.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "branch": "main",
   "gitSha": "preview-catalog-tree",
   "generatedAt": "2026-07-08T00:00:00.000Z",

--- a/repo/figma-design-sync/tools/fixtures/visual/versions.design-model.json
+++ b/repo/figma-design-sync/tools/fixtures/visual/versions.design-model.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "branch": "main",
   "gitSha": "preview-versions",
   "generatedAt": "2026-07-08T00:00:00.000Z",

--- a/repo/figma-design-sync/tools/package.json
+++ b/repo/figma-design-sync/tools/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.json && esbuild src/app/sync-trunk-design-model.mcp.ts --bundle --format=iife --global-name=FigmaTrunkSync --target=es2022 --minify --outfile=dist/sync-trunk-design-model.mcp.js && esbuild src/app/sync-catalog-tree-preview.mcp.ts --bundle --format=iife --global-name=FigmaCatalogTreePreview --target=es2022 --minify --outfile=dist/sync-catalog-tree-preview.mcp.js && esbuild scripts/write-mcp-js.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-js.mjs && esbuild scripts/write-mcp-runner.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-runner.mjs && node dist/write-mcp-js.mjs",
-    "test": "npm run test:payload-png && npm run test:sync-preflight && npm run test:version-sync-plan && npm run test:header-sync-plan && npm run test:write-mcp-runner && npm run test:catalog-root-filter && npm run test:library-catalog-entries && npm run test:catalog-tree-targets",
+    "test": "npm run test:payload-png && npm run test:sync-preflight && npm run test:version-sync-plan && npm run test:header-sync-plan && npm run test:write-mcp-runner && npm run test:catalog-root-filter && npm run test:library-catalog-entries && npm run test:catalog-tree-targets && npm run test:ci-visual-plan",
     "test:payload-png": "esbuild tests/payload-png.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/payload-png.test.mjs && node --test dist/payload-png.test.mjs",
     "test:sync-preflight": "esbuild tests/sync-preflight-target.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/sync-preflight-target.test.mjs && node --test dist/sync-preflight-target.test.mjs",
     "test:version-sync-plan": "esbuild tests/version-sync-plan.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/version-sync-plan.test.mjs && node --test dist/version-sync-plan.test.mjs",
@@ -12,6 +12,7 @@
     "test:catalog-root-filter": "esbuild tests/catalog-root-filter-scope.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/catalog-root-filter-scope.test.mjs && node --test dist/catalog-root-filter-scope.test.mjs",
     "test:library-catalog-entries": "esbuild tests/library-catalog-entries.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/library-catalog-entries.test.mjs && node --test dist/library-catalog-entries.test.mjs",
     "test:catalog-tree-targets": "esbuild tests/catalog-tree-targets.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/catalog-tree-targets.test.mjs && node --test dist/catalog-tree-targets.test.mjs",
+    "test:ci-visual-plan": "esbuild tests/ci-visual-plan.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/ci-visual-plan.test.mjs && node --test dist/ci-visual-plan.test.mjs",
     "premcp:runner": "npm run build",
     "mcp:runner": "node dist/write-mcp-runner.mjs",
     "premcp:preview": "npm run build",

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -32,6 +32,10 @@ const KNOWN_TARGETS = [
   "gradlePlugins.plugins",
   "figmaDesignSync.libraries",
   "figmaDesignSync.plugins",
+  "ci.overview",
+  "ci.pullRequestIntegration",
+  "ci.postMergeDesignDocumentation",
+  "ci.infrastructureAndAccess",
   "metadata",
 ];
 

--- a/repo/figma-design-sync/tools/src/app/create-figma-design-model-sync.ts
+++ b/repo/figma-design-sync/tools/src/app/create-figma-design-model-sync.ts
@@ -1,5 +1,6 @@
 import { FigmaCatalogTreeSyncGateway } from "../figma/figma-catalog-tree-sync-gateway";
 import { FigmaHeaderSyncGateway } from "../figma/figma-header-sync-gateway";
+import { FigmaCiDocumentationSyncGateway } from "../figma/figma-ci-documentation-sync-gateway";
 import { FigmaMetadataGateway } from "../figma/figma-metadata-gateway";
 import { FigmaVersionSyncGateway } from "../figma/figma-version-sync-gateway";
 import { FigmaVisualContractCheckGateway } from "../figma/figma-visual-contract-check-gateway";
@@ -12,6 +13,7 @@ export function createFigmaDesignModelSync() {
       versionSyncGateway: new FigmaVersionSyncGateway(),
       headerSyncGateway: new FigmaHeaderSyncGateway(),
       catalogTreeSyncGateway: new FigmaCatalogTreeSyncGateway(),
+      ciDocumentationSyncGateway: new FigmaCiDocumentationSyncGateway(),
       metadataSyncGateway: new FigmaMetadataGateway(),
       visualContractCheckGateway: new FigmaVisualContractCheckGateway(),
     },

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -2,6 +2,29 @@ import type { CatalogTreeTarget } from "../domain/design-model";
 
 export const METADATA_PAGE_ID = "62934:908";
 export const METADATA_NAMESPACE = "water_my_plants_sync";
+export const CI_DOCUMENTATION_PAGE_ID = "63153:2876";
+export const CI_NODE_COMPONENT_ID = "64301:3927";
+export const CI_VARIABLE_COLLECTION_NAME = "ci/cd";
+export const CI_VARIABLE_MODE_NAMES = [
+  "Actor",
+  "System",
+  "Git reference",
+  "Pipeline",
+  "Job",
+  "Artifact",
+  "Check",
+  "Gate",
+] as const;
+export const CI_NODE_INSTANCE_NAME = ".ci node";
+export const CI_CONNECTOR_NAME = ".ci connector";
+export const CI_NODE_PROPS = {
+  name: "name",
+  description: "description",
+  steps: "steps",
+  source: "source",
+  showSteps: "show steps",
+  showSource: "show source",
+};
 export const VERSIONS_COLLECTION_NAME = "repo\\dependency-catalog\\versions.properties";
 export const VERSIONS_COLLECTION_NAMES = [VERSIONS_COLLECTION_NAME];
 export const VERSION_ALIAS_MODE_NAME = "Version alias";

--- a/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
+++ b/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
@@ -1,0 +1,335 @@
+import type { DesignModel } from "../design-model";
+
+export const CI_VISUAL_TARGET_NAMES = [
+  "ci.overview",
+  "ci.pullRequestIntegration",
+  "ci.postMergeDesignDocumentation",
+  "ci.infrastructureAndAccess",
+] as const;
+
+export type CiVisualTargetName = typeof CI_VISUAL_TARGET_NAMES[number];
+export type CiVisualNodeType =
+  | "actor"
+  | "system"
+  | "git reference"
+  | "pipeline"
+  | "job"
+  | "artifact"
+  | "check"
+  | "gate";
+
+export type CiVisualNode = {
+  id: string;
+  type: CiVisualNodeType;
+  name: string;
+  description: string;
+  steps?: string;
+  source: string;
+  sourceUrl: string;
+  row: number;
+  column: number;
+};
+
+export type CiVisualConnection = {
+  id: string;
+  source: string;
+  target: string;
+  label: string;
+};
+
+export type CiVisualSection = {
+  target: CiVisualTargetName;
+  name: string;
+  description: string;
+  headerSources: Array<{ label: string; url: string }>;
+  nodes: CiVisualNode[];
+  connections: CiVisualConnection[];
+};
+
+export type CiVisualPlan = {
+  parentName: "Continuous Integration and Design Documentation";
+  sections: CiVisualSection[];
+};
+
+const GITHUB_MAIN_BLOB_URL = "https://github.com/marmatsan/water-my-plants/blob/main";
+const TEAMCITY_SOURCE = ".teamcity/settings.kts";
+const TOPOLOGY_SOURCE = "docs/ci/external-topology.yaml";
+const VISUAL_CONTRACT_SOURCE = "docs/ci/visual-model-contract.md";
+const BRANCH_PROTECTION_SOURCE = "docs/ci/main-branch-protection.md";
+const OFFICIAL_SYNC_SOURCE = "repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md";
+
+export function createCiVisualPlan(designModel: DesignModel): CiVisualPlan {
+  const ci = requireCiContent(designModel);
+  const ciPipeline = requirePipeline(ci.teamCity, "CI");
+  const figmaPipeline = requirePipeline(ci.teamCity, "Figma Sync");
+
+  return {
+    parentName: "Continuous Integration and Design Documentation",
+    sections: [
+      createOverviewSection(ciPipeline, figmaPipeline),
+      createPullRequestSection(ciPipeline),
+      createPostMergeSection(ci, figmaPipeline),
+      createInfrastructureSection(ci),
+    ],
+  };
+}
+
+export function requireCiContent(designModel: DesignModel) {
+  const ci = designModel.content?.ci;
+  if (!ci || typeof ci !== "object") {
+    throw new Error("designModel.content.ci is required for CI visual sync.");
+  }
+  if (!ci.externalTopology || !Array.isArray(ci.externalTopology.nodes) || !Array.isArray(ci.externalTopology.connections)) {
+    throw new Error("designModel.content.ci.externalTopology must contain nodes and connections.");
+  }
+  if (!ci.teamCity || !Array.isArray(ci.teamCity.pipelines) || !Array.isArray(ci.teamCity.vcsRoots)) {
+    throw new Error("designModel.content.ci.teamCity must contain pipelines and vcsRoots.");
+  }
+  return ci;
+}
+
+function createOverviewSection(ciPipeline, figmaPipeline): CiVisualSection {
+  const ciCheck = publishedChecks(ciPipeline)[0] || "TeamCity CI";
+  const figmaCheck = publishedChecks(figmaPipeline)[0] || "TeamCity Figma Sync";
+  const nodes: CiVisualNode[] = [
+    visualNode("overview-pr", "git reference", "Pull Request", "Proposes a reviewed change to the repository.", BRANCH_PROTECTION_SOURCE, 0, 0),
+    pipelineNode("overview-ci", ciPipeline, 1, 0),
+    visualNode("overview-ci-check", "check", ciCheck, "Reports CI verification to GitHub.", TEAMCITY_SOURCE, 2, 0),
+    visualNode("overview-gate", "gate", "Pull request merge gate", "Requires the CI check before merge.", BRANCH_PROTECTION_SOURCE, 3, 0),
+    visualNode("overview-main", "git reference", "main", "Stable trunk after the reviewed merge.", BRANCH_PROTECTION_SOURCE, 4, 0),
+    pipelineNode("overview-figma", figmaPipeline, 5, 0),
+    visualNode("overview-model", "artifact", "design-model.json", "Carries the repository documentation snapshot.", TEAMCITY_SOURCE, 6, 0),
+    visualNode("overview-figma-check", "check", figmaCheck, "Reports whether Figma metadata matches main.", TEAMCITY_SOURCE, 7, 0),
+  ];
+
+  return section(
+    "ci.overview",
+    "Overview",
+    "Simplified pull request and post-merge design documentation journeys.",
+    [VISUAL_CONTRACT_SOURCE],
+    nodes,
+    [
+      connection("overview-pr-trigger", "overview-pr", "overview-ci", triggerLabel(ciPipeline)),
+      connection("overview-ci-check", "overview-ci", "overview-ci-check", "Publish check"),
+      connection("overview-check-gate", "overview-ci-check", "overview-gate", "Required check"),
+      connection("overview-gate-main", "overview-gate", "overview-main", "Merge"),
+      connection("overview-main-figma", "overview-main", "overview-figma", triggerLabel(figmaPipeline)),
+      connection("overview-figma-model", "overview-figma", "overview-model", "Generate and publish"),
+      connection("overview-model-check", "overview-model", "overview-figma-check", "Verify model hash"),
+    ]
+  );
+}
+
+function createPullRequestSection(ciPipeline): CiVisualSection {
+  const nodes: CiVisualNode[] = [
+    visualNode("pr", "git reference", "Pull Request", "Contains the branch revision proposed for main.", BRANCH_PROTECTION_SOURCE, 0, 0),
+    pipelineNode(`pipeline-${ciPipeline.id}`, ciPipeline, 1, 0),
+    ...ciPipeline.jobs.map((job, index) => jobNode(`job-${job.id}`, job, 2 + index, 0)),
+  ];
+
+  const lastJob = ciPipeline.jobs.at(-1);
+  for (const [index, checkName] of publishedChecks(ciPipeline).entries()) {
+    nodes.push(visualNode(`check-${index}`, "check", checkName, "Publishes the CI result to GitHub.", TEAMCITY_SOURCE, 2 + ciPipeline.jobs.length, index));
+  }
+  nodes.push(visualNode("merge-gate", "gate", "Pull request merge gate", "Requires TeamCity CI before merging.", BRANCH_PROTECTION_SOURCE, 3 + ciPipeline.jobs.length, 0));
+  nodes.push(visualNode("main", "git reference", "main", "Receives the reviewed change after the gate passes.", BRANCH_PROTECTION_SOURCE, 4 + ciPipeline.jobs.length, 0));
+
+  const connections: CiVisualConnection[] = [
+    connection("pr-trigger", "pr", `pipeline-${ciPipeline.id}`, triggerLabel(ciPipeline)),
+    ...ciPipeline.jobs.map((job, index) => connection(
+      `pipeline-job-${job.id}`,
+      index === 0 ? `pipeline-${ciPipeline.id}` : `job-${ciPipeline.jobs[index - 1].id}`,
+      `job-${job.id}`,
+      index === 0 ? "Run pipeline" : "Continue"
+    )),
+    ...publishedChecks(ciPipeline).map((_, index) => connection(
+      `job-check-${index}`,
+      lastJob ? `job-${lastJob.id}` : `pipeline-${ciPipeline.id}`,
+      `check-${index}`,
+      "Publish check"
+    )),
+    ...publishedChecks(ciPipeline).map((_, index) => connection(`check-gate-${index}`, `check-${index}`, "merge-gate", "Required check")),
+    connection("gate-main", "merge-gate", "main", "Merge"),
+  ];
+
+  return section(
+    "ci.pullRequestIntegration",
+    "Pull Request Integration",
+    "Detailed merge-gate flow derived from the effective CI pipeline.",
+    [TEAMCITY_SOURCE, BRANCH_PROTECTION_SOURCE],
+    nodes,
+    connections
+  );
+}
+
+function createPostMergeSection(ci, figmaPipeline): CiVisualSection {
+  const externalById = new Map(ci.externalTopology.nodes.map((node) => [node.id, node]));
+  const operator = externalById.get("operator");
+  const codex = externalById.get("codex-mcp-client");
+  const figmaDocument = externalById.get("figma-design-document");
+  const nodes: CiVisualNode[] = [
+    visualNode("main", "git reference", "main", "Starts documentation verification after successful CI.", TEAMCITY_SOURCE, 0, 0),
+    pipelineNode(`pipeline-${figmaPipeline.id}`, figmaPipeline, 1, 0),
+    ...figmaPipeline.jobs.map((job, index) => jobNode(`job-${job.id}`, job, 2 + index * 2, 0)),
+  ];
+  const artifactJob = figmaPipeline.jobs.find((job) => job.artifacts?.some((artifact) => artifact.path.endsWith("design-model.json")));
+  const artifactRow = artifactJob ? 3 : 2;
+  nodes.push(visualNode("design-model", "artifact", "design-model.json", "Official repository snapshot consumed by visual synchronization.", TEAMCITY_SOURCE, artifactRow, 0));
+  const checkRow = 2 + figmaPipeline.jobs.length * 2;
+  for (const [index, checkName] of publishedChecks(figmaPipeline).entries()) {
+    nodes.push(visualNode(`figma-check-${index}`, "check", checkName, "Publishes the post-merge documentation result.", TEAMCITY_SOURCE, checkRow, index));
+  }
+  if (operator) nodes.push(externalNode("operator", operator, checkRow + 1, 0));
+  if (codex) nodes.push(externalNode("codex", codex, checkRow + 2, 0));
+  if (figmaDocument) nodes.push(externalNode("figma-document", figmaDocument, checkRow + 3, 0));
+
+  const generateJob = figmaPipeline.jobs[0];
+  const checkJob = figmaPipeline.jobs[1];
+  const connections: CiVisualConnection[] = [
+    connection("main-trigger", "main", `pipeline-${figmaPipeline.id}`, triggerLabel(figmaPipeline)),
+    ...(generateJob ? [connection("pipeline-generate", `pipeline-${figmaPipeline.id}`, `job-${generateJob.id}`, "Run pipeline")] : []),
+    ...(artifactJob ? [connection("generate-artifact", `job-${artifactJob.id}`, "design-model", "Publish artifact")] : []),
+    ...(checkJob ? [connection("artifact-check", "design-model", `job-${checkJob.id}`, "Consume artifact")] : []),
+    ...publishedChecks(figmaPipeline).map((_, index) => connection(
+      `check-status-${index}`,
+      checkJob ? `job-${checkJob.id}` : `pipeline-${figmaPipeline.id}`,
+      `figma-check-${index}`,
+      "Publish status"
+    )),
+    ...(operator && publishedChecks(figmaPipeline).length > 0 ? [connection("mismatch-operator", "figma-check-0", "operator", "Mismatch requires action")] : []),
+    ...(operator && codex ? [connection("operator-codex", "operator", "codex", "Request visual synchronization")] : []),
+    ...(codex && figmaDocument ? [connection("codex-figma", "codex", "figma-document", "Apply visual changes")] : []),
+    ...(figmaDocument && checkJob ? [connection("rerun", "figma-document", `job-${checkJob.id}`, "Manual rerun")] : []),
+  ];
+
+  return section(
+    "ci.postMergeDesignDocumentation",
+    "Post-merge Design Documentation",
+    "Official model generation, visual synchronization, and verification loop.",
+    [TEAMCITY_SOURCE, OFFICIAL_SYNC_SOURCE],
+    nodes,
+    connections
+  );
+}
+
+function createInfrastructureSection(ci): CiVisualSection {
+  const placement = infrastructurePlacement();
+  const nodes = ci.externalTopology.nodes.map((node, index) => {
+    const position = placement[node.id] || { row: index, column: 0 };
+    return externalNode(`external-${node.id}`, node, position.row, position.column);
+  });
+  const nodeIds = new Map(ci.externalTopology.nodes.map((node) => [node.id, `external-${node.id}`]));
+  const connections = ci.externalTopology.connections.map((edge) => connection(
+    `external-${edge.id}`,
+    nodeIds.get(edge.source),
+    nodeIds.get(edge.target),
+    edge.label
+  ));
+
+  return section(
+    "ci.infrastructureAndAccess",
+    "Infrastructure and Access",
+    "External systems, trust boundaries, authentication paths, and automation modes.",
+    [TOPOLOGY_SOURCE, "docs/ci/external-topology-validation.md"],
+    nodes,
+    connections
+  );
+}
+
+function section(target, name, description, sources, nodes, connections): CiVisualSection {
+  return {
+    target,
+    name,
+    description,
+    headerSources: sources.map((source) => ({ label: source, url: sourceUrl(source) })),
+    nodes,
+    connections,
+  };
+}
+
+function pipelineNode(id, pipeline, row, column): CiVisualNode {
+  return visualNode(id, "pipeline", pipeline.name, pipelineDescription(pipeline.name), TEAMCITY_SOURCE, row, column);
+}
+
+function jobNode(id, job, row, column): CiVisualNode {
+  return {
+    ...visualNode(id, "job", job.name, jobDescription(job.name), TEAMCITY_SOURCE, row, column),
+    steps: job.steps?.map((step) => summarizeCommand(step.command, step.name)).join("\n") || undefined,
+  };
+}
+
+function externalNode(id, node, row, column): CiVisualNode {
+  return visualNode(id, node.type, node.name, node.description, TOPOLOGY_SOURCE, row, column);
+}
+
+function visualNode(id, type, name, description, source, row, column): CiVisualNode {
+  return { id, type, name, description, source, sourceUrl: sourceUrl(source), row, column };
+}
+
+function connection(id, source, target, label): CiVisualConnection {
+  if (!source || !target) throw new Error(`CI visual connection '${id}' has an unknown endpoint.`);
+  return { id, source, target, label };
+}
+
+function publishedChecks(pipeline): string[] {
+  return pipeline.jobs.flatMap((job) => job.publishedChecks || []).map((check) => check.name);
+}
+
+function requirePipeline(teamCity, name) {
+  const pipeline = teamCity.pipelines.find((candidate) => candidate.name === name);
+  if (!pipeline) throw new Error(`Effective TeamCity configuration is missing pipeline '${name}'.`);
+  if (!Array.isArray(pipeline.jobs) || !Array.isArray(pipeline.triggers)) {
+    throw new Error(`Effective TeamCity pipeline '${name}' has an invalid shape.`);
+  }
+  return pipeline;
+}
+
+function triggerLabel(pipeline): string {
+  const trigger = pipeline.triggers[0];
+  if (!trigger) return "Run manually";
+  if (trigger.type === "vcs") return `VCS trigger ${trigger.branchFilter || ""}`.trim();
+  if (trigger.type === "pipeline finish") return `After ${trigger.dependencyPipelineId || "pipeline"} succeeds`;
+  return trigger.type;
+}
+
+function summarizeCommand(command: string, fallback: string): string {
+  if (command.includes("teamcity-configs:generate")) return "Generate effective TeamCity configuration";
+  if (command.includes("generateFigmaDesignModel")) return "Generate design model";
+  if (command.includes("checkFigmaTrunkSync")) return "Check Figma trunk sync";
+  if (/gradlew(?:\.bat)?\s+check(?:\s|$)/i.test(command)) return "Gradle check";
+  return fallback;
+}
+
+function pipelineDescription(name: string): string {
+  return name === "CI"
+    ? "Validates pull requests and branch revisions before merge."
+    : "Verifies post-merge Figma documentation against main.";
+}
+
+function jobDescription(name: string): string {
+  if (name === "Verify") return "Runs repository verification and publishes the required CI check.";
+  if (name === "Generate main design model") return "Builds and publishes the official design-model.json artifact.";
+  if (name === "Check Figma trunk sync") return "Compares current Figma metadata with the official model hash.";
+  return "Executes an effective TeamCity pipeline job.";
+}
+
+function sourceUrl(source: string): string {
+  return `${GITHUB_MAIN_BLOB_URL}/${source}`;
+}
+
+function infrastructurePlacement() {
+  return {
+    browser: { row: 0, column: 0 },
+    "teamcity-cli": { row: 0, column: 1 },
+    "github-app": { row: 0, column: 2 },
+    operator: { row: 0, column: 3 },
+    "cloudflare-access": { row: 1, column: 1 },
+    "cloudflare-tunnel": { row: 2, column: 1 },
+    "teamcity-server": { row: 3, column: 1 },
+    "github-repository": { row: 3, column: 2 },
+    "build-agent": { row: 4, column: 1 },
+    "codex-mcp-client": { row: 4, column: 3 },
+    "figma-api": { row: 5, column: 2 },
+    "figma-design-document": { row: 6, column: 2 },
+  };
+}

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -36,6 +36,10 @@ export type SyncTargetName =
   | "gradlePlugins.plugins"
   | "figmaDesignSync.libraries"
   | "figmaDesignSync.plugins"
+  | "ci.overview"
+  | "ci.pullRequestIntegration"
+  | "ci.postMergeDesignDocumentation"
+  | "ci.infrastructureAndAccess"
   | "metadata";
 
 export type SyncFigmaDesignModelOptions = {

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -1,0 +1,440 @@
+import {
+  CI_CONNECTOR_NAME,
+  CI_DOCUMENTATION_PAGE_ID,
+  CI_NODE_COMPONENT_ID,
+  CI_NODE_INSTANCE_NAME,
+  CI_NODE_PROPS,
+  CI_VARIABLE_COLLECTION_NAME,
+  HEADER_INSTANCE_NAME,
+  HEADER_SECTION_TARGETS,
+  METADATA_NAMESPACE,
+} from "../config/figma-config";
+import {
+  CI_VISUAL_TARGET_NAMES,
+  createCiVisualPlan,
+  type CiVisualNode,
+  type CiVisualSection,
+} from "../domain/ci/create-ci-visual-plan";
+import type { DesignModel } from "../domain/design-model";
+import type { CiDocumentationSyncGateway } from "../ports/sync-gateways";
+import {
+  applySectionStrokeContractTree,
+  requireComponent,
+  requireModeId,
+  requireOutlineColorVariable,
+  requirePage,
+  requireSection,
+  requireVariableCollection,
+} from "./figma-node-gateway";
+
+const SECTION_PADDING = 100;
+const SECTION_GAP = 114;
+const NODE_COLUMN_GAP = 160;
+const NODE_ROW_GAP = 128;
+const PARENT_CORNER_RADIUS = 28;
+const CI_ROLE_KEY = "ciDocumentationRole";
+const CI_TARGET_KEY = "ciDocumentationTarget";
+const CI_MODEL_ID_KEY = "ciDocumentationModelId";
+const ROLE_PARENT = "parent";
+const ROLE_SECTION = "section";
+const ROLE_NODE = "node";
+const ROLE_CONNECTOR = "connector";
+
+export class FigmaCiDocumentationSyncGateway implements CiDocumentationSyncGateway {
+  async syncCiDocumentation(designModel: DesignModel, targetNames: string[]) {
+    const unknownTargets = targetNames.filter((target) => !CI_VISUAL_TARGET_NAMES.includes(target as any));
+    if (unknownTargets.length > 0) {
+      throw new Error(`Unknown CI documentation target(s): ${unknownTargets.join(", ")}.`);
+    }
+
+    const plan = createCiVisualPlan(designModel);
+    const page = await requirePage(CI_DOCUMENTATION_PAGE_ID);
+    const nodeComponent = await requireComponent(CI_NODE_COMPONENT_ID);
+    const modeCollection = await requireVariableCollection(CI_VARIABLE_COLLECTION_NAME);
+    const outlineVariable = await requireOutlineColorVariable();
+    const surfaceVariable = await requireColorVariable("md/sys/color/surface");
+    const mutatedNodeIds: string[] = [];
+    const createdCiNodes: string[] = [];
+    const createdCiConnectors: string[] = [];
+    const updatedCiSections: string[] = [];
+    const parent = await requireOrCreateParentSection(page, plan.parentName, surfaceVariable, mutatedNodeIds);
+    unlockTree(parent, mutatedNodeIds);
+    await syncParentHeader(parent, mutatedNodeIds);
+
+    const requestedTargets = new Set(targetNames);
+    for (const sectionPlan of plan.sections) {
+      if (!requestedTargets.has(sectionPlan.target)) continue;
+
+      const section = requireOrCreateChildSection(parent, sectionPlan, mutatedNodeIds);
+      clearManagedSectionContent(section, mutatedNodeIds);
+      await syncSectionContent(
+        section,
+        sectionPlan,
+        nodeComponent,
+        modeCollection,
+        outlineVariable,
+        createdCiNodes,
+        createdCiConnectors,
+        mutatedNodeIds
+      );
+      updatedCiSections.push(section.id);
+    }
+
+    layoutChildSections(parent, mutatedNodeIds);
+    resizeParent(parent, mutatedNodeIds);
+    lockOnlyParent(parent, mutatedNodeIds);
+
+    return {
+      updatedCiSections,
+      createdCiNodes,
+      createdCiConnectors,
+      mutatedNodeIds: [...new Set(mutatedNodeIds)],
+    };
+  }
+}
+
+async function requireOrCreateParentSection(page, name, surfaceVariable, mutatedNodeIds) {
+  const existing = page.children.find((child) =>
+    child.type === "SECTION" &&
+      (
+        child.getSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY) === ROLE_PARENT ||
+        child.name === name
+      )
+  );
+  const parent = existing?.type === "SECTION" ? existing : figma.createSection();
+
+  if (!existing) {
+    page.appendChild(parent);
+    parent.x = 0;
+    parent.y = 0;
+  }
+  parent.name = name;
+  parent.cornerRadius = PARENT_CORNER_RADIUS;
+  parent.strokes = [];
+  parent.fills = [boundColorPaint(surfaceVariable)];
+  parent.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_PARENT);
+  mutatedNodeIds.push(parent.id);
+  return parent;
+}
+
+async function syncParentHeader(parent, mutatedNodeIds) {
+  let header = parent.children.find((child) => child.type === "INSTANCE" && child.name === HEADER_INSTANCE_NAME);
+  if (!header || header.type !== "INSTANCE") {
+    const templateSection = await requireSection(HEADER_SECTION_TARGETS[0].sectionNodeId);
+    const templateInstance = templateSection.children.find(
+      (child) => child.type === "INSTANCE" && child.name === HEADER_INSTANCE_NAME
+    );
+    if (!templateInstance || templateInstance.type !== "INSTANCE") {
+      throw new Error(`Could not resolve '${HEADER_INSTANCE_NAME}' from section '${templateSection.id}'.`);
+    }
+    const mainComponent = await templateInstance.getMainComponentAsync();
+    if (!mainComponent) throw new Error(`Header instance '${templateInstance.id}' has no main component.`);
+    header = mainComponent.createInstance();
+    header.name = HEADER_INSTANCE_NAME;
+    parent.appendChild(header);
+  }
+
+  const links = [
+    sourceLink("docs/ci/visual-model-contract.md"),
+    sourceLink(".teamcity/settings.kts"),
+    sourceLink("docs/ci/external-topology.yaml"),
+  ];
+  setComponentTextProperty(header, "Header", "Continuous Integration and Design Documentation");
+  setComponentTextProperty(
+    header,
+    "Definition",
+    "Current pull request integration, post-merge design documentation, and CI infrastructure."
+  );
+  const linkText = links.map((link) => link.label).join("\n");
+  setComponentTextProperty(header, "Link", linkText);
+  applyTextLinks(header, "Link", links, linkText);
+  header.x = 0;
+  header.y = 0;
+  mutatedNodeIds.push(header.id);
+}
+
+function requireOrCreateChildSection(parent, plan: CiVisualSection, mutatedNodeIds) {
+  const existing = parent.children.find((child) =>
+    child.type === "SECTION" &&
+      child.getSharedPluginData(METADATA_NAMESPACE, CI_TARGET_KEY) === plan.target
+  );
+  const section = existing?.type === "SECTION" ? existing : figma.createSection();
+
+  if (!existing) parent.appendChild(section);
+  section.name = plan.name;
+  section.cornerRadius = 0;
+  section.fills = [];
+  section.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_SECTION);
+  section.setSharedPluginData(METADATA_NAMESPACE, CI_TARGET_KEY, plan.target);
+  mutatedNodeIds.push(section.id);
+  return section;
+}
+
+function clearManagedSectionContent(section, mutatedNodeIds) {
+  for (const child of [...section.children]) {
+    const role = child.getSharedPluginData?.(METADATA_NAMESPACE, CI_ROLE_KEY);
+    if (role === ROLE_NODE || role === ROLE_CONNECTOR) {
+      mutatedNodeIds.push(child.id);
+      child.remove();
+    }
+  }
+}
+
+async function syncSectionContent(
+  section,
+  plan: CiVisualSection,
+  nodeComponent,
+  modeCollection,
+  outlineVariable,
+  createdCiNodes,
+  createdCiConnectors,
+  mutatedNodeIds
+) {
+  const groupsByModelId = new Map<string, GroupNode>();
+  const groups: Array<{ plan: CiVisualNode; group: GroupNode }> = [];
+
+  for (const nodePlan of plan.nodes) {
+    const instance = nodeComponent.createInstance();
+    instance.name = CI_NODE_INSTANCE_NAME;
+    section.appendChild(instance);
+    await syncCiNode(instance, nodePlan, modeCollection);
+    const group = figma.group([instance], section);
+    group.name = ".ci node group";
+    group.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_NODE);
+    group.setSharedPluginData(METADATA_NAMESPACE, CI_MODEL_ID_KEY, nodePlan.id);
+    groupsByModelId.set(nodePlan.id, group);
+    groups.push({ plan: nodePlan, group });
+    createdCiNodes.push(instance.id);
+    mutatedNodeIds.push(group.id, instance.id);
+  }
+
+  layoutNodeGroups(groups);
+
+  for (const edge of plan.connections) {
+    const source = groupsByModelId.get(edge.source);
+    const target = groupsByModelId.get(edge.target);
+    if (!source || !target) {
+      throw new Error(`CI section '${plan.target}' connection '${edge.id}' references an unknown node.`);
+    }
+    const connector = figma.createConnector();
+    connector.name = CI_CONNECTOR_NAME;
+    connector.connectorLineType = "ELBOWED";
+    connector.connectorStartStrokeCap = "NONE";
+    connector.connectorEndStrokeCap = "ARROW_LINES";
+    connector.connectorStart = { endpointNodeId: source.id, magnet: "BOTTOM" };
+    connector.connectorEnd = { endpointNodeId: target.id, magnet: "TOP" };
+    connector.strokes = [boundColorPaint(outlineVariable)];
+    connector.strokeWeight = 2;
+    connector.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_CONNECTOR);
+    connector.setSharedPluginData(METADATA_NAMESPACE, CI_MODEL_ID_KEY, edge.id);
+    section.insertChild(0, connector);
+    await setConnectorLabel(connector, edge.label);
+    createdCiConnectors.push(connector.id);
+    mutatedNodeIds.push(connector.id);
+  }
+
+  resizeChildSection(section, groups.map((item) => item.group), mutatedNodeIds);
+  applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
+}
+
+async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
+  const modeId = requireModeId(modeCollection, modeName(nodePlan.type));
+  instance.setExplicitVariableModeForCollection(modeCollection, modeId);
+  setComponentTextProperty(instance, CI_NODE_PROPS.name, nodePlan.name);
+  setComponentTextProperty(instance, CI_NODE_PROPS.description, nodePlan.description);
+  setComponentTextProperty(instance, CI_NODE_PROPS.steps, nodePlan.steps || "");
+  setComponentTextProperty(instance, CI_NODE_PROPS.source, nodePlan.source);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSteps, Boolean(nodePlan.steps));
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSource, true);
+  applyTextLinks(
+    instance,
+    "File",
+    [{ label: nodePlan.source, url: nodePlan.sourceUrl }],
+    nodePlan.source
+  );
+}
+
+function layoutNodeGroups(groups: Array<{ plan: CiVisualNode; group: GroupNode }>) {
+  const rows = [...new Set(groups.map(({ plan }) => plan.row))].sort((a, b) => a - b);
+  const columns = [...new Set(groups.map(({ plan }) => plan.column))].sort((a, b) => a - b);
+  const rowHeights = new Map(rows.map((row) => [
+    row,
+    Math.max(...groups.filter(({ plan }) => plan.row === row).map(({ group }) => group.height)),
+  ]));
+  const columnWidths = new Map(columns.map((column) => [
+    column,
+    Math.max(...groups.filter(({ plan }) => plan.column === column).map(({ group }) => group.width)),
+  ]));
+  const rowY = cumulativePositions(rows, rowHeights, NODE_ROW_GAP, SECTION_PADDING);
+  const columnX = cumulativePositions(columns, columnWidths, NODE_COLUMN_GAP, SECTION_PADDING);
+
+  for (const { plan, group } of groups) {
+    const columnWidth = columnWidths.get(plan.column)!;
+    group.x = columnX.get(plan.column)! + (columnWidth - group.width) / 2;
+    group.y = rowY.get(plan.row)!;
+  }
+}
+
+function cumulativePositions(
+  keys: number[],
+  sizes: Map<number, number>,
+  gap: number,
+  start: number
+): Map<number, number> {
+  const positions = new Map<number, number>();
+  let next = start;
+  for (const key of keys) {
+    positions.set(key, next);
+    next += (sizes.get(key) ?? 0) + gap;
+  }
+  return positions;
+}
+
+function modeName(type: CiVisualNode["type"]): string {
+  const names: Record<CiVisualNode["type"], string> = {
+    actor: "Actor",
+    system: "System",
+    "git reference": "Git reference",
+    pipeline: "Pipeline",
+    job: "Job",
+    artifact: "Artifact",
+    check: "Check",
+    gate: "Gate",
+  };
+  return names[type];
+}
+
+function resizeChildSection(section, groups, mutatedNodeIds) {
+  const maxRight = Math.max(...groups.map((group) => group.x + group.width));
+  const maxBottom = Math.max(...groups.map((group) => group.y + group.height));
+  section.resizeWithoutConstraints(maxRight + SECTION_PADDING, maxBottom + SECTION_PADDING);
+  mutatedNodeIds.push(section.id);
+}
+
+function layoutChildSections(parent, mutatedNodeIds) {
+  const header = parent.children.find((child) => child.type === "INSTANCE" && child.name === HEADER_INSTANCE_NAME);
+  const sections = parent.children
+    .filter((child) => child.type === "SECTION")
+    .sort((first, second) => targetOrder(first) - targetOrder(second));
+  let nextY = (header?.height || 0) + SECTION_GAP;
+
+  for (const section of sections) {
+    section.x = SECTION_PADDING;
+    section.y = nextY;
+    nextY += section.height + SECTION_GAP;
+    mutatedNodeIds.push(section.id);
+  }
+}
+
+function resizeParent(parent, mutatedNodeIds) {
+  const children = parent.children.filter((child) => child.visible !== false);
+  const width = Math.max(...children.map((child) => child.x + child.width), 1) + SECTION_PADDING;
+  const height = Math.max(...children.map((child) => child.y + child.height), 1) + SECTION_PADDING;
+  parent.resizeWithoutConstraints(width, height);
+  const header = children.find((child) => child.type === "INSTANCE" && child.name === HEADER_INSTANCE_NAME);
+  if (header?.type === "INSTANCE") {
+    header.resizeWithoutConstraints(width, header.height);
+  }
+  mutatedNodeIds.push(parent.id);
+}
+
+function targetOrder(section) {
+  const target = section.getSharedPluginData(METADATA_NAMESPACE, CI_TARGET_KEY);
+  const index = CI_VISUAL_TARGET_NAMES.indexOf(target as any);
+  return index < 0 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+function setComponentTextProperty(instance, propertyName, value) {
+  const key = requireComponentPropertyKey(instance, propertyName, "TEXT");
+  instance.setProperties({ [key]: value });
+}
+
+function setComponentBooleanProperty(instance, propertyName, value) {
+  const key = requireComponentPropertyKey(instance, propertyName, "BOOLEAN");
+  instance.setProperties({ [key]: value });
+}
+
+function requireComponentPropertyKey(instance, propertyName, propertyType) {
+  const expected = normalizePropertyName(propertyName);
+  const match = Object.entries(instance.componentProperties || {}).find(([key, property]: [string, any]) =>
+    normalizePropertyName(key) === expected && property.type === propertyType
+  );
+  if (!match) {
+    throw new Error(`CI node '${instance.id}' is missing ${propertyType} property '${propertyName}'.`);
+  }
+  return match[0];
+}
+
+function normalizePropertyName(value) {
+  return value.split("#")[0].trim().toLowerCase();
+}
+
+function applyTextLinks(root, textNodeName, links, expectedText) {
+  const text = root.findAllWithCriteria({ types: ["TEXT"] })
+    .find((candidate) => candidate.name.toLowerCase() === textNodeName.toLowerCase());
+  if (!text || text.characters !== expectedText) return;
+
+  let start = 0;
+  for (const link of links) {
+    const end = start + link.label.length;
+    text.setRangeHyperlink(start, end, { type: "URL", value: link.url });
+    start = end + 1;
+  }
+  text.textAlignHorizontal = "LEFT";
+}
+
+async function setConnectorLabel(connector, label) {
+  const fontName = connector.text.fontName === figma.mixed
+    ? { family: "Inter", style: "Regular" }
+    : connector.text.fontName;
+  await figma.loadFontAsync(fontName);
+  connector.text.fontName = fontName;
+  connector.text.characters = label;
+  connector.text.textAlignHorizontal = "CENTER";
+}
+
+async function requireColorVariable(name) {
+  const variables = await figma.variables.getLocalVariablesAsync("COLOR");
+  const variable = variables.find((candidate) => candidate.name === name);
+  if (!variable) throw new Error(`Color variable '${name}' was not found.`);
+  return variable;
+}
+
+function boundColorPaint(variable) {
+  return figma.variables.setBoundVariableForPaint(
+    { type: "SOLID", color: { r: 0, g: 0, b: 0 }, opacity: 1 },
+    "color",
+    variable
+  );
+}
+
+function sourceLink(path) {
+  return {
+    label: path,
+    url: `https://github.com/marmatsan/water-my-plants/blob/main/${path}`,
+  };
+}
+
+function unlockTree(parent, mutatedNodeIds) {
+  if (parent.locked) {
+    parent.locked = false;
+    mutatedNodeIds.push(parent.id);
+  }
+  for (const node of parent.findAll(() => true)) {
+    if ("locked" in node && node.locked) {
+      node.locked = false;
+      mutatedNodeIds.push(node.id);
+    }
+  }
+}
+
+function lockOnlyParent(parent, mutatedNodeIds) {
+  for (const node of parent.findAll(() => true)) {
+    if ("locked" in node && node.locked) {
+      node.locked = false;
+      mutatedNodeIds.push(node.id);
+    }
+  }
+  parent.locked = true;
+  mutatedNodeIds.push(parent.id);
+}

--- a/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -4,6 +4,11 @@ import {
   ARTIFACT_INSTANCE_NAME,
   ARTIFACT_PROPS,
   CATALOG_TREE_TARGETS,
+  CI_DOCUMENTATION_PAGE_ID,
+  CI_NODE_COMPONENT_ID,
+  CI_NODE_PROPS,
+  CI_VARIABLE_COLLECTION_NAME,
+  CI_VARIABLE_MODE_NAMES,
   HEADER_INSTANCE_NAME,
   HEADER_LINK_PROPERTY_NAME,
   HEADER_SECTION_TARGETS,
@@ -22,6 +27,7 @@ import {
   VERSION_SECTION_TARGETS,
   VERSIONS_COLLECTION_NAMES,
 } from "../config/figma-config";
+import { CI_VISUAL_TARGET_NAMES } from "../domain/ci/create-ci-visual-plan";
 import { flattenCatalogNodes, requireUniqueLabels } from "../domain/catalog/flatten-catalog-nodes";
 import {
   libraryArtifacts,
@@ -59,6 +65,7 @@ export class FigmaVisualContractCheckGateway implements VisualContractCheckGatew
     await checkVersionContract(checkedComponents, checkedSections, checkedVariables);
     await checkHeaderContract(checkedComponents, checkedSections);
     await checkCatalogTreeContract(designModel, options, checkedComponents, checkedSections, checkedTargets);
+    await checkCiDocumentationContract(options, checkedComponents, checkedSections, checkedVariables, checkedTargets);
 
     return {
       checkedComponents,
@@ -68,6 +75,38 @@ export class FigmaVisualContractCheckGateway implements VisualContractCheckGatew
       mutatedNodeIds: [],
     };
   }
+}
+
+async function checkCiDocumentationContract(
+  options,
+  checkedComponents,
+  checkedSections,
+  checkedVariables,
+  checkedTargets
+) {
+  const requestedTargets = options.targetNames == null
+    ? [...CI_VISUAL_TARGET_NAMES]
+    : options.targetNames.filter((target) => CI_VISUAL_TARGET_NAMES.includes(target));
+  if (requestedTargets.length === 0) return;
+
+  const page = await requirePage(CI_DOCUMENTATION_PAGE_ID);
+  checkedSections.push(`ciDocumentation:${page.id}`);
+
+  const component = await requireComponent(CI_NODE_COMPONENT_ID);
+  requireComponentProperty(component, CI_NODE_PROPS.name, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.description, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.steps, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.source, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.showSteps, "BOOLEAN");
+  requireComponentProperty(component, CI_NODE_PROPS.showSource, "BOOLEAN");
+  checkedComponents.push(`${component.name}:${component.id}`);
+
+  const collection = await requireVariableCollection(CI_VARIABLE_COLLECTION_NAME);
+  for (const modeName of CI_VARIABLE_MODE_NAMES) {
+    requireModeId(collection, modeName);
+  }
+  checkedVariables.push(collection.name);
+  checkedTargets.push(...requestedTargets);
 }
 
 async function checkHeaderContract(checkedComponents, checkedSections) {
@@ -258,14 +297,11 @@ async function checkUsageChipComponentSet(checkedComponents) {
 }
 
 function resolveCatalogTargets(targetNames?: string[]) {
-  const targetNameSet = new Set<string>(targetNames || CATALOG_TREE_TARGETS.map((target) => target.name));
   const knownTargetNames = new Set(
     CATALOG_TREE_TARGETS.flatMap((target) => [target.name, ...(target.aliases || [])])
   );
-  const unknownTargetNames = [...targetNameSet].filter((targetName) => !knownTargetNames.has(targetName));
-  if (unknownTargetNames.length > 0) {
-    throw new Error(`Unknown catalog tree target(s) for visual contract preflight: ${unknownTargetNames.join(", ")}.`);
-  }
+  const scopedTargetNames = targetNames?.filter((targetName) => knownTargetNames.has(targetName));
+  const targetNameSet = new Set<string>(scopedTargetNames || CATALOG_TREE_TARGETS.map((target) => target.name));
 
   return CATALOG_TREE_TARGETS.filter((target) =>
     targetNameSet.has(target.name) || (target.aliases || []).some((alias) => targetNameSet.has(alias))

--- a/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
+++ b/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
@@ -21,6 +21,13 @@ export type CatalogTreeSyncResult = {
   mutatedNodeIds: string[];
 };
 
+export type CiDocumentationSyncResult = {
+  updatedCiSections: string[];
+  createdCiNodes: string[];
+  createdCiConnectors: string[];
+  mutatedNodeIds: string[];
+};
+
 export type CatalogTreeSyncOptions = {
   targetNames?: string[];
   sectionNodeOverrides?: Record<string, string>;
@@ -61,6 +68,10 @@ export type HeaderSyncGateway = {
 
 export type CatalogTreeSyncGateway = {
   syncCatalogTrees(designModel: DesignModel, options?: CatalogTreeSyncOptions): Promise<CatalogTreeSyncResult>;
+};
+
+export type CiDocumentationSyncGateway = {
+  syncCiDocumentation(designModel: DesignModel, targetNames: string[]): Promise<CiDocumentationSyncResult>;
 };
 
 export type MetadataSyncGateway = {

--- a/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
+++ b/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
@@ -1,6 +1,7 @@
 import type { DesignModel, SyncFigmaDesignModelOptions, SyncTargetName } from "../domain/design-model";
 import type {
   CatalogTreeSyncGateway,
+  CiDocumentationSyncGateway,
   HeaderSyncGateway,
   MetadataSyncGateway,
   VersionSyncGateway,
@@ -11,6 +12,7 @@ export type SyncFigmaDesignModelDependencies = {
   versionSyncGateway: VersionSyncGateway;
   headerSyncGateway: HeaderSyncGateway;
   catalogTreeSyncGateway: CatalogTreeSyncGateway;
+  ciDocumentationSyncGateway: CiDocumentationSyncGateway;
   metadataSyncGateway: MetadataSyncGateway;
   visualContractCheckGateway: VisualContractCheckGateway;
 };
@@ -29,12 +31,11 @@ export async function syncFigmaDesignModel(
   const completedTargets: SyncTargetName[] = [];
   const skippedTargets = ALL_SYNC_TARGETS.filter((target) => !requestedTargets.has(target));
   const visualTargets = [...requestedTargets].filter((target) => target !== "preflight");
-  const catalogPreflightTargets = visualTargets.filter((target) => CATALOG_SYNC_TARGETS.includes(target));
   const preflightResult = requestedTargets.has("preflight")
     ? await dependencies.visualContractCheckGateway.checkVisualContract(
         designModel,
         {
-          targetNames: visualTargets.length > 0 ? catalogPreflightTargets : undefined,
+          targetNames: visualTargets.length > 0 ? visualTargets : undefined,
           sectionNodeOverrides: options.sectionNodeOverrides,
           rootFilters: options.catalogRootFilters,
         }
@@ -71,6 +72,12 @@ export async function syncFigmaDesignModel(
     : emptyCatalogTreeSyncResult();
   completedTargets.push(...catalogTargets);
 
+  const ciTargets = CI_SYNC_TARGETS.filter((target) => requestedTargets.has(target));
+  const ciSyncResult = ciTargets.length > 0
+    ? await dependencies.ciDocumentationSyncGateway.syncCiDocumentation(designModel, ciTargets)
+    : emptyCiDocumentationSyncResult();
+  completedTargets.push(...ciTargets);
+
   const shouldWriteMetadata = requestedTargets.has("metadata") || options.writeMetadata === true;
   const metadataSyncResult = shouldWriteMetadata
     ? await dependencies.metadataSyncGateway.writeMetadata(designModel)
@@ -92,6 +99,9 @@ export async function syncFigmaDesignModel(
     createdCatalogConnectors: catalogSyncResult.createdCatalogConnectors,
     removedCatalogNodes: catalogSyncResult.removedCatalogNodes,
     removedCatalogConnectors: catalogSyncResult.removedCatalogConnectors,
+    updatedCiSections: ciSyncResult.updatedCiSections,
+    createdCiNodes: ciSyncResult.createdCiNodes,
+    createdCiConnectors: ciSyncResult.createdCiConnectors,
     checkedComponents: preflightResult.checkedComponents,
     checkedSections: preflightResult.checkedSections,
     checkedVariables: preflightResult.checkedVariables,
@@ -103,6 +113,7 @@ export async function syncFigmaDesignModel(
         ...headerSyncResult.mutatedNodeIds,
         ...versionSyncResult.mutatedNodeIds,
         ...catalogSyncResult.mutatedNodeIds,
+        ...ciSyncResult.mutatedNodeIds,
         ...metadataSyncResult.mutatedNodeIds,
       ]),
     ],
@@ -178,6 +189,15 @@ function emptyMetadataSyncResult() {
   };
 }
 
+function emptyCiDocumentationSyncResult() {
+  return {
+    updatedCiSections: [],
+    createdCiNodes: [],
+    createdCiConnectors: [],
+    mutatedNodeIds: [],
+  };
+}
+
 function emptyVisualContractCheckResult() {
   return {
     checkedComponents: [],
@@ -203,10 +223,18 @@ const CATALOG_SYNC_TARGETS: SyncTargetName[] = [
   "figmaDesignSync.plugins",
 ];
 
+const CI_SYNC_TARGETS: SyncTargetName[] = [
+  "ci.overview",
+  "ci.pullRequestIntegration",
+  "ci.postMergeDesignDocumentation",
+  "ci.infrastructureAndAccess",
+];
+
 const ALL_SYNC_TARGETS: SyncTargetName[] = [
   "headers",
   "versions",
   ...CATALOG_SYNC_TARGETS,
+  ...CI_SYNC_TARGETS,
   "metadata",
 ];
 

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCiVisualPlan } from "../src/domain/ci/create-ci-visual-plan";
+
+test("CI visual plan creates the four documented granular sections", () => {
+  const plan = createCiVisualPlan(designModel());
+
+  assert.equal(plan.parentName, "Continuous Integration and Design Documentation");
+  assert.deepEqual(
+    plan.sections.map((section) => section.target),
+    [
+      "ci.overview",
+      "ci.pullRequestIntegration",
+      "ci.postMergeDesignDocumentation",
+      "ci.infrastructureAndAccess",
+    ]
+  );
+});
+
+test("CI visual plan summarizes commands and keeps exact operational names", () => {
+  const plan = createCiVisualPlan(designModel());
+  const postMerge = plan.sections.find((section) => section.target === "ci.postMergeDesignDocumentation")!;
+  const generateJob = postMerge.nodes.find((node) => node.name === "Generate main design model")!;
+
+  assert.equal(
+    generateJob.steps,
+    "Generate effective TeamCity configuration\nGenerate design model"
+  );
+  assert.ok(postMerge.nodes.some((node) => node.name === "design-model.json" && node.type === "artifact"));
+  assert.ok(postMerge.connections.some((edge) => edge.label === "Manual rerun"));
+});
+
+test("CI overview labels trigger, check, gate, merge, and model verification connections", () => {
+  const overview = createCiVisualPlan(designModel()).sections
+    .find((section) => section.target === "ci.overview")!;
+
+  assert.deepEqual(
+    overview.connections.map((connection) => connection.label),
+    [
+      "VCS trigger +:*",
+      "Publish check",
+      "Required check",
+      "Merge",
+      "After Root_Ci succeeds",
+      "Generate and publish",
+      "Verify model hash",
+    ]
+  );
+});
+
+test("CI visual plan renders external topology as infrastructure nodes and directed edges", () => {
+  const infrastructure = createCiVisualPlan(designModel()).sections
+    .find((section) => section.target === "ci.infrastructureAndAccess")!;
+
+  assert.deepEqual(
+    infrastructure.nodes.map((node) => node.name),
+    ["Operator", "Cloudflare Access", "TeamCity Server", "Codex/MCP Client", "Figma Design Document"]
+  );
+  assert.deepEqual(infrastructure.connections[0], {
+    id: "external-operator-access",
+    source: "external-operator",
+    target: "external-cloudflare-access",
+    label: "Open TeamCity",
+  });
+});
+
+test("CI visual plan rejects models without CI content", () => {
+  assert.throws(
+    () => createCiVisualPlan({ branch: "main", content: {} }),
+    /designModel\.content\.ci is required/
+  );
+});
+
+function designModel() {
+  return {
+    branch: "main",
+    content: {
+      ci: {
+        externalTopology: {
+          nodes: [
+            { id: "operator", type: "actor", name: "Operator", description: "Starts manual actions." },
+            { id: "cloudflare-access", type: "system", name: "Cloudflare Access", description: "Applies access policy." },
+            { id: "teamcity-server", type: "system", name: "TeamCity Server", description: "Orchestrates pipelines." },
+            { id: "codex-mcp-client", type: "system", name: "Codex/MCP Client", description: "Applies visual changes." },
+            { id: "figma-design-document", type: "system", name: "Figma Design Document", description: "Stores visual documentation." },
+          ],
+          connections: [
+            { id: "operator-access", source: "operator", target: "cloudflare-access", label: "Open TeamCity" },
+          ],
+        },
+        teamCity: {
+          vcsRoots: [],
+          pipelines: [
+            {
+              id: "Root_Ci",
+              name: "CI",
+              triggers: [{ type: "vcs", branchFilter: "+:*" }],
+              jobs: [
+                {
+                  id: "verify",
+                  name: "Verify",
+                  steps: [{ id: "RUNNER_1", name: "Run Gradle check", command: ".\\gradlew.bat check" }],
+                  artifacts: [],
+                  publishedChecks: [{ name: "TeamCity CI" }],
+                },
+              ],
+            },
+            {
+              id: "Root_FigmaSync",
+              name: "Figma Sync",
+              triggers: [{ type: "pipeline finish", dependencyPipelineId: "Root_Ci" }],
+              jobs: [
+                {
+                  id: "generate",
+                  name: "Generate main design model",
+                  steps: [
+                    { id: "RUNNER_1", name: "Generate config", command: ".\\mvnw.cmd teamcity-configs:generate" },
+                    { id: "RUNNER_2", name: "Generate model", command: ".\\gradlew.bat generateFigmaDesignModel" },
+                  ],
+                  artifacts: [{ path: "build/reports/figma-sync/design-model.json" }],
+                  publishedChecks: [],
+                },
+                {
+                  id: "check",
+                  name: "Check Figma trunk sync",
+                  steps: [{ id: "RUNNER_1", name: "Check", command: ".\\gradlew.bat checkFigmaTrunkSync" }],
+                  artifacts: [],
+                  publishedChecks: [{ name: "TeamCity Figma Sync" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+}

--- a/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
+++ b/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
@@ -59,6 +59,23 @@ test("headers can be synchronized as an independent visual target", async () => 
   assert.deepEqual(result.updatedHeaders, ["parent-section"]);
 });
 
+test("preflight validates and synchronizes a granular CI documentation target", async () => {
+  const calls: string[] = [];
+  const result = await syncFigmaDesignModel(
+    mainDesignModel(),
+    fakeDependencies(calls),
+    {
+      targets: ["preflight", "ci.overview"],
+      writeMetadata: false,
+    }
+  );
+
+  assert.deepEqual(calls, ["preflight", "ci"]);
+  assert.deepEqual(result.completedTargets, ["preflight", "ci.overview"]);
+  assert.deepEqual(result.checkedTargets, ["ci.overview"]);
+  assert.deepEqual(result.updatedCiSections, ["ci.overview"]);
+});
+
 function mainDesignModel() {
   return {
     branch: "main",
@@ -100,6 +117,17 @@ function fakeDependencies(calls: string[]) {
           removedCatalogNodes: [],
           removedCatalogConnectors: [],
           mutatedNodeIds: ["catalog"],
+        };
+      },
+    },
+    ciDocumentationSyncGateway: {
+      async syncCiDocumentation(_designModel, targetNames) {
+        calls.push("ci");
+        return {
+          updatedCiSections: targetNames,
+          createdCiNodes: ["ci-node"],
+          createdCiConnectors: ["ci-connector"],
+          mutatedNodeIds: ["ci-section"],
         };
       },
     },

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -88,6 +88,25 @@ test("official runner accepts preflight plus the granular headers target", async
   }
 });
 
+test("official runner accepts preflight plus a granular CI documentation target", async () => {
+  const workspace = createRunnerFixture();
+  try {
+    runRunner([
+      "--mode=official",
+      `--model=${workspace.modelPath}`,
+      `--script=${workspace.scriptPath}`,
+      "--targets=preflight,ci.overview",
+      `--out-dir=${workspace.outDir}`,
+    ]);
+
+    const runDir = join(workspace.outDir, "official-trunk-sync-preflight-ci-overview-png-design-model-json");
+    const manifest = readManifest(runDir);
+    assert.deepEqual(manifest.targets, ["preflight", "ci.overview"]);
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
 test("official runner can explicitly use chunk transport fallback", async () => {
   const workspace = createRunnerFixture();
 


### PR DESCRIPTION
## Summary

- model the external CI topology and effective TeamCity configuration in `design-model.json`
- add granular Figma targets for overview, pull request integration, post-merge design documentation, and infrastructure/access
- validate the `.ci node` and `ci/cd` contracts before visual writes
- document the official artifact and operator-assisted Figma synchronization flow

## Why

The CI documentation needs one reviewed source model that combines versioned external topology with effective TeamCity configuration, while keeping Figma as derived documentation and preserving the manual MCP write boundary.

## Verification

- `npm test`
- `npm run build`
- `./gradlew.bat :figma-design-sync:domain:check :figma-design-sync:data:check :figma-design-sync:plugin:check checkCiExternalTopologyFreshness`
- `teamcity project settings validate .teamcity --verbose`
- `git diff --check`