### PR TITLE
fix(figma-design-sync): clone native CI connectors

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -82,8 +82,10 @@ content. Commands are summarized for display; the `source` row links to the
 canonical file on GitHub `main`, where the literal DSL remains available.
 
 Every `.ci node` instance is the only child of a managed group. Native Figma
-connectors attach from the bottom of the source group to the top of the target
-group, remain children of the target section, and are inserted behind nodes.
+connectors are cloned from the existing `simple-solid_arrow` template because
+the MCP runtime does not expose `figma.createConnector()`. The clones attach
+from the bottom of the source group to the top of the target group, remain
+children of the target section, and are inserted behind nodes.
 The writer derives labels from triggers and connection purposes rather than
 using generic continuation text.
 

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -17,6 +17,7 @@ export const CI_VARIABLE_MODE_NAMES = [
 ] as const;
 export const CI_NODE_INSTANCE_NAME = ".ci node";
 export const CI_CONNECTOR_NAME = ".ci connector";
+export const CI_CONNECTOR_TEMPLATE_SECTION_ID = "63069:629";
 export const CI_NODE_PROPS = {
   name: "name",
   description: "description",

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -1,10 +1,12 @@
 import {
   CI_CONNECTOR_NAME,
+  CI_CONNECTOR_TEMPLATE_SECTION_ID,
   CI_DOCUMENTATION_PAGE_ID,
   CI_NODE_COMPONENT_ID,
   CI_NODE_INSTANCE_NAME,
   CI_NODE_PROPS,
   CI_VARIABLE_COLLECTION_NAME,
+  CONNECTOR_TEMPLATE_NAME,
   HEADER_INSTANCE_NAME,
   HEADER_SECTION_TARGETS,
   METADATA_NAMESPACE,
@@ -193,6 +195,9 @@ async function syncSectionContent(
 ) {
   const groupsByModelId = new Map<string, GroupNode>();
   const groups: Array<{ plan: CiVisualNode; group: GroupNode }> = [];
+  const connectorTemplate = plan.connections.length > 0
+    ? await requireCiConnectorTemplate()
+    : null;
 
   for (const nodePlan of plan.nodes) {
     const instance = nodeComponent.createInstance();
@@ -217,7 +222,10 @@ async function syncSectionContent(
     if (!source || !target) {
       throw new Error(`CI section '${plan.target}' connection '${edge.id}' references an unknown node.`);
     }
-    const connector = figma.createConnector();
+    if (!connectorTemplate) {
+      throw new Error(`CI section '${plan.target}' requires a connector template.`);
+    }
+    const connector = connectorTemplate.clone();
     connector.name = CI_CONNECTOR_NAME;
     connector.connectorLineType = "ELBOWED";
     connector.connectorStartStrokeCap = "NONE";
@@ -236,6 +244,18 @@ async function syncSectionContent(
 
   resizeChildSection(section, groups.map((item) => item.group), mutatedNodeIds);
   applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
+}
+
+async function requireCiConnectorTemplate(): Promise<ConnectorNode> {
+  const section = await requireSection(CI_CONNECTOR_TEMPLATE_SECTION_ID);
+  const connector = section.findAllWithCriteria({ types: ["CONNECTOR"] })
+    .find((candidate) => candidate.name === CONNECTOR_TEMPLATE_NAME);
+  if (!connector) {
+    throw new Error(
+      `No '${CONNECTOR_TEMPLATE_NAME}' connector template was found in section '${section.id}'.`
+    );
+  }
+  return connector;
 }
 
 async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {

--- a/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -4,11 +4,13 @@ import {
   ARTIFACT_INSTANCE_NAME,
   ARTIFACT_PROPS,
   CATALOG_TREE_TARGETS,
+  CI_CONNECTOR_TEMPLATE_SECTION_ID,
   CI_DOCUMENTATION_PAGE_ID,
   CI_NODE_COMPONENT_ID,
   CI_NODE_PROPS,
   CI_VARIABLE_COLLECTION_NAME,
   CI_VARIABLE_MODE_NAMES,
+  CONNECTOR_TEMPLATE_NAME,
   HEADER_INSTANCE_NAME,
   HEADER_LINK_PROPERTY_NAME,
   HEADER_SECTION_TARGETS,
@@ -100,6 +102,17 @@ async function checkCiDocumentationContract(
   requireComponentProperty(component, CI_NODE_PROPS.showSteps, "BOOLEAN");
   requireComponentProperty(component, CI_NODE_PROPS.showSource, "BOOLEAN");
   checkedComponents.push(`${component.name}:${component.id}`);
+
+  const connectorSection = await requireSection(CI_CONNECTOR_TEMPLATE_SECTION_ID);
+  const connectorTemplate = connectorSection.findAllWithCriteria({ types: ["CONNECTOR"] })
+    .find((candidate) => candidate.name === CONNECTOR_TEMPLATE_NAME);
+  if (!connectorTemplate) {
+    throw new Error(
+      `No '${CONNECTOR_TEMPLATE_NAME}' connector template was found in section '${connectorSection.id}'.`
+    );
+  }
+  checkedComponents.push(`${connectorTemplate.name}:${connectorTemplate.id}`);
+  checkedSections.push(`ciConnectorTemplate:${connectorSection.id}`);
 
   const collection = await requireVariableCollection(CI_VARIABLE_COLLECTION_NAME);
   for (const modeName of CI_VARIABLE_MODE_NAMES) {


### PR DESCRIPTION
## Summary

- clone the existing `simple-solid_arrow` connector template for CI sections
- attach cloned connectors from source-group bottom to target-group top
- validate the connector template during CI preflight
- document the Figma MCP runtime limitation

## Root cause

The official Figma MCP runtime does not expose `figma.createConnector()`, so the first CI overview write failed after the font issue was resolved.

## Verification

- reproduced through the official `preflight,ci.overview` runner
- `npm test`
- `npm run build`