### PR TITLE
fix(figma-design-sync): preserve connector text contracts

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -86,6 +86,12 @@ connectors are cloned from the existing `simple-solid_arrow` template because
 the MCP runtime does not expose `figma.createConnector()`. The clones attach
 from the bottom of the source group to the top of the target group, remain
 children of the target section, and are inserted behind nodes.
+Cloned connector text may initially expose an empty font name; the writer uses
+the design file's `Poppins Regular` connector font as the explicit fallback
+before setting the connection label.
+Text alignment is owned by `.ci node`, `.Header`, and the connector template;
+the writer does not override sublayer alignment because the MCP text proxy does
+not expose that style mutation consistently.
 The writer derives labels from triggers and connection purposes rather than
 using generic continuation text.
 

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -403,17 +403,18 @@ async function applyTextLinks(root, textNodeName, links, expectedText) {
     text.setRangeHyperlink(start, end, { type: "URL", value: link.url });
     start = end + 1;
   }
-  text.textAlignHorizontal = "LEFT";
 }
 
 async function setConnectorLabel(connector, label) {
-  const fontName = connector.text.fontName === figma.mixed
-    ? { family: "Inter", style: "Regular" }
-    : connector.text.fontName;
+  const currentFontName = connector.text.fontName;
+  const fontName = currentFontName === figma.mixed ||
+      !currentFontName.family?.trim() ||
+      !currentFontName.style?.trim()
+    ? { family: "Poppins", style: "Regular" }
+    : currentFontName;
   await figma.loadFontAsync(fontName);
   connector.text.fontName = fontName;
   connector.text.characters = label;
-  connector.text.textAlignHorizontal = "CENTER";
 }
 
 async function requireColorVariable(name) {

--- a/repo/figma-design-sync/tools/src/figma/figma-text-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-text-gateway.ts
@@ -63,6 +63,9 @@ export async function loadTextNodeFonts(textNode) {
     if (segment.fontName === figma.mixed) {
       continue;
     }
+    if (!segment.fontName.family?.trim() || !segment.fontName.style?.trim()) {
+      continue;
+    }
     fontKeys.add(`${segment.fontName.family}\u0000${segment.fontName.style}`);
   }
 


### PR DESCRIPTION
## Summary
- fall back to `Poppins Regular` when cloned Figma connectors expose blank font metadata
- keep text alignment owned by `.ci node`, `.Header`, and the connector template
- document the MCP runtime limitation

## Verification
- `npm test`
- `npm run build`
- all four granular CI documentation targets executed successfully in Figma
- parent CI documentation section inspected via screenshot