### PR TITLE
fix(figma-design-sync): refine CI visual documentation

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -5,6 +5,9 @@ This directory is the source of truth for TeamCity project settings.
 The contract used to derive the Figma representation of CI from these settings
 is documented in
 [`docs/ci/visual-model-contract.md`](../docs/ci/visual-model-contract.md).
+Public HTTPS access, Cloudflare policies, CLI service authentication, webhook
+validation, and CSRF recovery are documented in
+[`docs/runbooks/teamcity-cloudflare-access.md`](../docs/runbooks/teamcity-cloudflare-access.md).
 
 ## Branching Workflow
 
@@ -310,6 +313,13 @@ teamcity auth login --server <teamcity-url> --token <token>
 teamcity auth status
 ```
 
+The public HTTPS route also requires Cloudflare Service Auth. Keep the
+Cloudflare service token in PowerShell SecretStore and inject its headers only
+for the duration of each CLI command. Follow
+[`docs/runbooks/teamcity-cloudflare-access.md`](../docs/runbooks/teamcity-cloudflare-access.md)
+for the wrapper, verification procedure, webhook boundary, and the known CSRF
+limitation on mutating CLI requests.
+
 Bind the current checkout to the TeamCity project and default pipeline if the
 local `teamcity.toml` is missing:
 
@@ -394,6 +404,12 @@ If `Figma Sync` fails on `main`, check whether the Figma MCP visual sync has
 been run with the latest `design-model.json` artifact from
 `Figma Sync > Generate main design model`. If the failure mentions a branch
 other than `main`, fix repository checkout before investigating Figma sync.
+
+After the MCP write updates official metadata, rerun the complete `Figma Sync`
+pipeline. A successful standalone `Check Figma trunk sync` proves that metadata
+matches, but it does not replace the previously failed aggregate pipeline or
+its GitHub status. Confirm that `Generate main design model`, `Check Figma trunk
+sync`, and the aggregate `Figma Sync` run all succeed.
 
 ## Clean-up Rules
 

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -73,7 +73,8 @@ The GitHub ruleset for `main` is documented in
 The pipeline:
 
 - monitors all branches;
-- runs `Verify` with `.\gradlew.bat check`;
+- runs `Verify` with `.\gradlew.bat check --stacktrace` so Gradle failures keep
+  their diagnostic context in the TeamCity build log;
 - blocks invalid dependency version key names through
   `checkFigmaVersionNaming`, which is wired into the Gradle `check` lifecycle;
 - blocks unused dependency catalog entries through `checkFigmaCatalogUsage`,
@@ -182,7 +183,7 @@ repositories:
 The generated script content should remain a direct Gradle call:
 
 ```yaml
-script-content: .\gradlew.bat check
+script-content: .\gradlew.bat check --stacktrace
 ```
 
 Do not perform `git init`, `git fetch`, or `git checkout` from build script

--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -378,6 +378,42 @@ Do not rely on `--local-changes` unless the access token has the TeamCity
 permission `Change build source code with a custom patch`. The normal workflow
 is to commit and push the branch, then run the pipeline against that branch.
 
+## Windows Agent Runtime
+
+Run the TeamCity server and build agent with separate virtual service accounts:
+
+- `NT SERVICE\TeamCity` owns the server data directory;
+- `NT SERVICE\TCBuildAgent` owns the agent's mutable `system`, `work`, `temp`,
+  and `.gradle` directories.
+
+The agent must use a system-wide JDK instead of a JDK inside a developer profile.
+Keep the following properties in
+`C:\TeamCity\buildAgent\conf\buildAgent.properties`, updating the Temurin
+directory when the installed patch version changes:
+
+```properties
+env.JAVA_HOME=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.11.10-hotspot
+env.GRADLE_USER_HOME=C\:\\TeamCity\\buildAgent\\.gradle
+```
+
+`NT SERVICE\TCBuildAgent` needs `Modify` on its mutable directories. It also
+needs non-inherited `ReadAndExecute` on `C:\TeamCity` so Java
+`Path.toRealPath()` can traverse the parent directory while resolving Gradle
+distribution JARs. Do not grant the agent `FullControl` over `C:\TeamCity` or
+inherit agent permissions into the server data directory.
+
+After changing the service account or these permissions:
+
+1. stop the build agent;
+2. stop Gradle daemons owned by the agent;
+3. remove only the failed `dependencies-accessors` cache and the checkout's
+   `.gradle` directory;
+4. restart the agent and run the pipeline again.
+
+The first clean run downloads and compiles more work than later runs. Confirm
+that its log reports the expected JDK and that `BUILD SUCCESSFUL` comes from the
+child `Verify` job.
+
 ## Troubleshooting
 
 If a job cannot find `gradlew.bat`, check that the job declares the GitHub
@@ -397,6 +433,23 @@ batch variables in the TeamCity step.
 If pipeline generation reports that a repository is not found, check for direct
 references to generated VCS root ids in job repository blocks. Use the local DSL
 object instead.
+
+If Gradle reports `GeneratedClassCompilationException`, inspect the final
+`Caused by` entry from the `--stacktrace` output. An `AccessDeniedException` for
+`gradle-core-api-*.jar` from `ZipFileSystemProvider.removeFileSystem` means the
+agent cannot resolve the real path through `C:\TeamCity`; fix parent-directory
+traversal before clearing the generated accessor cache.
+
+If agent-side checkout reports dubious ownership after changing the Windows
+service account, stop the agent and assign both ownership and `Modify` access on
+the agent's mutable directories to `NT SERVICE\TCBuildAgent`. Do not hide the
+problem with a global Git `safe.directory` entry.
+
+If the TeamCity server cannot run `git ls-remote origin` after its service
+account changes, reset the server `git` cache from
+`Administration > Diagnostics > Caches`. The page does not show progress; verify
+the reset in the server log, then send a VCS commit-hook notification or push a
+new commit.
 
 If GitHub receives no status check, inspect `teamcity-commit-status.log` and
 confirm that the status publisher feature is attached to the final job.

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -69,7 +69,7 @@ object WaterMyPlantsCi : Pipeline({
         steps {
             step(PipelineScriptStep {
                 name = "Run Gradle check"
-                scriptContent = """.\gradlew.bat check"""
+                scriptContent = """.\gradlew.bat check --stacktrace"""
             })
         }
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Documentation guide](docs/documentation.md)
 - [Project structure](docs/project-structure.md)
 - [Main branch protection](docs/ci/main-branch-protection.md)
+- [TeamCity HTTPS and webhook operations](docs/runbooks/teamcity-cloudflare-access.md)
 
 ## BDD with Cucumber
 

--- a/docs/ci/external-topology-validation.md
+++ b/docs/ci/external-topology-validation.md
@@ -4,6 +4,11 @@ Use this runbook to validate `docs/ci/external-topology.yaml` against the active
 services. The review is manual because Cloudflare, GitHub, TeamCity, and Figma
 configuration is not fully represented by repository code.
 
+Use
+[`../runbooks/teamcity-cloudflare-access.md`](../runbooks/teamcity-cloudflare-access.md)
+for the executable HTTPS, CLI, and GitHub App webhook configuration and
+recovery procedure.
+
 ## Validation Procedure
 
 1. Confirm the public TeamCity UI route uses Cloudflare Access and Cloudflare

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -55,4 +55,6 @@ scripts should stay together.
 - Repository overview: `README.md`
 - Project structure: `docs/project-structure.md`
 - CI policy: `docs/ci/main-branch-protection.md`
+- TeamCity HTTPS and webhook operations:
+  `docs/runbooks/teamcity-cloudflare-access.md`
 - Figma design sync docs: `repo/figma-design-sync/docs/README.md`

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -1,0 +1,187 @@
+# TeamCity Cloudflare Access Runbook
+
+## Purpose
+
+Use this runbook to configure, validate, or recover access to the TeamCity
+server at `https://teamcity.marmatsan.dev`.
+
+The public hostname is exposed through Cloudflare Tunnel and has three distinct
+access paths. Do not collapse them into one policy:
+
+| Client | Cloudflare policy | TeamCity authentication |
+|--------|-------------------|-------------------------|
+| Browser | Interactive `Allow` policy | TeamCity user session |
+| TeamCity CLI | `Service Auth` policy | TeamCity access token |
+| GitHub App webhook | Path-specific `Bypass` policy | GitHub webhook signature |
+
+The repository documents the contract, but Cloudflare, GitHub, and TeamCity
+credentials remain operator-managed state and must not be committed.
+
+## Prerequisites
+
+- Cloudflare Tunnel routes the public hostname to the private TeamCity origin.
+- The browser `Allow` policy grants only intended users access to the UI.
+- A Cloudflare service token is included by the CLI `Service Auth` policy.
+- TeamCity CLI is authenticated to the HTTPS server with a TeamCity access
+  token stored in the system keyring.
+- The GitHub App webhook uses a dedicated bypass destination for only
+  `/app/webhooks/githubapp`.
+- PowerShell SecretManagement and SecretStore are installed for local service
+  token storage.
+
+## Store The Cloudflare Service Token
+
+Store the Cloudflare service token as a `PSCredential`. Use its client ID as the
+username and its client secret as the password:
+
+```powershell
+Set-Secret -Vault TeamCitySecrets -Name TeamCityCloudflareAccess -Secret (Get-Credential)
+```
+
+Configure SecretStore according to the workstation security policy. Never put
+the client ID, client secret, or TeamCity access token in the repository,
+PowerShell profile, command history, or `teamcity.toml`.
+
+## Run TeamCity CLI Through Service Auth
+
+The PowerShell profile may expose a `teamcity` wrapper that loads the
+Cloudflare credential only for the duration of one command:
+
+```powershell
+function teamcity {
+    $credential = Get-Secret TeamCityCloudflareAccess -ErrorAction Stop
+    $previousId = $env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID
+    $previousSecret = $env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET
+    $exitCode = 1
+
+    try {
+        $env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID = $credential.UserName
+        $env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET =
+            $credential.GetNetworkCredential().Password
+        & teamcity.exe @args
+        $exitCode = $LASTEXITCODE
+    } finally {
+        if ($null -eq $previousId) {
+            Remove-Item Env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID -ErrorAction SilentlyContinue
+        } else {
+            $env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID = $previousId
+        }
+
+        if ($null -eq $previousSecret) {
+            Remove-Item Env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET -ErrorAction SilentlyContinue
+        } else {
+            $env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET = $previousSecret
+        }
+
+        Remove-Variable credential -ErrorAction SilentlyContinue
+    }
+
+    $global:LASTEXITCODE = $exitCode
+}
+```
+
+Verify both authentication layers and confirm the Cloudflare secret is not left
+in the shell environment:
+
+```powershell
+teamcity auth status
+Test-Path Env:TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET
+```
+
+The first command must report the HTTPS TeamCity server as API compatible. The
+second command must return `False` after the wrapper exits.
+
+## Configure The GitHub App Webhook
+
+Use the TeamCity GitHub App connection's webhook URL:
+
+```text
+https://teamcity.marmatsan.dev/app/webhooks/githubapp
+```
+
+The GitHub App subscribes to the events required by TeamCity:
+
+- `push`;
+- `pull_request`;
+- `check_suite`;
+- `check_run`.
+
+The webhook secret configured in GitHub and TeamCity must match. Cloudflare
+Access must bypass interactive authentication only for the exact webhook path.
+Do not bypass the whole TeamCity hostname or its REST API.
+
+Validate the route by creating a temporary branch and checking the GitHub App
+advanced delivery log. A valid `push` delivery must receive HTTP `200` from
+TeamCity. Delete the temporary branch after validation.
+
+## Mutating CLI Requests And CSRF
+
+Read-only CLI commands such as `teamcity auth status`, `teamcity run list`, and
+`teamcity run view` work through the public HTTPS route. A mutating command such
+as `teamcity run start` or `teamcity run restart` can fail with:
+
+```text
+403 Forbidden: failed CSRF check
+```
+
+Cloudflare Access can add a `CF_Authorization` cookie to the authenticated
+request. TeamCity then treats the POST as cookie-authenticated and requires an
+`X-TC-CSRF-Token` value that TeamCity CLI does not currently provide.
+
+Use one of these recovery paths:
+
+1. Rerun the build from the authenticated TeamCity UI.
+2. On the TeamCity server host only, call the private origin with a TeamCity
+   Bearer token and no Cloudflare headers or cookies.
+
+For the second option, load `TEAMCITY_TOKEN` from an approved local secret
+provider, then queue the complete Figma Sync pipeline:
+
+```powershell
+$headers = @{
+    Authorization = "Bearer $env:TEAMCITY_TOKEN"
+    Accept = "application/json"
+}
+$body = @{
+    buildType = @{ id = "WaterMyPlants_WaterMyPlantsFigmaSync" }
+    branchName = "main"
+} | ConvertTo-Json -Depth 4 -Compress
+
+Invoke-RestMethod `
+    -Method Post `
+    -Uri "http://localhost:8111/app/rest/buildQueue" `
+    -Headers $headers `
+    -ContentType "application/json" `
+    -Body $body
+
+Remove-Item Env:TEAMCITY_TOKEN -ErrorAction SilentlyContinue
+```
+
+Do not expose `localhost:8111` outside the TeamCity host, do not bypass
+Cloudflare for the public REST API, and do not add a build comment unless the
+token has the TeamCity `Comment build` permission.
+
+## Verification
+
+After configuration or recovery:
+
+1. Open the TeamCity UI through the HTTPS hostname and complete interactive
+   authentication.
+2. Run `teamcity auth status` and one read-only run query through the wrapper.
+3. Confirm a GitHub App test webhook and a real `push` delivery return HTTP
+   `200`.
+4. Confirm GitHub push or pull request events start the expected TeamCity
+   pipeline and publish its repository check.
+5. Run the manual validation in
+   [`../ci/external-topology-validation.md`](../ci/external-topology-validation.md).
+
+## Secret Rotation
+
+- When the TeamCity access token expires, run `teamcity auth login` against the
+  HTTPS server and approve only the required permissions. The replacement token
+  remains in the system keyring.
+- When the Cloudflare service token rotates, replace
+  `TeamCityCloudflareAccess` in SecretStore and leave the PowerShell wrapper
+  unchanged.
+- When the GitHub webhook secret rotates, update GitHub and the TeamCity GitHub
+  App connection in the same operation, then send a test delivery.

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -82,12 +82,23 @@ intentionally non-authoritative and must not write official metadata.
    [visual-sync-contract.md](visual-sync-contract.md).
 9. After all visual targets are correct, run only the `metadata` target with
    `writeMetadata=true`.
-10. Rerun TeamCity `Figma Sync`, or run `checkFigmaTrunkSync` locally as a
-   diagnostic check before rerunning TeamCity.
+10. Optionally rerun only TeamCity `Check Figma trunk sync`, or run
+    `checkFigmaTrunkSync` locally, as an early diagnostic after writing
+    metadata.
+11. Rerun the complete TeamCity `Figma Sync` pipeline. Confirm that `Generate
+    main design model`, `Check Figma trunk sync`, and the aggregate pipeline all
+    succeed so TeamCity publishes a successful final status.
 
 Do not write metadata before visual targets are reconciled. `checkFigmaTrunkSync`
 trusts the metadata hash, so premature metadata can make CI pass while Figma is
 still visually stale.
+
+A successful standalone `Check Figma trunk sync` does not change the result of
+an earlier failed aggregate `Figma Sync` run. The complete pipeline must be
+rerun after the MCP write. If its generated artifact has the same `gitSha` and
+`modelHash` already stored in Figma, do not repeat the visual write. If either
+value changes, treat the new artifact as a new synchronization input and resume
+the visual flow before writing metadata again.
 
 ## Failure Recovery
 

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -76,6 +76,8 @@ and exposes four independently runnable targets:
 Each visual entity is an instance of `.ci node` (`64301:3927`). The writer
 selects the matching mode from the `ci/cd` variable collection: `Actor`,
 `System`, `Git reference`, `Pipeline`, `Job`, `Artifact`, `Check`, or `Gate`.
+The collection's `type_label` string supplies the visible type label for each
+mode.
 It binds the exposed `name`, `description`, `steps`, and `source` text
 properties and controls `show steps` and `show source` from actual model
 content. Commands are summarized for display; the `source` row links to the
@@ -83,15 +85,53 @@ canonical file on GitHub `main`, where the literal DSL remains available.
 
 Every `.ci node` instance is the only child of a managed group. Native Figma
 connectors are cloned from the existing `simple-solid_arrow` template because
-the MCP runtime does not expose `figma.createConnector()`. The clones attach
-from the bottom of the source group to the top of the target group, remain
-children of the target section, and are inserted behind nodes.
+the MCP runtime does not expose `figma.createConnector()`. The clones attach to
+the managed node groups using the magnets selected for the section layout,
+remain children of the target section, and are inserted behind nodes.
 Cloned connector text may initially expose an empty font name; the writer uses
 the design file's `Poppins Regular` connector font as the explicit fallback
-before setting the connection label.
+before clearing the native connector text. Connector labels are managed groups
+named `.ci connector label`, composed of a surface background and horizontal
+text, and placed between connected node groups. Do not use native connector
+text for CI labels because Figma rotates it with vertical and elbowed connector
+paths.
+`Overview`, `Pull Request Integration`, and `Post-merge Design Documentation`
+use a left-to-right flow. `Infrastructure and Access` keeps its two-dimensional
+topology grid. Horizontal flows connect from the side anchors of their node
+groups and vertically align node centers. Their inter-node gap grows when
+necessary so the connector label fits centered on the horizontal connector.
+Disconnected horizontal flows are stacked as separate rows and each row starts
+at the same left edge. Post-merge job order is derived from declared artifact
+publication and job dependencies, never from the order of jobs in the generated
+TeamCity model.
+Return connections use bottom anchors and route below the row instead of
+crossing intermediate nodes. In the topology grid, parallel opposite vertical
+connections keep the forward path direct and route the return path around the
+left side so its label cannot obscure the forward path or adjacent connectors.
+Label text wraps when it exceeds 280 px, and label placement must avoid every
+`.ci node group` and previously placed connector label. If no direct gap is
+available, search additional positions outside the connected nodes instead of
+covering a node or another label.
+Distinct connections that share the same endpoints must remain visually
+distinct. Route horizontal parallel connections above and below their nodes;
+for opposite vertical connections, keep the forward path direct and route the
+return path around one side.
+The icon shown in a `.ci node` header is exactly one nested `.ci icon` instance
+from component set `64361:716`. Its `environment` variant is configured directly
+on the nested instance because Figma does not promote that property to the
+parent `.ci node` component. Supported environments are `github`, `teamcity`,
+`cloudflare`, `figma`, `codex`, `browser`, `terminal`, `operator`, and `json`.
+The visual plan maps every node explicitly; there is no generic fallback. The
+preflight must fail when the nested instance is absent or duplicated, belongs
+to another component set, lacks the `environment` property, or exposes a
+different set of variant values.
 Text alignment is owned by `.ci node`, `.Header`, and the connector template;
 the writer does not override sublayer alignment because the MCP text proxy does
 not expose that style mutation consistently.
+The CI parent section explicitly uses the `Light` mode from the collection that
+owns `md/sys/color/surface`. Its bound fill also carries the resolved Light
+color as fallback so exports and MCP screenshots do not render the section as a
+black surface when variable resolution is unavailable.
 The writer derives labels from triggers and connection purposes rather than
 using generic continuation text.
 

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -4,6 +4,7 @@ export const METADATA_PAGE_ID = "62934:908";
 export const METADATA_NAMESPACE = "water_my_plants_sync";
 export const CI_DOCUMENTATION_PAGE_ID = "63153:2876";
 export const CI_NODE_COMPONENT_ID = "64301:3927";
+export const CI_ICON_COMPONENT_SET_ID = "64361:716";
 export const CI_VARIABLE_COLLECTION_NAME = "ci/cd";
 export const CI_VARIABLE_MODE_NAMES = [
   "Actor",
@@ -16,7 +17,21 @@ export const CI_VARIABLE_MODE_NAMES = [
   "Gate",
 ] as const;
 export const CI_NODE_INSTANCE_NAME = ".ci node";
+export const CI_ICON_INSTANCE_NAME = ".ci icon";
+export const CI_ICON_ENVIRONMENT_PROPERTY = "environment";
+export const CI_ICON_ENVIRONMENTS = [
+  "github",
+  "teamcity",
+  "cloudflare",
+  "figma",
+  "codex",
+  "browser",
+  "terminal",
+  "operator",
+  "json",
+] as const;
 export const CI_CONNECTOR_NAME = ".ci connector";
+export const CI_CONNECTOR_LABEL_NAME = ".ci connector label";
 export const CI_CONNECTOR_TEMPLATE_SECTION_ID = "63069:629";
 export const CI_NODE_PROPS = {
   name: "name",

--- a/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
+++ b/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
@@ -8,6 +8,7 @@ export const CI_VISUAL_TARGET_NAMES = [
 ] as const;
 
 export type CiVisualTargetName = typeof CI_VISUAL_TARGET_NAMES[number];
+export type CiVisualOrientation = "horizontal" | "grid";
 export type CiVisualNodeType =
   | "actor"
   | "system"
@@ -17,10 +18,21 @@ export type CiVisualNodeType =
   | "artifact"
   | "check"
   | "gate";
+export type CiVisualEnvironment =
+  | "github"
+  | "teamcity"
+  | "cloudflare"
+  | "figma"
+  | "codex"
+  | "browser"
+  | "terminal"
+  | "operator"
+  | "json";
 
 export type CiVisualNode = {
   id: string;
   type: CiVisualNodeType;
+  environment: CiVisualEnvironment;
   name: string;
   description: string;
   steps?: string;
@@ -41,6 +53,7 @@ export type CiVisualSection = {
   target: CiVisualTargetName;
   name: string;
   description: string;
+  orientation: CiVisualOrientation;
   headerSources: Array<{ label: string; url: string }>;
   nodes: CiVisualNode[];
   connections: CiVisualConnection[];
@@ -92,14 +105,14 @@ function createOverviewSection(ciPipeline, figmaPipeline): CiVisualSection {
   const ciCheck = publishedChecks(ciPipeline)[0] || "TeamCity CI";
   const figmaCheck = publishedChecks(figmaPipeline)[0] || "TeamCity Figma Sync";
   const nodes: CiVisualNode[] = [
-    visualNode("overview-pr", "git reference", "Pull Request", "Proposes a reviewed change to the repository.", BRANCH_PROTECTION_SOURCE, 0, 0),
+    visualNode("overview-pr", "git reference", "github", "Pull Request", "Proposes a reviewed change to the repository.", BRANCH_PROTECTION_SOURCE, 0, 0),
     pipelineNode("overview-ci", ciPipeline, 1, 0),
-    visualNode("overview-ci-check", "check", ciCheck, "Reports CI verification to GitHub.", TEAMCITY_SOURCE, 2, 0),
-    visualNode("overview-gate", "gate", "Pull request merge gate", "Requires the CI check before merge.", BRANCH_PROTECTION_SOURCE, 3, 0),
-    visualNode("overview-main", "git reference", "main", "Stable trunk after the reviewed merge.", BRANCH_PROTECTION_SOURCE, 4, 0),
+    visualNode("overview-ci-check", "check", "teamcity", ciCheck, "Reports CI verification to GitHub.", TEAMCITY_SOURCE, 2, 0),
+    visualNode("overview-gate", "gate", "github", "Pull request merge gate", "Requires the CI check before merge.", BRANCH_PROTECTION_SOURCE, 3, 0),
+    visualNode("overview-main", "git reference", "github", "main", "Stable trunk after the reviewed merge.", BRANCH_PROTECTION_SOURCE, 4, 0),
     pipelineNode("overview-figma", figmaPipeline, 5, 0),
-    visualNode("overview-model", "artifact", "design-model.json", "Carries the repository documentation snapshot.", TEAMCITY_SOURCE, 6, 0),
-    visualNode("overview-figma-check", "check", figmaCheck, "Reports whether Figma metadata matches main.", TEAMCITY_SOURCE, 7, 0),
+    visualNode("overview-model", "artifact", "json", "design-model.json", "Carries the repository documentation snapshot.", TEAMCITY_SOURCE, 6, 0),
+    visualNode("overview-figma-check", "check", "teamcity", figmaCheck, "Reports whether Figma metadata matches main.", TEAMCITY_SOURCE, 7, 0),
   ];
 
   return section(
@@ -107,6 +120,7 @@ function createOverviewSection(ciPipeline, figmaPipeline): CiVisualSection {
     "Overview",
     "Simplified pull request and post-merge design documentation journeys.",
     [VISUAL_CONTRACT_SOURCE],
+    "horizontal",
     nodes,
     [
       connection("overview-pr-trigger", "overview-pr", "overview-ci", triggerLabel(ciPipeline)),
@@ -122,17 +136,17 @@ function createOverviewSection(ciPipeline, figmaPipeline): CiVisualSection {
 
 function createPullRequestSection(ciPipeline): CiVisualSection {
   const nodes: CiVisualNode[] = [
-    visualNode("pr", "git reference", "Pull Request", "Contains the branch revision proposed for main.", BRANCH_PROTECTION_SOURCE, 0, 0),
+    visualNode("pr", "git reference", "github", "Pull Request", "Contains the branch revision proposed for main.", BRANCH_PROTECTION_SOURCE, 0, 0),
     pipelineNode(`pipeline-${ciPipeline.id}`, ciPipeline, 1, 0),
     ...ciPipeline.jobs.map((job, index) => jobNode(`job-${job.id}`, job, 2 + index, 0)),
   ];
 
   const lastJob = ciPipeline.jobs.at(-1);
   for (const [index, checkName] of publishedChecks(ciPipeline).entries()) {
-    nodes.push(visualNode(`check-${index}`, "check", checkName, "Publishes the CI result to GitHub.", TEAMCITY_SOURCE, 2 + ciPipeline.jobs.length, index));
+    nodes.push(visualNode(`check-${index}`, "check", "teamcity", checkName, "Publishes the CI result to GitHub.", TEAMCITY_SOURCE, 2 + ciPipeline.jobs.length, index));
   }
-  nodes.push(visualNode("merge-gate", "gate", "Pull request merge gate", "Requires TeamCity CI before merging.", BRANCH_PROTECTION_SOURCE, 3 + ciPipeline.jobs.length, 0));
-  nodes.push(visualNode("main", "git reference", "main", "Receives the reviewed change after the gate passes.", BRANCH_PROTECTION_SOURCE, 4 + ciPipeline.jobs.length, 0));
+  nodes.push(visualNode("merge-gate", "gate", "github", "Pull request merge gate", "Requires TeamCity CI before merging.", BRANCH_PROTECTION_SOURCE, 3 + ciPipeline.jobs.length, 0));
+  nodes.push(visualNode("main", "git reference", "github", "main", "Receives the reviewed change after the gate passes.", BRANCH_PROTECTION_SOURCE, 4 + ciPipeline.jobs.length, 0));
 
   const connections: CiVisualConnection[] = [
     connection("pr-trigger", "pr", `pipeline-${ciPipeline.id}`, triggerLabel(ciPipeline)),
@@ -157,6 +171,7 @@ function createPullRequestSection(ciPipeline): CiVisualSection {
     "Pull Request Integration",
     "Detailed merge-gate flow derived from the effective CI pipeline.",
     [TEAMCITY_SOURCE, BRANCH_PROTECTION_SOURCE],
+    "horizontal",
     nodes,
     connections
   );
@@ -167,27 +182,40 @@ function createPostMergeSection(ci, figmaPipeline): CiVisualSection {
   const operator = externalById.get("operator");
   const codex = externalById.get("codex-mcp-client");
   const figmaDocument = externalById.get("figma-design-document");
+  const artifactJob = figmaPipeline.jobs.find((job) =>
+    job.artifacts?.some((artifact) => artifact.path.endsWith("design-model.json"))
+  );
+  const checkJob = artifactJob
+    ? figmaPipeline.jobs.find((job) => job.dependencies?.some((dependency) =>
+      dependency.jobId === artifactJob.id &&
+      dependency.artifactPaths?.some((path) => path.endsWith("design-model.json"))
+    ))
+    : undefined;
+  const remainingJobs = figmaPipeline.jobs.filter((job) =>
+    job.id !== artifactJob?.id && job.id !== checkJob?.id
+  );
+  const orderedJobs = [artifactJob, checkJob, ...remainingJobs].filter(Boolean);
+  const jobRows = new Map(orderedJobs.map((job, index) => [job.id, 2 + index * 2]));
   const nodes: CiVisualNode[] = [
-    visualNode("main", "git reference", "main", "Starts documentation verification after successful CI.", TEAMCITY_SOURCE, 0, 0),
+    visualNode("main", "git reference", "github", "main", "Starts documentation verification after successful CI.", TEAMCITY_SOURCE, 0, 0),
     pipelineNode(`pipeline-${figmaPipeline.id}`, figmaPipeline, 1, 0),
-    ...figmaPipeline.jobs.map((job, index) => jobNode(`job-${job.id}`, job, 2 + index * 2, 0)),
+    ...figmaPipeline.jobs.map((job, index) =>
+      jobNode(`job-${job.id}`, job, jobRows.get(job.id) ?? 2 + index * 2, 0)
+    ),
   ];
-  const artifactJob = figmaPipeline.jobs.find((job) => job.artifacts?.some((artifact) => artifact.path.endsWith("design-model.json")));
-  const artifactRow = artifactJob ? 3 : 2;
-  nodes.push(visualNode("design-model", "artifact", "design-model.json", "Official repository snapshot consumed by visual synchronization.", TEAMCITY_SOURCE, artifactRow, 0));
-  const checkRow = 2 + figmaPipeline.jobs.length * 2;
+  const artifactRow = artifactJob ? (jobRows.get(artifactJob.id) ?? 2) + 1 : 2;
+  nodes.push(visualNode("design-model", "artifact", "json", "design-model.json", "Official repository snapshot consumed by visual synchronization.", TEAMCITY_SOURCE, artifactRow, 0));
+  const checkRow = Math.max(2 + figmaPipeline.jobs.length * 2, ...(nodes.map((node) => node.row + 1)));
   for (const [index, checkName] of publishedChecks(figmaPipeline).entries()) {
-    nodes.push(visualNode(`figma-check-${index}`, "check", checkName, "Publishes the post-merge documentation result.", TEAMCITY_SOURCE, checkRow, index));
+    nodes.push(visualNode(`figma-check-${index}`, "check", "teamcity", checkName, "Publishes the post-merge documentation result.", TEAMCITY_SOURCE, checkRow, index));
   }
   if (operator) nodes.push(externalNode("operator", operator, checkRow + 1, 0));
   if (codex) nodes.push(externalNode("codex", codex, checkRow + 2, 0));
   if (figmaDocument) nodes.push(externalNode("figma-document", figmaDocument, checkRow + 3, 0));
 
-  const generateJob = figmaPipeline.jobs[0];
-  const checkJob = figmaPipeline.jobs[1];
   const connections: CiVisualConnection[] = [
     connection("main-trigger", "main", `pipeline-${figmaPipeline.id}`, triggerLabel(figmaPipeline)),
-    ...(generateJob ? [connection("pipeline-generate", `pipeline-${figmaPipeline.id}`, `job-${generateJob.id}`, "Run pipeline")] : []),
+    ...(artifactJob ? [connection("pipeline-generate", `pipeline-${figmaPipeline.id}`, `job-${artifactJob.id}`, "Run pipeline")] : []),
     ...(artifactJob ? [connection("generate-artifact", `job-${artifactJob.id}`, "design-model", "Publish artifact")] : []),
     ...(checkJob ? [connection("artifact-check", "design-model", `job-${checkJob.id}`, "Consume artifact")] : []),
     ...publishedChecks(figmaPipeline).map((_, index) => connection(
@@ -207,6 +235,7 @@ function createPostMergeSection(ci, figmaPipeline): CiVisualSection {
     "Post-merge Design Documentation",
     "Official model generation, visual synchronization, and verification loop.",
     [TEAMCITY_SOURCE, OFFICIAL_SYNC_SOURCE],
+    "horizontal",
     nodes,
     connections
   );
@@ -231,16 +260,18 @@ function createInfrastructureSection(ci): CiVisualSection {
     "Infrastructure and Access",
     "External systems, trust boundaries, authentication paths, and automation modes.",
     [TOPOLOGY_SOURCE, "docs/ci/external-topology-validation.md"],
+    "grid",
     nodes,
     connections
   );
 }
 
-function section(target, name, description, sources, nodes, connections): CiVisualSection {
+function section(target, name, description, sources, orientation, nodes, connections): CiVisualSection {
   return {
     target,
     name,
     description,
+    orientation,
     headerSources: sources.map((source) => ({ label: source, url: sourceUrl(source) })),
     nodes,
     connections,
@@ -248,22 +279,42 @@ function section(target, name, description, sources, nodes, connections): CiVisu
 }
 
 function pipelineNode(id, pipeline, row, column): CiVisualNode {
-  return visualNode(id, "pipeline", pipeline.name, pipelineDescription(pipeline.name), TEAMCITY_SOURCE, row, column);
+  return visualNode(id, "pipeline", "teamcity", pipeline.name, pipelineDescription(pipeline.name), TEAMCITY_SOURCE, row, column);
 }
 
 function jobNode(id, job, row, column): CiVisualNode {
   return {
-    ...visualNode(id, "job", job.name, jobDescription(job.name), TEAMCITY_SOURCE, row, column),
+    ...visualNode(id, "job", "teamcity", job.name, jobDescription(job.name), TEAMCITY_SOURCE, row, column),
     steps: job.steps?.map((step) => summarizeCommand(step.command, step.name)).join("\n") || undefined,
   };
 }
 
 function externalNode(id, node, row, column): CiVisualNode {
-  return visualNode(id, node.type, node.name, node.description, TOPOLOGY_SOURCE, row, column);
+  return visualNode(id, node.type, externalEnvironment(node.id), node.name, node.description, TOPOLOGY_SOURCE, row, column);
 }
 
-function visualNode(id, type, name, description, source, row, column): CiVisualNode {
-  return { id, type, name, description, source, sourceUrl: sourceUrl(source), row, column };
+function visualNode(id, type, environment, name, description, source, row, column): CiVisualNode {
+  return { id, type, environment, name, description, source, sourceUrl: sourceUrl(source), row, column };
+}
+
+export function externalEnvironment(id: string): CiVisualEnvironment {
+  const environments: Record<string, CiVisualEnvironment> = {
+    operator: "operator",
+    browser: "browser",
+    "teamcity-cli": "terminal",
+    "github-repository": "github",
+    "github-app": "github",
+    "cloudflare-access": "cloudflare",
+    "cloudflare-tunnel": "cloudflare",
+    "teamcity-server": "teamcity",
+    "build-agent": "teamcity",
+    "codex-mcp-client": "codex",
+    "figma-api": "figma",
+    "figma-design-document": "figma",
+  };
+  const environment = environments[id];
+  if (!environment) throw new Error(`External CI node '${id}' has no .ci icon environment mapping.`);
+  return environment;
 }
 
 function connection(id, source, target, label): CiVisualConnection {

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -1,7 +1,10 @@
 import {
   CI_CONNECTOR_NAME,
+  CI_CONNECTOR_LABEL_NAME,
   CI_CONNECTOR_TEMPLATE_SECTION_ID,
   CI_DOCUMENTATION_PAGE_ID,
+  CI_ICON_ENVIRONMENT_PROPERTY,
+  CI_ICON_INSTANCE_NAME,
   CI_NODE_COMPONENT_ID,
   CI_NODE_INSTANCE_NAME,
   CI_NODE_PROPS,
@@ -14,7 +17,9 @@ import {
 import {
   CI_VISUAL_TARGET_NAMES,
   createCiVisualPlan,
+  type CiVisualConnection,
   type CiVisualNode,
+  type CiVisualOrientation,
   type CiVisualSection,
 } from "../domain/ci/create-ci-visual-plan";
 import type { DesignModel } from "../domain/design-model";
@@ -42,6 +47,11 @@ const ROLE_PARENT = "parent";
 const ROLE_SECTION = "section";
 const ROLE_NODE = "node";
 const ROLE_CONNECTOR = "connector";
+const LIGHT_MODE_NAME = "Light";
+const CONNECTOR_LABEL_FONT = { family: "Inter", style: "Medium" } as const;
+const CONNECTOR_LABEL_CLEARANCE = 24;
+const CONNECTOR_LABEL_COLLISION_GAP = 16;
+const CONNECTOR_LABEL_MAX_TEXT_WIDTH = 280;
 
 export class FigmaCiDocumentationSyncGateway implements CiDocumentationSyncGateway {
   async syncCiDocumentation(designModel: DesignModel, targetNames: string[]) {
@@ -56,11 +66,21 @@ export class FigmaCiDocumentationSyncGateway implements CiDocumentationSyncGatew
     const modeCollection = await requireVariableCollection(CI_VARIABLE_COLLECTION_NAME);
     const outlineVariable = await requireOutlineColorVariable();
     const surfaceVariable = await requireColorVariable("md/sys/color/surface");
+    const onSurfaceVariable = await requireColorVariable("md/sys/color/on-surface");
+    const surfaceCollection = await requireVariableCollectionById(surfaceVariable.variableCollectionId);
+    const surfaceModeId = requireModeId(surfaceCollection, LIGHT_MODE_NAME);
     const mutatedNodeIds: string[] = [];
     const createdCiNodes: string[] = [];
     const createdCiConnectors: string[] = [];
     const updatedCiSections: string[] = [];
-    const parent = await requireOrCreateParentSection(page, plan.parentName, surfaceVariable, mutatedNodeIds);
+    const parent = await requireOrCreateParentSection(
+      page,
+      plan.parentName,
+      surfaceVariable,
+      surfaceCollection,
+      surfaceModeId,
+      mutatedNodeIds
+    );
     unlockTree(parent, mutatedNodeIds);
     await syncParentHeader(parent, mutatedNodeIds);
 
@@ -76,6 +96,8 @@ export class FigmaCiDocumentationSyncGateway implements CiDocumentationSyncGatew
         nodeComponent,
         modeCollection,
         outlineVariable,
+        surfaceVariable,
+        onSurfaceVariable,
         createdCiNodes,
         createdCiConnectors,
         mutatedNodeIds
@@ -96,7 +118,14 @@ export class FigmaCiDocumentationSyncGateway implements CiDocumentationSyncGatew
   }
 }
 
-async function requireOrCreateParentSection(page, name, surfaceVariable, mutatedNodeIds) {
+async function requireOrCreateParentSection(
+  page,
+  name,
+  surfaceVariable,
+  surfaceCollection,
+  surfaceModeId,
+  mutatedNodeIds
+) {
   const existing = page.children.find((child) =>
     child.type === "SECTION" &&
       (
@@ -114,7 +143,8 @@ async function requireOrCreateParentSection(page, name, surfaceVariable, mutated
   parent.name = name;
   parent.cornerRadius = PARENT_CORNER_RADIUS;
   parent.strokes = [];
-  parent.fills = [boundColorPaint(surfaceVariable)];
+  parent.setExplicitVariableModeForCollection(surfaceCollection, surfaceModeId);
+  parent.fills = [boundColorPaint(surfaceVariable, resolveColorForConsumer(surfaceVariable, parent))];
   parent.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_PARENT);
   mutatedNodeIds.push(parent.id);
   return parent;
@@ -189,12 +219,16 @@ async function syncSectionContent(
   nodeComponent,
   modeCollection,
   outlineVariable,
+  surfaceVariable,
+  onSurfaceVariable,
   createdCiNodes,
   createdCiConnectors,
   mutatedNodeIds
 ) {
   const groupsByModelId = new Map<string, GroupNode>();
   const groups: Array<{ plan: CiVisualNode; group: GroupNode }> = [];
+  const connectorLabels: GroupNode[] = [];
+  const connectorLabelsByModelId = new Map<string, GroupNode>();
   const connectorTemplate = plan.connections.length > 0
     ? await requireCiConnectorTemplate()
     : null;
@@ -214,7 +248,22 @@ async function syncSectionContent(
     mutatedNodeIds.push(group.id, instance.id);
   }
 
-  layoutNodeGroups(groups);
+  for (const edge of plan.connections) {
+    const label = await createConnectorLabel(
+      section,
+      edge.label,
+      edge.id,
+      surfaceVariable,
+      onSurfaceVariable
+    );
+    connectorLabels.push(label);
+    connectorLabelsByModelId.set(edge.id, label);
+    mutatedNodeIds.push(label.id);
+  }
+
+  layoutNodeGroups(groups, plan.orientation, plan.connections, connectorLabelsByModelId);
+  const positionedLabels: GroupNode[] = [];
+  const parallelConnections = parallelConnectionInfo(plan.connections);
 
   for (const edge of plan.connections) {
     const source = groupsByModelId.get(edge.source);
@@ -225,24 +274,57 @@ async function syncSectionContent(
     if (!connectorTemplate) {
       throw new Error(`CI section '${plan.target}' requires a connector template.`);
     }
+    const label = connectorLabelsByModelId.get(edge.id);
+    if (!label) throw new Error(`CI section '${plan.target}' has no label for connection '${edge.id}'.`);
     const connector = connectorTemplate.clone();
     connector.name = CI_CONNECTOR_NAME;
     connector.connectorLineType = "ELBOWED";
     connector.connectorStartStrokeCap = "NONE";
     connector.connectorEndStrokeCap = "ARROW_LINES";
-    connector.connectorStart = { endpointNodeId: source.id, magnet: "BOTTOM" };
-    connector.connectorEnd = { endpointNodeId: target.id, magnet: "TOP" };
+    const magnets = ciConnectorMagnets(
+      source,
+      target,
+      plan.orientation,
+      parallelConnections.get(edge.id)
+    );
+    connector.connectorStart = { endpointNodeId: source.id, magnet: magnets.start };
+    connector.connectorEnd = { endpointNodeId: target.id, magnet: magnets.end };
     connector.strokes = [boundColorPaint(outlineVariable)];
     connector.strokeWeight = 2;
     connector.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_CONNECTOR);
     connector.setSharedPluginData(METADATA_NAMESPACE, CI_MODEL_ID_KEY, edge.id);
     section.insertChild(0, connector);
-    await setConnectorLabel(connector, edge.label);
+    await clearNativeConnectorLabel(connector);
+    const connectorBounds = connector.absoluteBoundingBox;
+    const sectionBounds = section.absoluteBoundingBox;
+    const position = centersLabelOnConnector(magnets) && connectorBounds && sectionBounds
+      ? connectorBoundsLabelPosition(
+          connectorBounds,
+          sectionBounds,
+          label.width,
+          label.height
+        )
+      : connectorLabelPosition(
+          source,
+          target,
+          label.width,
+          label.height,
+          groups.map((item) => item.group),
+          positionedLabels,
+          magnets
+        );
+    label.x = position.x;
+    label.y = position.y;
+    positionedLabels.push(label);
     createdCiConnectors.push(connector.id);
     mutatedNodeIds.push(connector.id);
   }
 
-  resizeChildSection(section, groups.map((item) => item.group), mutatedNodeIds);
+  resizeChildSection(
+    section,
+    [...groups.map((item) => item.group), ...connectorLabels],
+    mutatedNodeIds
+  );
   applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
 }
 
@@ -261,6 +343,8 @@ async function requireCiConnectorTemplate(): Promise<ConnectorNode> {
 async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
   const modeId = requireModeId(modeCollection, modeName(nodePlan.type));
   instance.setExplicitVariableModeForCollection(modeCollection, modeId);
+  const icon = requireSingleNestedInstance(instance, CI_ICON_INSTANCE_NAME);
+  setComponentVariantProperty(icon, CI_ICON_ENVIRONMENT_PROPERTY, nodePlan.environment);
   setComponentTextProperty(instance, CI_NODE_PROPS.name, nodePlan.name);
   setComponentTextProperty(instance, CI_NODE_PROPS.description, nodePlan.description);
   setComponentTextProperty(instance, CI_NODE_PROPS.steps, nodePlan.steps || "");
@@ -275,25 +359,203 @@ async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
   );
 }
 
-function layoutNodeGroups(groups: Array<{ plan: CiVisualNode; group: GroupNode }>) {
-  const rows = [...new Set(groups.map(({ plan }) => plan.row))].sort((a, b) => a - b);
-  const columns = [...new Set(groups.map(({ plan }) => plan.column))].sort((a, b) => a - b);
+function layoutNodeGroups(
+  groups: Array<{ plan: CiVisualNode; group: GroupNode }>,
+  orientation: CiVisualOrientation,
+  connections: CiVisualConnection[],
+  labelsByModelId: Map<string, GroupNode>
+) {
+  const items = groups.map(({ plan, group }) => ({
+    plan,
+    group,
+    position: ciVisualGridPosition(plan, orientation),
+  }));
+  if (orientation === "horizontal") {
+    const flowPositions = horizontalFlowPositions(groups.map(({ plan }) => plan), connections);
+    for (const item of items) {
+      item.position = flowPositions.get(item.plan.id) ?? item.position;
+    }
+  }
+  const rows = [...new Set(items.map(({ position }) => position.row))].sort((a, b) => a - b);
+  const columns = [...new Set(items.map(({ position }) => position.column))].sort((a, b) => a - b);
   const rowHeights = new Map(rows.map((row) => [
     row,
-    Math.max(...groups.filter(({ plan }) => plan.row === row).map(({ group }) => group.height)),
+    Math.max(...items.filter(({ position }) => position.row === row).map(({ group }) => group.height)),
   ]));
   const columnWidths = new Map(columns.map((column) => [
     column,
-    Math.max(...groups.filter(({ plan }) => plan.column === column).map(({ group }) => group.width)),
+    Math.max(...items.filter(({ position }) => position.column === column).map(({ group }) => group.width)),
   ]));
   const rowY = cumulativePositions(rows, rowHeights, NODE_ROW_GAP, SECTION_PADDING);
-  const columnX = cumulativePositions(columns, columnWidths, NODE_COLUMN_GAP, SECTION_PADDING);
+  const columnGaps = requiredHorizontalColumnGaps(
+    items,
+    columns,
+    connections,
+    labelsByModelId,
+    orientation
+  );
+  const columnX = cumulativePositionsWithVariableGaps(
+    columns,
+    columnWidths,
+    columnGaps,
+    NODE_COLUMN_GAP,
+    SECTION_PADDING
+  );
 
-  for (const { plan, group } of groups) {
-    const columnWidth = columnWidths.get(plan.column)!;
-    group.x = columnX.get(plan.column)! + (columnWidth - group.width) / 2;
-    group.y = rowY.get(plan.row)!;
+  for (const { group, position } of items) {
+    const columnWidth = columnWidths.get(position.column)!;
+    const rowHeight = rowHeights.get(position.row)!;
+    group.x = columnX.get(position.column)! + (columnWidth - group.width) / 2;
+    group.y = centeredRowY(rowY.get(position.row)!, rowHeight, group.height);
   }
+}
+
+function requireSingleNestedInstance(root, instanceName) {
+  const matches = root.findAllWithCriteria({ types: ["INSTANCE"] })
+    .filter((candidate) => candidate.name === instanceName);
+  if (matches.length !== 1) {
+    throw new Error(
+      `CI node '${root.id}' must contain exactly one '${instanceName}' nested instance; found ${matches.length}.`
+    );
+  }
+  return matches[0];
+}
+
+function requiredHorizontalColumnGaps(
+  items: Array<{
+    plan: CiVisualNode;
+    group: GroupNode;
+    position: { row: number; column: number };
+  }>,
+  columns: number[],
+  connections: CiVisualConnection[],
+  labelsByModelId: Map<string, GroupNode>,
+  orientation: CiVisualOrientation
+): Map<number, number> {
+  const gaps = new Map<number, number>();
+  if (orientation !== "horizontal") return gaps;
+  const itemByModelId = new Map(items.map((item) => [item.plan.id, item]));
+  const columnIndex = new Map(columns.map((column, index) => [column, index]));
+
+  for (const edge of connections) {
+    const source = itemByModelId.get(edge.source);
+    const target = itemByModelId.get(edge.target);
+    const label = labelsByModelId.get(edge.id);
+    if (!source || !target || !label || source.position.row !== target.position.row) continue;
+    const sourceIndex = columnIndex.get(source.position.column);
+    const targetIndex = columnIndex.get(target.position.column);
+    if (sourceIndex === undefined || targetIndex === undefined || Math.abs(sourceIndex - targetIndex) !== 1) continue;
+    const boundaryColumn = columns[Math.min(sourceIndex, targetIndex)];
+    const requiredGap = horizontalConnectorGap(label.width);
+    gaps.set(boundaryColumn, Math.max(gaps.get(boundaryColumn) || 0, requiredGap));
+  }
+  return gaps;
+}
+
+export function centeredRowY(rowTop: number, rowHeight: number, itemHeight: number) {
+  return rowTop + (rowHeight - itemHeight) / 2;
+}
+
+export function horizontalConnectorGap(labelWidth: number) {
+  return Math.max(NODE_COLUMN_GAP, labelWidth + CONNECTOR_LABEL_CLEARANCE * 2);
+}
+
+export function ciVisualGridPosition(
+  plan: Pick<CiVisualNode, "row" | "column">,
+  orientation: CiVisualOrientation
+) {
+  return orientation === "horizontal"
+    ? { row: plan.column, column: plan.row }
+    : { row: plan.row, column: plan.column };
+}
+
+export function horizontalFlowPositions(
+  nodes: Array<Pick<CiVisualNode, "id" | "row">>,
+  connections: Array<Pick<CiVisualConnection, "source" | "target">>
+) {
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const adjacent = new Map(nodes.map((node) => [node.id, new Set<string>()]));
+  for (const edge of connections) {
+    if (!byId.has(edge.source) || !byId.has(edge.target)) continue;
+    adjacent.get(edge.source)!.add(edge.target);
+    adjacent.get(edge.target)!.add(edge.source);
+  }
+
+  const components: Array<Array<Pick<CiVisualNode, "id" | "row">>> = [];
+  const visited = new Set<string>();
+  for (const node of [...nodes].sort((first, second) => first.row - second.row)) {
+    if (visited.has(node.id)) continue;
+    const component: Array<Pick<CiVisualNode, "id" | "row">> = [];
+    const pending = [node.id];
+    visited.add(node.id);
+    while (pending.length > 0) {
+      const id = pending.shift()!;
+      component.push(byId.get(id)!);
+      for (const neighbour of adjacent.get(id) || []) {
+        if (visited.has(neighbour)) continue;
+        visited.add(neighbour);
+        pending.push(neighbour);
+      }
+    }
+    components.push(component.sort((first, second) => first.row - second.row));
+  }
+
+  return new Map(components.flatMap((component, visualRow) =>
+    component.map((node, visualColumn) => [node.id, { row: visualRow, column: visualColumn }] as const)
+  ));
+}
+
+export function ciConnectorMagnets(
+  source: Pick<SceneNode, "x" | "y" | "width" | "height">,
+  target: Pick<SceneNode, "x" | "y" | "width" | "height">,
+  orientation: CiVisualOrientation,
+  parallel: { index: number; count: number } = { index: 0, count: 1 }
+) {
+  if (orientation === "horizontal") {
+    return source.x <= target.x
+      ? { start: "RIGHT", end: "LEFT" } as const
+      : { start: "BOTTOM", end: "BOTTOM" } as const;
+  }
+
+  const sourceCenterX = source.x + source.width / 2;
+  const sourceCenterY = source.y + source.height / 2;
+  const targetCenterX = target.x + target.width / 2;
+  const targetCenterY = target.y + target.height / 2;
+  const isHorizontal = Math.abs(targetCenterX - sourceCenterX) >=
+    Math.abs(targetCenterY - sourceCenterY);
+
+  if (parallel.count > 1) {
+    if (isHorizontal) {
+      return parallel.index % 2 === 0
+        ? { start: "TOP", end: "TOP" } as const
+        : { start: "BOTTOM", end: "BOTTOM" } as const;
+    }
+    if (parallel.index > 0) return { start: "LEFT", end: "LEFT" } as const;
+  }
+
+  if (isHorizontal) {
+    return sourceCenterX <= targetCenterX
+      ? { start: "RIGHT", end: "LEFT" } as const
+      : { start: "LEFT", end: "RIGHT" } as const;
+  }
+  return sourceCenterY <= targetCenterY
+    ? { start: "BOTTOM", end: "TOP" } as const
+    : { start: "TOP", end: "BOTTOM" } as const;
+}
+
+function parallelConnectionInfo(connections: CiVisualConnection[]) {
+  const byEndpoints = new Map<string, CiVisualConnection[]>();
+  for (const edge of connections) {
+    const key = [edge.source, edge.target].sort().join("::");
+    const edges = byEndpoints.get(key) || [];
+    edges.push(edge);
+    byEndpoints.set(key, edges);
+  }
+  const result = new Map<string, { index: number; count: number }>();
+  for (const edges of byEndpoints.values()) {
+    edges.forEach((edge, index) => result.set(edge.id, { index, count: edges.length }));
+  }
+  return result;
 }
 
 function cumulativePositions(
@@ -405,7 +667,7 @@ async function applyTextLinks(root, textNodeName, links, expectedText) {
   }
 }
 
-async function setConnectorLabel(connector, label) {
+async function clearNativeConnectorLabel(connector) {
   const currentFontName = connector.text.fontName;
   const fontName = currentFontName === figma.mixed ||
       !currentFontName.family?.trim() ||
@@ -414,7 +676,72 @@ async function setConnectorLabel(connector, label) {
     : currentFontName;
   await figma.loadFontAsync(fontName);
   connector.text.fontName = fontName;
-  connector.text.characters = label;
+  connector.text.characters = "";
+}
+
+function setComponentVariantProperty(instance, propertyName, value) {
+  const key = requireComponentPropertyKey(instance, propertyName, "VARIANT");
+  instance.setProperties({ [key]: value });
+}
+
+function cumulativePositionsWithVariableGaps(
+  keys: number[],
+  sizes: Map<number, number>,
+  gaps: Map<number, number>,
+  defaultGap: number,
+  start: number
+) {
+  const positions = new Map<number, number>();
+  let next = start;
+  for (const key of keys) {
+    positions.set(key, next);
+    next += (sizes.get(key) ?? 0) + Math.max(defaultGap, gaps.get(key) || 0);
+  }
+  return positions;
+}
+
+async function createConnectorLabel(
+  section,
+  label,
+  modelId,
+  surfaceVariable,
+  onSurfaceVariable
+) {
+  await figma.loadFontAsync(CONNECTOR_LABEL_FONT);
+  const text = figma.createText();
+  text.name = "Label";
+  text.fontName = CONNECTOR_LABEL_FONT;
+  text.fontSize = 16;
+  text.lineHeight = { unit: "PERCENT", value: 150 };
+  text.textAlignHorizontal = "CENTER";
+  text.textAutoResize = "WIDTH_AND_HEIGHT";
+  text.characters = label;
+  if (text.width > CONNECTOR_LABEL_MAX_TEXT_WIDTH) {
+    text.textAutoResize = "HEIGHT";
+    text.resize(CONNECTOR_LABEL_MAX_TEXT_WIDTH, text.height);
+  }
+  section.appendChild(text);
+  text.fills = [boundColorPaint(onSurfaceVariable, resolveColorForConsumer(onSurfaceVariable, text))];
+
+  const background = figma.createRectangle();
+  background.name = "Background";
+  section.appendChild(background);
+  background.resize(text.width + 24, text.height + 16);
+  background.cornerRadius = 4;
+  background.strokes = [];
+  background.fills = [
+    boundColorPaint(surfaceVariable, resolveColorForConsumer(surfaceVariable, background)),
+  ];
+  background.x = 0;
+  background.y = 0;
+  text.x = 12;
+  text.y = 8;
+
+  const group = figma.group([background, text], section);
+  group.name = CI_CONNECTOR_LABEL_NAME;
+  group.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_CONNECTOR);
+  group.setSharedPluginData(METADATA_NAMESPACE, CI_MODEL_ID_KEY, modelId);
+  return group;
 }
 
 async function requireColorVariable(name) {
@@ -424,12 +751,147 @@ async function requireColorVariable(name) {
   return variable;
 }
 
-function boundColorPaint(variable) {
+async function requireVariableCollectionById(collectionId) {
+  const collection = await figma.variables.getVariableCollectionByIdAsync(collectionId);
+  if (!collection) throw new Error(`Variable collection '${collectionId}' was not found.`);
+  return collection;
+}
+
+function resolveColorForConsumer(variable, consumer) {
+  const resolved = variable.resolveForConsumer(consumer);
+  if (resolved.resolvedType !== "COLOR" || !resolved.value) {
+    throw new Error(`Color variable '${variable.name}' did not resolve for '${consumer.id}'.`);
+  }
+  const { r, g, b } = resolved.value;
+  return { r, g, b };
+}
+
+function boundColorPaint(variable, fallbackColor = { r: 0, g: 0, b: 0 }) {
   return figma.variables.setBoundVariableForPaint(
-    { type: "SOLID", color: { r: 0, g: 0, b: 0 }, opacity: 1 },
+    { type: "SOLID", color: fallbackColor, opacity: 1 },
     "color",
     variable
   );
+}
+
+export function connectorLabelPosition(
+  source,
+  target,
+  labelWidth,
+  labelHeight,
+  obstacles: Array<{ x: number; y: number; width: number; height: number }> = [],
+  occupied: Array<{ x: number; y: number; width: number; height: number }> = [],
+  route?: { start: string; end: string }
+) {
+  const sourceRight = source.x + source.width;
+  const sourceBottom = source.y + source.height;
+  const targetRight = target.x + target.width;
+  const targetBottom = target.y + target.height;
+  let centerX = (source.x + source.width / 2 + target.x + target.width / 2) / 2;
+  let centerY = (source.y + source.height / 2 + target.y + target.height / 2) / 2;
+
+  if (target.y >= sourceBottom) {
+    centerY = (sourceBottom + target.y) / 2;
+  } else if (source.y >= targetBottom) {
+    centerY = (targetBottom + source.y) / 2;
+  } else if (target.x >= sourceRight) {
+    centerX = (sourceRight + target.x) / 2;
+  } else if (source.x >= targetRight) {
+    centerX = (targetRight + source.x) / 2;
+  }
+
+  const preferred = {
+    x: centerX - labelWidth / 2,
+    y: centerY - labelHeight / 2,
+  };
+  const sharedCenterX = (source.x + source.width / 2 + target.x + target.width / 2) / 2;
+  const sharedCenterY = (source.y + source.height / 2 + target.y + target.height / 2) / 2;
+  const above = [];
+  const below = [];
+  const beside = [];
+  for (let level = 0; level < 6; level++) {
+    const offset = level * (labelHeight + CONNECTOR_LABEL_COLLISION_GAP);
+    above.push({
+      x: sharedCenterX - labelWidth / 2,
+      y: Math.min(source.y, target.y) - labelHeight - CONNECTOR_LABEL_CLEARANCE - offset,
+    });
+    below.push({
+      x: sharedCenterX - labelWidth / 2,
+      y: Math.max(sourceBottom, targetBottom) + CONNECTOR_LABEL_CLEARANCE + offset,
+    });
+    if (level > 0) {
+      const horizontalOffset = level * (labelWidth + CONNECTOR_LABEL_COLLISION_GAP);
+      beside.push(
+        { x: preferred.x - horizontalOffset, y: preferred.y },
+        { x: preferred.x + horizontalOffset, y: preferred.y }
+      );
+    }
+  }
+  const isHorizontalReturn = source.x > target.x &&
+    source.y < targetBottom && sourceBottom > target.y;
+  const hasVerticalGap = target.y >= sourceBottom || source.y >= targetBottom;
+  const right = {
+    x: Math.max(sourceRight, targetRight) + CONNECTOR_LABEL_CLEARANCE,
+    y: sharedCenterY - labelHeight / 2,
+  };
+  const left = {
+    x: Math.min(source.x, target.x) - labelWidth - CONNECTOR_LABEL_CLEARANCE,
+    y: sharedCenterY - labelHeight / 2,
+  };
+  let candidates;
+  if (route?.start === "TOP" && route.end === "TOP") {
+    candidates = [...above, ...below, ...beside, preferred, right, left];
+  } else if (route?.start === "BOTTOM" && route.end === "BOTTOM") {
+    candidates = [...below, ...above, ...beside, preferred, right, left];
+  } else if (route?.start === "RIGHT" && route.end === "RIGHT") {
+    candidates = [right, left, ...beside, preferred, ...above, ...below];
+  } else if (route?.start === "LEFT" && route.end === "LEFT") {
+    candidates = [left, right, ...beside, preferred, ...above, ...below];
+  } else {
+    candidates = [
+      ...(isHorizontalReturn ? [] : [preferred]),
+      ...(hasVerticalGap ? beside : []),
+      ...(isHorizontalReturn ? below : above),
+      ...(isHorizontalReturn ? above : below),
+      ...(hasVerticalGap ? [] : beside),
+      right,
+      left,
+    ];
+  }
+  const collisionBounds = [...obstacles, ...occupied];
+  return candidates.find((candidate) =>
+    candidate.x >= 0 &&
+    candidate.y >= 0 &&
+    collisionBounds.every((bounds) => !rectanglesOverlap(
+      candidate,
+      { width: labelWidth, height: labelHeight },
+      bounds,
+      CONNECTOR_LABEL_COLLISION_GAP
+    ))
+  ) || preferred;
+}
+
+export function connectorBoundsLabelPosition(
+  connectorBounds: { x: number; y: number; width: number; height: number },
+  parentBounds: { x: number; y: number },
+  labelWidth: number,
+  labelHeight: number
+) {
+  return {
+    x: connectorBounds.x - parentBounds.x + connectorBounds.width / 2 - labelWidth / 2,
+    y: connectorBounds.y - parentBounds.y + connectorBounds.height / 2 - labelHeight / 2,
+  };
+}
+
+function centersLabelOnConnector(route: { start: string; end: string }) {
+  return route.start === route.end && (route.start === "LEFT" || route.start === "RIGHT");
+}
+
+function rectanglesOverlap(position, size, bounds, gap) {
+  return position.x < bounds.x + bounds.width + gap &&
+    position.x + size.width + gap > bounds.x &&
+    position.y < bounds.y + bounds.height + gap &&
+    position.y + size.height + gap > bounds.y;
 }
 
 function sourceLink(path) {

--- a/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
@@ -58,6 +58,14 @@ export async function requireComponent(nodeId) {
   return node;
 }
 
+export async function requireComponentSet(nodeId) {
+  const node = await figma.getNodeByIdAsync(nodeId);
+  if (!node || node.type !== "COMPONENT_SET") {
+    throw new Error(`Expected '${nodeId}' to be a COMPONENT_SET.`);
+  }
+  return node;
+}
+
 export async function requireFrame(nodeId) {
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node || node.type !== "FRAME") {

--- a/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -6,6 +6,10 @@ import {
   CATALOG_TREE_TARGETS,
   CI_CONNECTOR_TEMPLATE_SECTION_ID,
   CI_DOCUMENTATION_PAGE_ID,
+  CI_ICON_COMPONENT_SET_ID,
+  CI_ICON_ENVIRONMENT_PROPERTY,
+  CI_ICON_ENVIRONMENTS,
+  CI_ICON_INSTANCE_NAME,
   CI_NODE_COMPONENT_ID,
   CI_NODE_PROPS,
   CI_VARIABLE_COLLECTION_NAME,
@@ -43,6 +47,7 @@ import type {
 import { filterModelRoots } from "./figma-catalog-tree-sync-gateway";
 import {
   requireComponent,
+  requireComponentSet,
   requireFrameOrSection,
   requireModeId,
   requireOutlineColorVariable,
@@ -102,6 +107,40 @@ async function checkCiDocumentationContract(
   requireComponentProperty(component, CI_NODE_PROPS.showSteps, "BOOLEAN");
   requireComponentProperty(component, CI_NODE_PROPS.showSource, "BOOLEAN");
   checkedComponents.push(`${component.name}:${component.id}`);
+
+  const iconSet = await requireComponentSet(CI_ICON_COMPONENT_SET_ID);
+  const nestedIcons = component.findAllWithCriteria({ types: ["INSTANCE"] })
+    .filter((candidate) => candidate.name === CI_ICON_INSTANCE_NAME);
+  if (nestedIcons.length !== 1) {
+    throw new Error(
+      `CI node component '${component.id}' must contain exactly one '${CI_ICON_INSTANCE_NAME}' ` +
+        `nested instance; found ${nestedIcons.length}.`
+    );
+  }
+  const nestedIcon = nestedIcons[0];
+  const mainIconComponent = await nestedIcon.getMainComponentAsync();
+  if (!mainIconComponent || mainIconComponent.parent?.id !== iconSet.id) {
+    throw new Error(
+      `Nested CI icon '${nestedIcon.id}' must belong to component set '${iconSet.id}'.`
+    );
+  }
+  requireComponentProperty(nestedIcon, CI_ICON_ENVIRONMENT_PROPERTY, "VARIANT");
+  const environmentDefinition = requireComponentProperty(
+    iconSet,
+    CI_ICON_ENVIRONMENT_PROPERTY,
+    "VARIANT"
+  );
+  const actualEnvironments = environmentDefinition.variantOptions || [];
+  const missingEnvironments = CI_ICON_ENVIRONMENTS.filter((value) => !actualEnvironments.includes(value));
+  const unexpectedEnvironments = actualEnvironments.filter((value) => !CI_ICON_ENVIRONMENTS.includes(value));
+  if (missingEnvironments.length > 0 || unexpectedEnvironments.length > 0) {
+    throw new Error(
+      `CI icon environments differ from the supported contract. ` +
+        `Missing: ${missingEnvironments.join(", ") || "none"}. ` +
+        `Unexpected: ${unexpectedEnvironments.join(", ") || "none"}.`
+    );
+  }
+  checkedComponents.push(`${iconSet.name}:${iconSet.id}`);
 
   const connectorSection = await requireSection(CI_CONNECTOR_TEMPLATE_SECTION_ID);
   const connectorTemplate = connectorSection.findAllWithCriteria({ types: ["CONNECTOR"] })
@@ -343,6 +382,7 @@ function requireComponentProperty(node: any, propertyName: string, propertyType:
       `Node '${node.id}' is missing ${propertyType} component property '${componentPropertyName(propertyName)}'.`
     );
   }
+  return propertyEntry[1] as any;
 }
 
 function componentPropertiesForPreflight(node: any): Record<string, any> {

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -1,6 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createCiVisualPlan } from "../src/domain/ci/create-ci-visual-plan";
+import {
+  createCiVisualPlan,
+  externalEnvironment,
+} from "../src/domain/ci/create-ci-visual-plan";
+import {
+  centeredRowY,
+  ciConnectorMagnets,
+  ciVisualGridPosition,
+  connectorBoundsLabelPosition,
+  connectorLabelPosition,
+  horizontalFlowPositions,
+  horizontalConnectorGap,
+} from "../src/figma/figma-ci-documentation-sync-gateway";
 
 test("CI visual plan creates the four documented granular sections", () => {
   const plan = createCiVisualPlan(designModel());
@@ -15,6 +27,10 @@ test("CI visual plan creates the four documented granular sections", () => {
       "ci.infrastructureAndAccess",
     ]
   );
+  assert.deepEqual(
+    plan.sections.map((section) => section.orientation),
+    ["horizontal", "horizontal", "horizontal", "grid"]
+  );
 });
 
 test("CI visual plan summarizes commands and keeps exact operational names", () => {
@@ -28,6 +44,47 @@ test("CI visual plan summarizes commands and keeps exact operational names", () 
   );
   assert.ok(postMerge.nodes.some((node) => node.name === "design-model.json" && node.type === "artifact"));
   assert.ok(postMerge.connections.some((edge) => edge.label === "Manual rerun"));
+  assert.deepEqual(
+    postMerge.connections
+      .filter((edge) => ["pipeline-generate", "generate-artifact", "artifact-check"].includes(edge.id))
+      .map(({ source, target }) => ({ source, target })),
+    [
+      { source: "pipeline-Root_FigmaSync", target: "job-generate" },
+      { source: "job-generate", target: "design-model" },
+      { source: "design-model", target: "job-check" },
+    ]
+  );
+});
+
+test("CI visual plan maps node ownership to explicit icon environments", () => {
+  const plan = createCiVisualPlan(designModel());
+  const overview = plan.sections.find((section) => section.target === "ci.overview")!;
+
+  assert.deepEqual(
+    overview.nodes.map(({ name, environment }) => ({ name, environment })),
+    [
+      { name: "Pull Request", environment: "github" },
+      { name: "CI", environment: "teamcity" },
+      { name: "TeamCity CI", environment: "teamcity" },
+      { name: "Pull request merge gate", environment: "github" },
+      { name: "main", environment: "github" },
+      { name: "Figma Sync", environment: "teamcity" },
+      { name: "design-model.json", environment: "json" },
+      { name: "TeamCity Figma Sync", environment: "teamcity" },
+    ]
+  );
+});
+
+test("external CI nodes require an explicit icon environment mapping", () => {
+  assert.equal(externalEnvironment("operator"), "operator");
+  assert.equal(externalEnvironment("browser"), "browser");
+  assert.equal(externalEnvironment("teamcity-cli"), "terminal");
+  assert.equal(externalEnvironment("github-app"), "github");
+  assert.equal(externalEnvironment("cloudflare-tunnel"), "cloudflare");
+  assert.equal(externalEnvironment("build-agent"), "teamcity");
+  assert.equal(externalEnvironment("codex-mcp-client"), "codex");
+  assert.equal(externalEnvironment("figma-api"), "figma");
+  assert.throws(() => externalEnvironment("unknown-system"), /no \.ci icon environment mapping/);
 });
 
 test("CI overview labels trigger, check, gate, merge, and model verification connections", () => {
@@ -71,6 +128,162 @@ test("CI visual plan rejects models without CI content", () => {
   );
 });
 
+test("CI connector labels stay horizontal and centered in a vertical gap", () => {
+  assert.deepEqual(
+    connectorLabelPosition(
+      { x: 100, y: 100, width: 300, height: 100 },
+      { x: 200, y: 400, width: 300, height: 100 },
+      120,
+      40
+    ),
+    { x: 240, y: 280 }
+  );
+});
+
+test("CI connector labels stay centered in a horizontal gap", () => {
+  assert.deepEqual(
+    connectorLabelPosition(
+      { x: 100, y: 100, width: 200, height: 100 },
+      { x: 500, y: 120, width: 200, height: 100 },
+      100,
+      40
+    ),
+    { x: 350, y: 140 }
+  );
+});
+
+test("CI horizontal sections transpose logical rows into visual columns", () => {
+  assert.deepEqual(ciVisualGridPosition({ row: 3, column: 1 }, "horizontal"), {
+    row: 1,
+    column: 3,
+  });
+  assert.deepEqual(ciVisualGridPosition({ row: 3, column: 1 }, "grid"), {
+    row: 3,
+    column: 1,
+  });
+});
+
+test("CI connectors use horizontal anchors only in horizontal flows", () => {
+  const left = { x: 100, y: 100, width: 200, height: 100 };
+  const right = { x: 400, y: 100, width: 200, height: 100 };
+  assert.deepEqual(ciConnectorMagnets(left, right, "horizontal"), {
+    start: "RIGHT",
+    end: "LEFT",
+  });
+  assert.deepEqual(ciConnectorMagnets(right, left, "horizontal"), {
+    start: "BOTTOM",
+    end: "BOTTOM",
+  });
+  assert.deepEqual(ciConnectorMagnets(left, right, "grid"), {
+    start: "RIGHT",
+    end: "LEFT",
+  });
+  assert.deepEqual(ciConnectorMagnets(left, right, "grid", { index: 0, count: 2 }), {
+    start: "TOP",
+    end: "TOP",
+  });
+  assert.deepEqual(ciConnectorMagnets(left, right, "grid", { index: 1, count: 2 }), {
+    start: "BOTTOM",
+    end: "BOTTOM",
+  });
+  assert.deepEqual(
+    ciConnectorMagnets(
+      { x: 100, y: 100, width: 200, height: 100 },
+      { x: 100, y: 400, width: 200, height: 100 },
+      "grid",
+      { index: 1, count: 2 }
+    ),
+    { start: "LEFT", end: "LEFT" }
+  );
+});
+
+test("CI horizontal layouts stack disconnected flows and left-align each row", () => {
+  assert.deepEqual(
+    [...horizontalFlowPositions(
+      [
+        { id: "first-a", row: 4 },
+        { id: "first-b", row: 8 },
+        { id: "second-a", row: 10 },
+        { id: "second-b", row: 12 },
+      ],
+      [
+        { source: "first-a", target: "first-b" },
+        { source: "second-a", target: "second-b" },
+      ]
+    )],
+    [
+      ["first-a", { row: 0, column: 0 }],
+      ["first-b", { row: 0, column: 1 }],
+      ["second-a", { row: 1, column: 0 }],
+      ["second-b", { row: 1, column: 1 }],
+    ]
+  );
+});
+
+test("CI horizontal rows align node centers and reserve label width", () => {
+  assert.equal(centeredRowY(100, 200, 120), 140);
+  assert.equal(horizontalConnectorGap(80), 160);
+  assert.equal(horizontalConnectorGap(280), 328);
+});
+
+test("CI connector labels move outside nodes when the direct gap is too narrow", () => {
+  assert.deepEqual(
+    connectorLabelPosition(
+      { x: 100, y: 100, width: 200, height: 100 },
+      { x: 400, y: 100, width: 200, height: 100 },
+      180,
+      40,
+      [
+        { x: 100, y: 100, width: 200, height: 100 },
+        { x: 400, y: 100, width: 200, height: 100 },
+      ]
+    ),
+    { x: 260, y: 36 }
+  );
+});
+
+test("CI parallel connector labels follow their distinct outside routes", () => {
+  const source = { x: 100, y: 100, width: 200, height: 100 };
+  const target = { x: 400, y: 100, width: 200, height: 100 };
+  const obstacles = [source, target];
+  assert.deepEqual(
+    connectorLabelPosition(
+      source,
+      target,
+      180,
+      40,
+      obstacles,
+      [],
+      { start: "TOP", end: "TOP" }
+    ),
+    { x: 260, y: 36 }
+  );
+  assert.deepEqual(
+    connectorLabelPosition(
+      source,
+      target,
+      180,
+      40,
+      obstacles,
+      [],
+      { start: "BOTTOM", end: "BOTTOM" }
+    ),
+    { x: 260, y: 224 }
+  );
+});
+
+test("CI vertical return labels are centered on their connector bounds", () => {
+  assert.deepEqual(
+    connectorBoundsLabelPosition(
+      { x: 1036.5, y: 3047.5, width: 55.5, height: 279 },
+      { x: 100, y: 2035 },
+      232,
+      40
+    ),
+    { x: 848.25, y: 1132 }
+  );
+});
+
 function designModel() {
   return {
     branch: "main",
@@ -111,6 +324,14 @@ function designModel() {
               triggers: [{ type: "pipeline finish", dependencyPipelineId: "Root_Ci" }],
               jobs: [
                 {
+                  id: "check",
+                  name: "Check Figma trunk sync",
+                  steps: [{ id: "RUNNER_1", name: "Check", command: ".\\gradlew.bat checkFigmaTrunkSync" }],
+                  artifacts: [],
+                  dependencies: [{ jobId: "generate", artifactPaths: ["build/reports/figma-sync/design-model.json"] }],
+                  publishedChecks: [{ name: "TeamCity Figma Sync" }],
+                },
+                {
                   id: "generate",
                   name: "Generate main design model",
                   steps: [
@@ -118,14 +339,8 @@ function designModel() {
                     { id: "RUNNER_2", name: "Generate model", command: ".\\gradlew.bat generateFigmaDesignModel" },
                   ],
                   artifacts: [{ path: "build/reports/figma-sync/design-model.json" }],
+                  dependencies: [],
                   publishedChecks: [],
-                },
-                {
-                  id: "check",
-                  name: "Check Figma trunk sync",
-                  steps: [{ id: "RUNNER_1", name: "Check", command: ".\\gradlew.bat checkFigmaTrunkSync" }],
-                  artifacts: [],
-                  publishedChecks: [{ name: "TeamCity Figma Sync" }],
                 },
               ],
             },


### PR DESCRIPTION
## Summary
- document TeamCity HTTPS, Cloudflare Access, CLI authentication, and GitHub webhook operations
- render CI documentation flows with explicit orientations, readable connector labels, and environment-specific icons
- validate the nested .ci icon contract and preserve the visual layout with executable tests

## Verification
- npm test
- npm run build
- .\gradlew.bat check
- git diff --check