### PR TITLE
fix(figma-design-sync): clean CI connectors before endpoint nodes

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -298,21 +298,24 @@ behavior changes.
 
 ## Removed Connector Lookup Failures
 
-If a catalog tree sync fails with a message like:
+If a catalog tree or granular CI documentation sync fails with a message like:
 
 ```text
 The node with id "..." does not exist
 ```
 
-while removing stale tree nodes or connectors, inspect whether the sync removed
-a `simple-solid_arrow` connector and then read that same connector object again
-in the same `use_figma` execution. Figma can invalidate removed nodes
-immediately.
+while removing stale nodes or connectors, inspect whether the sync removed a
+connector or one of its endpoint groups and then read an invalidated object
+again in the same `use_figma` execution. Figma can invalidate removed nodes
+immediately, and removing a native connector endpoint may remove its connector
+as a side effect.
 
-The cleanup code must collect removed connector ids before calling
+Catalog cleanup must collect removed connector ids before calling
 `connector.remove()` and then filter the in-memory connector list by those ids.
-Do not call `connectorReferencesAnyNode()` or read shared plugin data from a
-connector after it has been removed.
+CI section cleanup must classify managed children before mutating the tree,
+remove connectors before endpoint groups, and check `node.removed` immediately
+before every `remove()`. Do not call `connectorReferencesAnyNode()` or read
+shared plugin data from any node after it has been removed.
 
 This is a writer bug, not evidence that the TeamCity `design-model.json`
 artifact is invalid. Rebuild the MCP bundle after fixing the writer and rerun

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -204,13 +204,27 @@ function requireOrCreateChildSection(parent, plan: CiVisualSection, mutatedNodeI
 }
 
 function clearManagedSectionContent(section, mutatedNodeIds) {
-  for (const child of [...section.children]) {
-    const role = child.getSharedPluginData?.(METADATA_NAMESPACE, CI_ROLE_KEY);
-    if (role === ROLE_NODE || role === ROLE_CONNECTOR) {
-      mutatedNodeIds.push(child.id);
-      child.remove();
-    }
+  const managedChildren = [...section.children]
+    .filter((child) => !child.removed)
+    .map((child) => ({
+      child,
+      role: child.getSharedPluginData?.(METADATA_NAMESPACE, CI_ROLE_KEY),
+    }))
+    .filter(({ role }) => role === ROLE_NODE || role === ROLE_CONNECTOR)
+    .sort((first, second) => managedCiRemovalPriority(first.role) - managedCiRemovalPriority(second.role));
+
+  for (const { child } of managedChildren) {
+    // Removing an endpoint may remove its native connector as a side effect.
+    if (child.removed) continue;
+    mutatedNodeIds.push(child.id);
+    child.remove();
   }
+}
+
+export function managedCiRemovalPriority(role: string) {
+  if (role === ROLE_CONNECTOR) return 0;
+  if (role === ROLE_NODE) return 1;
+  return 2;
 }
 
 async function syncSectionContent(

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -12,6 +12,7 @@ import {
   connectorLabelPosition,
   horizontalFlowPositions,
   horizontalConnectorGap,
+  managedCiRemovalPriority,
 } from "../src/figma/figma-ci-documentation-sync-gateway";
 
 test("CI visual plan creates the four documented granular sections", () => {
@@ -281,6 +282,17 @@ test("CI vertical return labels are centered on their connector bounds", () => {
       40
     ),
     { x: 848.25, y: 1132 }
+  );
+});
+
+test("managed CI content removes connectors before their endpoint nodes", () => {
+  const roles = ["node", "connector", "unmanaged", "connector", "node"];
+
+  assert.deepEqual(
+    roles.toSorted((first, second) =>
+      managedCiRemovalPriority(first) - managedCiRemovalPriority(second)
+    ),
+    ["connector", "connector", "node", "node", "unmanaged"]
   );
 });
 


### PR DESCRIPTION
## Summary
- classify managed CI section children before removing any node
- remove native connectors before their endpoint groups and skip invalidated proxies
- document the Figma removed-node failure mode

## Verification
- npm test
- npm run build
- official TeamCity main design model reused for visual-only validation
- preflight + ci.postMergeDesignDocumentation passed
- preflight + ci.infrastructureAndAccess passed

Metadata has not been written from this branch.