### PR TITLE
docs(figma-design-sync): record official sync runtime behavior

### DIFF
--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -128,6 +128,18 @@ Cloudflare Access can add a `CF_Authorization` cookie to the authenticated
 request. TeamCity then treats the POST as cookie-authenticated and requires an
 `X-TC-CSRF-Token` value that TeamCity CLI does not currently provide.
 
+The CSRF value returned by:
+
+```powershell
+teamcity api '/authenticationTest.html?csrf' --raw
+```
+
+is session-bound. Fetching it in one TeamCity CLI invocation and passing it to
+a later `teamcity api -X POST` invocation does not work because the second
+process creates a different HTTP session. The failure reports that the supplied
+header does not match the current session value. Do not automate around this by
+disabling CSRF or by copying session cookies.
+
 Use one of these recovery paths:
 
 1. Rerun the build from the authenticated TeamCity UI.

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -75,6 +75,11 @@ Upload `10-official-sync-payload.png` to the Figma file before running
 lexical order. The PNG asset is a transport artifact only; the staging runner
 removes the uploaded image node after extracting the payload.
 
+`upload_assets` returns a single-use URL under `https://mcp.figma.com`. Upload
+the PNG as multipart form data with an explicit `image/png` content type.
+Sending it as the default `application/octet-stream` is rejected. Request a new
+URL after any failed or consumed upload attempt; do not reuse an old URL.
+
 `upload_assets` may place the temporary image on the current Figma page, which
 does not have to be the metadata page. The staging runner searches document
 image fills and does not rely on `loadAllPagesAsync`; this MCP runtime may
@@ -135,8 +140,22 @@ through the Figma plugin image API.
 The staging namespace is not authoritative state. It is a transport mechanism
 for the current sync run. The authoritative namespace remains
 `water_my_plants_sync`, and only the final `metadata` target writes to it.
-Always overwrite staged values for a new sync run; do not reuse values already
-present in `water_my_plants_sync_staging`.
+
+Staging may be reused across consecutive granular `99-run-target.mcp.js`
+executions only when all of these values remain identical:
+
+- `designModelHash`;
+- `designModelGitSha`;
+- `designModelLength`;
+- `scriptLength`;
+- `scriptBase64Length`.
+
+Restage from `00-clear-staging.mcp.js` whenever the TeamCity artifact or the
+generated MCP bundle changes. A stable `modelHash` is not sufficient: a
+visual-only TypeScript fix changes the generated script lengths even when the
+model content is unchanged. After that fix reaches `main`, the next official
+TeamCity artifact also has a new `gitSha`, so restage again before writing
+metadata.
 
 Stage these keys on page `62934:908` under
 `water_my_plants_sync_staging`:

--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -61,6 +61,17 @@ For a single visual target, prefer an atomic preflight-and-write runner:
 node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --targets=preflight,waterMyPlants.libraries
 ```
 
+For an atomic granular runner, `completedTargets` is expected to contain both
+`preflight` and the requested visual target. For example, a successful
+`ci.overview` runner returns:
+
+```text
+["preflight", "ci.overview"]
+```
+
+Do not reject a runner because `preflight` appears alongside the visual target.
+Generate `--target=preflight` only when no visual mutation is intended.
+
 If the preflight fails, the visual target is not executed. Use `--target=preflight`
 alone when you only want to inspect the contract without changing visuals.
 
@@ -69,13 +80,13 @@ alone when you only want to inspect the contract without changing visuals.
 | 0 | `preflight` | Figma variables, component contracts, configured sections, and target model shape | Missing component property, usage chip variant, section, variable collection, or invalid root filter | Returned `checkedComponents`, `checkedSections`, `checkedVariables`, and `checkedTargets` are populated and `mutatedNodeIds` is empty. |
 | 1 | `headers` | Parent documentation `.Header` links | Stale `build-logic` URL, centered link text, missing `Link` property, or multiple source paths sharing one hyperlink | Every displayed source path is left-aligned, opens its own canonical GitHub `main` URL, and `updatedHeaders` lists all configured parent sections. |
 | 2 | `versions` | Version variables and `.dependency version` nodes | Missing variable collection, stale version section, or duplicate renamed version key | Returned `updatedVersions` contains the expected version keys and stale visual version nodes are removed. |
-| 3 | `waterMyPlants.libraries` | Main app libraries and usage chips | Ambiguous `.artifact` / `.artifacts bundle` usage headings or hidden usage blocks on the visible instance | Returned `completedTargets` contains only this target and a spot-checked artifact with model usage shows `Applied by plugin` / `Used by module` chips. |
+| 3 | `waterMyPlants.libraries` | Main app libraries and usage chips | Ambiguous `.artifact` / `.artifacts bundle` usage headings or hidden usage blocks on the visible instance | Returned `completedTargets` contains `preflight` and this target, and a spot-checked artifact with model usage shows `Applied by plugin` / `Used by module` chips. |
 | 4 | `waterMyPlants.plugins` | Main app plugin catalog tree | Missing `.tree node` property or connector binding issue | Returned catalog nodes match the plugin tree and connectors stay in the section. |
 | 5 | `waterMyPlants.customGradleConventionPlugins` | Convention plugin catalog | Stale convention plugin names or missing usage chip variants | Returned nodes include the convention plugin ids expected from `repo/gradle-plugins`. |
 | 6 | `waterMyPlants.customGradlePlugins` | Regular custom Gradle plugin catalog | A regular plugin is modeled as a convention plugin, or the reverse | Returned nodes include `com.marmatsan.figmaDesignSync` as a regular plugin. |
-| 7 | `gradlePlugins.libraries` | `repo/gradle-plugins` libraries catalog | Large artifact/bundle update with stale nested component internals | Returned `completedTargets` contains the target and no metadata. |
+| 7 | `gradlePlugins.libraries` | `repo/gradle-plugins` libraries catalog | Large artifact/bundle update with stale nested component internals | Returned `completedTargets` contains `preflight` and the target, with no metadata. |
 | 8 | `gradlePlugins.plugins` | Declared catalog target from `repo/gradle-plugins` plugins catalog | Stale hidden section after removing `create("plugins")` | Empty or omitted catalog removes the target section; declared catalog nodes match the settings catalog. |
-| 9 | `figmaDesignSync.libraries` | `repo/figma-design-sync` libraries catalog | Large artifact/bundle update with stale nested component internals | Returned `completedTargets` contains the target and no metadata. |
+| 9 | `figmaDesignSync.libraries` | `repo/figma-design-sync` libraries catalog | Large artifact/bundle update with stale nested component internals | Returned `completedTargets` contains `preflight` and the target, with no metadata. |
 | 10 | `figmaDesignSync.plugins` | `repo/figma-design-sync` plugins catalog | Missing plugin tree connector or stale plugin aliases | Returned catalog nodes match the settings catalog. |
 | 11 | `ci.overview` | Simplified PR and post-merge journeys | Generic connector labels or missing check/gate distinction | Trigger, check, gate, merge, artifact, and hash-verification connections have explicit labels. |
 | 12 | `ci.pullRequestIntegration` | Detailed PR pipeline, jobs, checks, and merge gate | Effective TeamCity job or published check missing from Figma | Nodes and summarized steps match `content.ci.teamCity`. |

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -27,6 +27,24 @@ component contract no longer matches the writer code. In that case, keep using
 the TeamCity artifact as the authoritative model input, fix the visual contract
 or writer, and rerun the failed MCP visual target before writing metadata.
 
+## Timeout With Unknown Completion
+
+A failed `use_figma` response does not commit partial visual mutations.
+However, a caller or subprocess timeout is ambiguous because the remote
+`use_figma` call may still be running when the local process stops waiting.
+
+Before retrying after a timeout:
+
+1. Stop only the abandoned local runner process if it is still active.
+2. Inspect the target section in read-only mode.
+3. Compare managed child node ids or expected node counts with the state before
+   the attempted write.
+4. Retry only when the inspection confirms that the target was not committed.
+
+Do not infer success from elapsed time, and do not infer failure only because
+the local runner returned no result. Keep metadata unchanged until every target
+has a confirmed successful result.
+
 ## Payload Transport Failures
 
 The Figma MCP `use_figma` call has a practical source-size limit near 50k


### PR DESCRIPTION
## Summary
- document atomic preflight target results and staging reuse rules
- document PNG upload MIME and single-use URL behavior
- document timeout recovery and TeamCity CSRF session constraints

## Verification
- git diff --check
- documentation reconciled with the successful official Figma Sync #66