### PR TITLE
fix(figma-design-sync): keep CI connector labels visible

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -397,6 +397,10 @@ Run the TeamCity server and build agent with separate virtual service accounts:
 - `NT SERVICE\TCBuildAgent` owns the agent's mutable `system`, `work`, `temp`,
   and `.gradle` directories.
 
+The complete Windows service inventory, recovery order, Cloudflare Tunnel
+service, and public-route health checks live in
+[`docs/runbooks/teamcity-cloudflare-access.md`](../docs/runbooks/teamcity-cloudflare-access.md#windows-service-runtime).
+
 The agent must use a system-wide JDK instead of a JDK inside a developer profile.
 Keep the following properties in
 `C:\TeamCity\buildAgent\conf\buildAgent.properties`, updating the Temurin

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -35,6 +35,64 @@ credentials remain operator-managed state and must not be committed.
 - PowerShell SecretManagement and SecretStore are installed for local service
   token storage.
 
+## Windows Service Runtime
+
+The supported local runtime uses three automatic Windows services:
+
+| Service name | Display name | Service account | Responsibility |
+|--------------|--------------|-----------------|----------------|
+| `TeamCity` | `TeamCity Server` | `NT SERVICE\TeamCity` | Hosts the TeamCity server and owns its data directory. |
+| `TCBuildAgent` | `TeamCity Build Agent` | `NT SERVICE\TCBuildAgent` | Executes repository jobs in the agent work directories. |
+| `Cloudflared` | `Cloudflared agent` | `LocalSystem` | Publishes the private TeamCity origin through Cloudflare Tunnel. |
+
+Inspect status, startup mode, and service identity from an elevated PowerShell
+session:
+
+```powershell
+Get-Service -Name TeamCity,TCBuildAgent,Cloudflared
+Get-CimInstance Win32_Service |
+    Where-Object Name -In @("TeamCity", "TCBuildAgent", "Cloudflared") |
+    Select-Object Name,DisplayName,State,StartMode,StartName
+```
+
+Do not print or document the `Cloudflared` service command line. The installed
+service definition can contain the tunnel credential.
+
+All three services should report `Running` and `Automatic`. They have no
+repository-managed Windows dependency relationship, so use this recovery order
+when the host restarts or the installation is repaired:
+
+1. start `TeamCity` and wait for `http://localhost:8111` to respond;
+2. start `TCBuildAgent` and confirm the agent is connected and authorized;
+3. start `Cloudflared` and validate the public HTTPS route.
+
+Use the reverse order for planned shutdown:
+
+```powershell
+Stop-Service Cloudflared
+Stop-Service TCBuildAgent
+Stop-Service TeamCity
+```
+
+Service management requires an elevated shell. Once the services are
+installed, `runAll.bat start` is not the canonical runtime and should not be
+used alongside the Windows services.
+
+Validate the local and public boundaries after recovery:
+
+```powershell
+Get-Service -Name TeamCity,TCBuildAgent,Cloudflared
+curl.exe -I http://localhost:8111
+curl.exe -I https://teamcity.marmatsan.dev
+curl.exe -sS -D - -o NUL https://teamcity.marmatsan.dev/app/webhooks/githubapp
+teamcity auth status
+```
+
+An unauthenticated request to the public root should receive the Cloudflare
+Access redirect. A `GET` to the webhook path should reach TeamCity and return
+`400 Bad Request` because it is not a signed GitHub `POST`; an Access redirect
+there means the path-specific bypass policy is broken.
+
 ## Store The Cloudflare Service Token
 
 Store the Cloudflare service token as a `PSCredential`. Use its client ID as the

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -95,6 +95,9 @@ named `.ci connector label`, composed of a surface background and horizontal
 text, and placed between connected node groups. Do not use native connector
 text for CI labels because Figma rotates it with vertical and elbowed connector
 paths.
+Inside every label group, `Background` must be the bottom layer and `Label`
+must be the top layer. The background is opaque, so reversing this order keeps
+the text in the document but makes it disappear visually.
 `Overview`, `Pull Request Integration`, and `Post-merge Design Documentation`
 use a left-to-right flow. `Infrastructure and Access` keeps its two-dimensional
 topology grid. Horizontal flows connect from the side anchors of their node

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -734,28 +734,42 @@ async function createConnectorLabel(
     text.textAutoResize = "HEIGHT";
     text.resize(CONNECTOR_LABEL_MAX_TEXT_WIDTH, text.height);
   }
-  section.appendChild(text);
-  text.fills = [boundColorPaint(onSurfaceVariable, resolveColorForConsumer(onSurfaceVariable, text))];
 
   const background = figma.createRectangle();
   background.name = "Background";
-  section.appendChild(background);
   background.resize(text.width + 24, text.height + 16);
   background.cornerRadius = 4;
   background.strokes = [];
+
+  const layers = appendConnectorLabelLayers(section, background, text);
   background.fills = [
     boundColorPaint(surfaceVariable, resolveColorForConsumer(surfaceVariable, background)),
   ];
+  text.fills = [boundColorPaint(onSurfaceVariable, resolveColorForConsumer(onSurfaceVariable, text))];
   background.x = 0;
   background.y = 0;
   text.x = 12;
   text.y = 8;
 
-  const group = figma.group([background, text], section);
+  const group = figma.group(layers, section);
   group.name = CI_CONNECTOR_LABEL_NAME;
   group.setSharedPluginData(METADATA_NAMESPACE, CI_ROLE_KEY, ROLE_CONNECTOR);
   group.setSharedPluginData(METADATA_NAMESPACE, CI_MODEL_ID_KEY, modelId);
   return group;
+}
+
+export function connectorLabelLayers<B, T>(background: B, text: T): Array<B | T> {
+  return [background, text];
+}
+
+export function appendConnectorLabelLayers<B, T>(
+  section: { appendChild(node: B | T): void },
+  background: B,
+  text: T
+): Array<B | T> {
+  const layers = connectorLabelLayers(background, text);
+  for (const layer of layers) section.appendChild(layer);
+  return layers;
 }
 
 async function requireColorVariable(name) {

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -5,10 +5,12 @@ import {
   externalEnvironment,
 } from "../src/domain/ci/create-ci-visual-plan";
 import {
+  appendConnectorLabelLayers,
   centeredRowY,
   ciConnectorMagnets,
   ciVisualGridPosition,
   connectorBoundsLabelPosition,
+  connectorLabelLayers,
   connectorLabelPosition,
   horizontalFlowPositions,
   horizontalConnectorGap,
@@ -55,6 +57,23 @@ test("CI visual plan summarizes commands and keeps exact operational names", () 
       { source: "design-model", target: "job-check" },
     ]
   );
+});
+
+test("CI connector label text stays above its opaque background", () => {
+  const background = { name: "Background" };
+  const text = { name: "Label" };
+  const appended: Array<{ name: string }> = [];
+
+  assert.deepEqual(
+    appendConnectorLabelLayers(
+      { appendChild: (node) => appended.push(node) },
+      background,
+      text
+    ).map((node) => node.name),
+    ["Background", "Label"]
+  );
+  assert.deepEqual(appended.map((node) => node.name), ["Background", "Label"]);
+  assert.deepEqual(connectorLabelLayers(background, text), appended);
 });
 
 test("CI visual plan maps node ownership to explicit icon environments", () => {


### PR DESCRIPTION
## What changed

- keep `.ci connector label` backgrounds behind their text when Figma groups the nodes
- add a regression test for the append and layer order
- document the visual stacking contract
- document the TeamCity, build-agent, and Cloudflared Windows service runtime

## Root cause

The writer appended `Label` before the opaque `Background`. Figma preserved that canvas stacking when creating the group, so the background covered the text even though the label remained populated and visible.

## Verification

- `npm run build`
- `npm test`
- `.\gradlew.bat check`
- TeamCity CI #130
- all four CI documentation sections synchronized with the official main artifact
- 22 connector labels verified readable with `Background` before `Label`