### PR TITLE
feat(figma-design-sync): document Windows CI runtime

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -8,6 +8,8 @@ is documented in
 Public HTTPS access, Cloudflare policies, CLI service authentication, webhook
 validation, and CSRF recovery are documented in
 [`docs/runbooks/teamcity-cloudflare-access.md`](../docs/runbooks/teamcity-cloudflare-access.md).
+The Windows services that host this configuration are versioned in
+[`docs/ci/windows-runtime.yaml`](../docs/ci/windows-runtime.yaml).
 
 ## Branching Workflow
 

--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -18,6 +18,7 @@ It contains two levels of detail:
 2. `Pull Request Integration`
 3. `Post-merge Design Documentation`
 4. `Infrastructure and Access`
+5. `Windows Service Runtime`
 
 All visual labels and descriptions use English.
 
@@ -33,12 +34,15 @@ The visual model aggregates sources without duplicating their ownership:
   are not represented by TeamCity DSL, including Cloudflare access and tunnel
   boundaries, user and CLI access, the GitHub webhook ingress, and the external
   MCP-operated Figma write.
-- The generated `design-model.json` aggregates both sources for the visual sync.
+- `docs/ci/windows-runtime.yaml` owns the reviewed Windows service inventory,
+  startup modes, and service identities for the local CI host.
+- The generated `design-model.json` aggregates these sources for the visual sync.
 - Figma is derived documentation and is not a source of CI configuration.
 
 The generated JSON stores this aggregate under `content.ci`:
 
 - `externalTopology` contains the versioned YAML topology;
+- `windowsRuntime` contains the versioned Windows service inventory;
 - `teamCity` contains the effective generated pipelines and VCS roots.
 
 The official TeamCity jobs must run `teamcity-configs:generate` before Gradle
@@ -48,6 +52,9 @@ as a declared input; it does not invoke Maven implicitly.
 The external topology YAML must not duplicate TeamCity pipeline or job
 definitions. It must not contain tokens, secrets, credential references,
 account identifiers, personal names, or visual layout coordinates.
+The Windows runtime YAML must not contain service command lines, credentials,
+or tunnel configuration. In particular, it must never record the Cloudflared
+service command line because it can contain the tunnel credential.
 
 ## Visual Reading Levels
 
@@ -63,6 +70,12 @@ The overview contains two distinct journeys:
 
 Cloudflare appears as a simplified boundary in the overview. Its policies and
 authentication paths belong in `Infrastructure and Access`.
+
+`Windows Service Runtime` is a connector-free inventory. It shows TeamCity
+Server, TeamCity Build Agent, and Cloudflared as independent service nodes with
+their platform, Windows service name, startup mode, and service identity. The
+operational recovery order remains in the linked runbook and is not modeled as
+a dependency between services.
 
 ### Operational Detail
 
@@ -174,6 +187,10 @@ external connection before updating that date.
 The executable warning is `checkCiExternalTopologyFreshness`, wired into the
 root Gradle `check` lifecycle.
 
+The Windows runtime follows the same 90-day manual validation contract through
+`checkCiWindowsRuntimeFreshness`. Its validation procedure is documented in
+`docs/ci/windows-runtime-validation.md`.
+
 ## Excluded Content
 
 The visual model excludes:
@@ -184,3 +201,4 @@ The visual model excludes:
 - raw tokens, secrets, IDs, account details, and personal names;
 - Figma coordinates, colors, dimensions, and component property bindings;
 - manually duplicated TeamCity pipelines or jobs in the external topology.
+- Windows service command lines or credentials.

--- a/docs/ci/windows-runtime-validation.md
+++ b/docs/ci/windows-runtime-validation.md
@@ -1,0 +1,29 @@
+# Windows CI Runtime Validation
+
+Use this runbook to validate `docs/ci/windows-runtime.yaml` against the Windows
+services installed on the TeamCity host. The YAML is a reviewed inventory, not
+an installation script.
+
+Use
+[`../runbooks/teamcity-cloudflare-access.md`](../runbooks/teamcity-cloudflare-access.md)
+for service recovery, health checks, and security constraints.
+
+## Validation Procedure
+
+1. Open an elevated PowerShell session on the TeamCity host.
+2. Run `Get-Service -Name TeamCity,TCBuildAgent,Cloudflared` and confirm that all
+   three services exist and are running.
+3. Query `Win32_Service` as documented in the operational runbook and compare
+   each service name, display name, startup mode, and service account with the
+   YAML.
+4. Do not inspect, print, or copy the Cloudflared service command line because
+   it can contain the tunnel credential.
+5. Confirm the local TeamCity origin, public HTTPS route, webhook bypass, and
+   TeamCity CLI health checks from the operational runbook.
+6. Update `validation.lastValidatedOn` only after every service entry matches
+   the active host.
+7. Run `.\gradlew.bat checkCiWindowsRuntimeFreshness` and the normal repository
+   checks.
+
+The freshness task is intentionally non-blocking: an expired date produces a
+visible CI warning but does not prevent a merge.

--- a/docs/ci/windows-runtime.yaml
+++ b/docs/ci/windows-runtime.yaml
@@ -1,0 +1,29 @@
+schemaVersion: 1
+
+validation:
+  lastValidatedOn: "2026-07-16"
+  warnAfterDays: 90
+
+platform: Windows
+
+services:
+  - id: teamcity-server
+    name: TeamCity Server
+    description: Hosts the TeamCity server and owns its data directory.
+    service: TeamCity
+    startup: Automatic
+    identity: NT SERVICE\TeamCity
+
+  - id: teamcity-build-agent
+    name: TeamCity Build Agent
+    description: Executes repository jobs in the agent work directories.
+    service: TCBuildAgent
+    startup: Automatic
+    identity: NT SERVICE\TCBuildAgent
+
+  - id: cloudflared-agent
+    name: Cloudflared Agent
+    description: Publishes the private TeamCity origin through Cloudflare Tunnel.
+    service: Cloudflared
+    startup: Automatic
+    identity: LocalSystem

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -57,4 +57,6 @@ scripts should stay together.
 - CI policy: `docs/ci/main-branch-protection.md`
 - TeamCity HTTPS and webhook operations:
   `docs/runbooks/teamcity-cloudflare-access.md`
+- Windows CI runtime inventory validation:
+  `docs/ci/windows-runtime-validation.md`
 - Figma design sync docs: `repo/figma-design-sync/docs/README.md`

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -37,6 +37,11 @@ credentials remain operator-managed state and must not be committed.
 
 ## Windows Service Runtime
 
+The reviewed service inventory is versioned in
+[`../ci/windows-runtime.yaml`](../ci/windows-runtime.yaml). Follow
+[`../ci/windows-runtime-validation.md`](../ci/windows-runtime-validation.md)
+before updating its validation date.
+
 The supported local runtime uses three automatic Windows services:
 
 | Service name | Display name | Service account | Responsibility |

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -26,15 +26,15 @@ used by CI.
 ## Package Layout
 
 - `domain/model/catalog`: catalog tree, node, entry, and version models.
-- `domain/model/ci`: external topology and effective TeamCity configuration
-  models used by CI documentation.
+- `domain/model/ci`: external topology, Windows service runtime, and effective
+  TeamCity configuration models used by CI documentation.
 - `domain/model/figma`: Figma references used by domain requests.
 - `domain/model/modules`: module dependency models included in the generated
   design model.
 - `domain/port/catalog`, `domain/port/modules`, and `domain/port/versions`:
   source ports used to build the generated design model.
-- `domain/port/ci`: path-based sources and ports for external topology and
-  effective TeamCity configuration.
+- `domain/port/ci`: path-based sources and ports for external topology,
+  Windows service runtime, and effective TeamCity configuration.
 - `data/datasource/catalog`, `data/datasource/modules`, and
   `data/datasource/versions`: implementations of domain ports grouped by
   capability.
@@ -49,7 +49,8 @@ used by CI.
   models. Keep both module dependencies explicit.
 - `data/properties/versions`: readers for version properties files.
 - `data/teamcity/configuration`: readers for TeamCity generated YAML and XML.
-- `data/yaml/ci`: YAML 1.2 reader for the versioned external topology.
+- `data/yaml/ci`: YAML 1.2 readers for the versioned external topology and
+  Windows service runtime.
 - `plugin/generator`: design model JSON generation and hash calculation.
 - `plugin/checker/versions`: Gradle-facing adapter that verifies repository
   version section and suffix naming before CI can merge catalog changes.
@@ -74,6 +75,9 @@ used by CI.
   naming contract. This task is wired into the root `check` lifecycle.
 - `checkCiExternalTopologyFreshness`: emits a non-blocking warning after the
   validation window in `docs/ci/external-topology.yaml` expires. This task is
+  wired into the root `check` lifecycle.
+- `checkCiWindowsRuntimeFreshness`: emits a non-blocking warning after the
+  validation window in `docs/ci/windows-runtime.yaml` expires. This task is
   wired into the root `check` lifecycle.
 - `checkFigmaTrunkSync`: compares the generated model hash with Figma shared
   plugin data.

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -58,6 +58,7 @@ The model is generated from repository source files, not from Figma:
 | Included-build `settings.gradle.kts` files | Included-build catalog and module discovery. |
 | Gradle build files | Module dependency edges and applied plugin usage. |
 | `docs/ci/external-topology.yaml` | Versioned external systems, access boundaries, and directed connections. |
+| `docs/ci/windows-runtime.yaml` | Versioned Windows services, startup modes, and service identities for the local CI runtime. |
 | `.teamcity/target/generated-configs` | Effective pipelines, jobs, triggers, artifacts, checks, and VCS roots generated from `.teamcity/settings.kts`. |
 
 The default included-build sources are configured by the `figmaDesignSync`
@@ -86,7 +87,7 @@ The stable `content` object contains:
 | `catalogs` | Library, plugin, custom Gradle plugin, and convention plugin trees. |
 | `modules` | Repository module paths discovered from the root project and included builds. |
 | `moduleDependencies` | Module dependency edges grouped by source build. |
-| `ci` | External CI topology and effective TeamCity configuration. |
+| `ci` | External CI topology, Windows service runtime, and effective TeamCity configuration. |
 
 Figma visual code must treat this JSON as the source of truth. Manual visual
 changes in Figma are acceptable only when they are component contract changes;
@@ -99,6 +100,7 @@ Run these from the repository root:
 ```powershell
 .\gradlew.bat checkFigmaVersionNaming
 .\gradlew.bat checkFigmaCatalogUsage
+.\gradlew.bat checkCiWindowsRuntimeFreshness
 ```
 
 Task responsibilities:
@@ -108,12 +110,14 @@ Task responsibilities:
 | `checkFigmaVersionNaming` | Fails when version keys do not follow the Figma naming contract. |
 | `checkFigmaCatalogUsage` | Fails when catalog entries are declared but unused according to the repository usage contract. |
 | `checkCiExternalTopologyFreshness` | Emits a non-blocking warning when the external topology has not been manually validated within its configured window. |
+| `checkCiWindowsRuntimeFreshness` | Emits a non-blocking warning when the Windows service runtime has not been manually validated within its configured window. |
 | `generateFigmaDesignModel` | Generates the official JSON artifact inside TeamCity `Figma Sync` on `main`; do not run it as a local publication path. |
 | `checkFigmaTrunkSync` | Compares the generated `modelHash` with Figma shared plugin metadata inside the official pipeline. |
 
-`checkFigmaVersionNaming`, `checkFigmaCatalogUsage`, and
-`checkCiExternalTopologyFreshness` are wired into the root Gradle `check`
-lifecycle, so the TeamCity `Verify` step runs them through:
+`checkFigmaVersionNaming`, `checkFigmaCatalogUsage`,
+`checkCiExternalTopologyFreshness`, and `checkCiWindowsRuntimeFreshness` are
+wired into the root Gradle `check` lifecycle, so the TeamCity `Verify` step
+runs them through:
 
 ```powershell
 .\gradlew.bat check

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/ci/CiWindowsRuntimeDataSource.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/datasource/ci/CiWindowsRuntimeDataSource.kt
@@ -1,0 +1,19 @@
+package com.marmatsan.figmaDesignSync.data.datasource.ci
+
+import com.marmatsan.figmaDesignSync.data.yaml.ci.CiWindowsRuntimeYamlReader
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimeSource
+import me.tatarka.inject.annotations.Inject
+import java.io.File
+
+/**
+ * YAML-backed adapter for the Windows CI runtime port.
+ */
+@Inject
+class CiWindowsRuntimeDataSource(
+    private val reader: CiWindowsRuntimeYamlReader
+) : CiWindowsRuntimePort {
+    override fun readRuntime(source: CiWindowsRuntimeSource): CiWindowsRuntime =
+        reader.read(File(source.filePath))
+}

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiWindowsRuntimeYamlReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiWindowsRuntimeYamlReader.kt
@@ -1,0 +1,66 @@
+package com.marmatsan.figmaDesignSync.data.yaml.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import me.tatarka.inject.annotations.Inject
+import org.snakeyaml.engine.v2.api.Load
+import org.snakeyaml.engine.v2.api.LoadSettings
+import java.io.File
+import java.time.LocalDate
+
+/**
+ * Parses the repository-owned Windows CI runtime YAML.
+ */
+@Inject
+class CiWindowsRuntimeYamlReader {
+    fun read(file: File): CiWindowsRuntime {
+        val settings = LoadSettings.builder()
+            .setLabel(file.path)
+            .build()
+        val root = file.inputStream().use { input ->
+            Load(settings).loadFromInputStream(input)
+        }.asStringMap("root")
+        val validation = root.requiredMap("validation")
+
+        return CiWindowsRuntime(
+            schemaVersion = root.requiredInt("schemaVersion"),
+            validation = CiWindowsRuntime.Validation(
+                lastValidatedOn = LocalDate.parse(validation.requiredString("lastValidatedOn")),
+                warnAfterDays = validation.requiredInt("warnAfterDays")
+            ),
+            platform = root.requiredString("platform"),
+            services = root.requiredList("services").map(::readService)
+        )
+    }
+
+    private fun readService(value: Any?): CiWindowsRuntime.Service {
+        val service = value.asStringMap("service")
+        return CiWindowsRuntime.Service(
+            id = service.requiredString("id"),
+            name = service.requiredString("name"),
+            description = service.requiredString("description"),
+            service = service.requiredString("service"),
+            startup = service.requiredString("startup"),
+            identity = service.requiredString("identity")
+        )
+    }
+
+    private fun Any?.asStringMap(context: String): Map<String, Any?> {
+        val source = this as? Map<*, *> ?: error("Expected YAML mapping for $context")
+        return source.entries.associate { (key, value) ->
+            val stringKey = key as? String ?: error("Expected string key in $context")
+            stringKey to value
+        }
+    }
+
+    private fun Map<String, Any?>.requiredMap(key: String): Map<String, Any?> =
+        get(key).asStringMap(key)
+
+    private fun Map<String, Any?>.requiredList(key: String): List<Any?> =
+        get(key) as? List<*> ?: error("Expected YAML list '$key'")
+
+    private fun Map<String, Any?>.requiredString(key: String): String =
+        get(key) as? String ?: error("Expected YAML string '$key'")
+
+    private fun Map<String, Any?>.requiredInt(key: String): Int =
+        (get(key) as? Number)?.toInt() ?: error("Expected YAML integer '$key'")
+}

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiWindowsRuntimeYamlReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/yaml/ci/CiWindowsRuntimeYamlReaderTest.kt
@@ -1,0 +1,78 @@
+package com.marmatsan.figmaDesignSync.data.yaml.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.time.LocalDate
+
+internal class CiWindowsRuntimeYamlReaderTest : FunSpec({
+
+    test("read maps the versioned Windows service runtime") {
+        val file = Files.createTempFile("windows-runtime", ".yaml").toFile().apply {
+            writeText(
+                """
+                schemaVersion: 1
+                validation:
+                  lastValidatedOn: "2026-07-16"
+                  warnAfterDays: 90
+                platform: Windows
+                services:
+                  - id: teamcity-server
+                    name: TeamCity Server
+                    description: Hosts TeamCity.
+                    service: TeamCity
+                    startup: Automatic
+                    identity: NT SERVICE\TeamCity
+                """.trimIndent()
+            )
+        }
+
+        val runtime = CiWindowsRuntimeYamlReader().read(file)
+
+        runtime.schemaVersion shouldBe 1
+        runtime.validation.lastValidatedOn shouldBe LocalDate.of(2026, 7, 16)
+        runtime.validation.warnAfterDays shouldBe 90
+        runtime.platform shouldBe "Windows"
+        runtime.services.single() shouldBe CiWindowsRuntime.Service(
+            id = "teamcity-server",
+            name = "TeamCity Server",
+            description = "Hosts TeamCity.",
+            service = "TeamCity",
+            startup = "Automatic",
+            identity = "NT SERVICE\\TeamCity"
+        )
+    }
+
+    test("read rejects duplicate service ids") {
+        val file = Files.createTempFile("invalid-windows-runtime", ".yaml").toFile().apply {
+            writeText(
+                """
+                schemaVersion: 1
+                validation:
+                  lastValidatedOn: "2026-07-16"
+                  warnAfterDays: 90
+                platform: Windows
+                services:
+                  - id: teamcity
+                    name: TeamCity Server
+                    description: Hosts TeamCity.
+                    service: TeamCity
+                    startup: Automatic
+                    identity: LocalSystem
+                  - id: teamcity
+                    name: TeamCity Agent
+                    description: Runs builds.
+                    service: TCBuildAgent
+                    startup: Automatic
+                    identity: LocalSystem
+                """.trimIndent()
+            )
+        }
+
+        shouldThrow<IllegalArgumentException> {
+            CiWindowsRuntimeYamlReader().read(file)
+        }.message shouldBe "CI Windows runtime service ids must be unique"
+    }
+})

--- a/repo/figma-design-sync/docs/bdd/README.md
+++ b/repo/figma-design-sync/docs/bdd/README.md
@@ -90,6 +90,7 @@ Gherkin steps.
 | `repository project modules are available`     | `settings.gradle.kts` and configured included-build settings files through `ProjectModulesPort`                     | `FakeProjectModulesPort` in `DesignModelSteps.kt`            |
 | `repository module dependencies are available` | Project `build.gradle.kts` dependency blocks through `ProjectModuleDependenciesPort`                         | `FakeProjectModuleDependenciesPort` in `DesignModelSteps.kt` |
 | `the external CI topology is available`         | `docs/ci/external-topology.yaml` through `CiExternalTopologyPort`                                            | `FakeCiExternalTopologyPort` in `DesignModelSteps.kt`        |
+| `the Windows CI runtime is available`           | `docs/ci/windows-runtime.yaml` through `CiWindowsRuntimePort`                                                | `FakeCiWindowsRuntimePort` in `DesignModelSteps.kt`          |
 | `the effective TeamCity configuration is available` | `.teamcity/target/generated-configs` through `TeamCityConfigurationPort`                                  | `FakeTeamCityConfigurationPort` in `DesignModelSteps.kt`     |
 | `the design model is generated`                | `FigmaDesignModelGenerator` producing the in-memory design model                                             | Direct generator call from `DesignModelSteps.kt`             |
 | `generateFigmaDesignModel runs`                | Gradle task writing `build/reports/figma-sync/design-model.json`                                             | Temporary Gradle project assembled by `GradleTaskSteps.kt`   |
@@ -117,6 +118,7 @@ The contract has these inputs:
 | Project modules          | Root and configured included-build Gradle settings                                                          |
 | Module dependency graphs | Parsed `build.gradle.kts` dependency blocks for root and configured included-build modules                  |
 | External CI topology     | `docs/ci/external-topology.yaml`                                                                            |
+| Windows CI runtime       | `docs/ci/windows-runtime.yaml`                                                                              |
 | Effective TeamCity model | Generated XML and YAML under `.teamcity/target/generated-configs`                                           |
 
 The contract has one main output:
@@ -135,7 +137,7 @@ The contract has one main output:
 | `catalogs`           | Dependency and plugin trees for Water My Plants, configured included builds, custom Gradle convention plugins, and plugins, including direct and convention-plugin-provided usage metadata. |
 | `modules`            | Sorted Gradle module paths discovered from root and configured included-build settings files.                            |
 | `moduleDependencies` | Main and configured included-build module dependency edges, grouped by graph scope.                                      |
-| `ci`                 | Versioned external topology plus effective TeamCity pipelines, jobs, triggers, artifacts, checks, and VCS roots.         |
+| `ci`                 | Versioned external topology, Windows service runtime, and effective TeamCity pipelines, jobs, triggers, artifacts, checks, and VCS roots. |
 
 The current executable scenarios assert these guarantees:
 

--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -42,8 +42,9 @@ CI documentation visual targets:
 | `ci.pullRequestIntegration` | Effective `.teamcity/settings.kts` model and branch protection contract | `Pull Request Integration` inside page `63153:2876` |
 | `ci.postMergeDesignDocumentation` | Effective Figma Sync pipeline and the operator/MCP loop | `Post-merge Design Documentation` inside page `63153:2876` |
 | `ci.infrastructureAndAccess` | `docs/ci/external-topology.yaml` | `Infrastructure and Access` inside page `63153:2876` |
+| `ci.windowsRuntime` | `docs/ci/windows-runtime.yaml` | `Windows Service Runtime` inside page `63153:2876` |
 
-The four targets share the parent section `Continuous Integration and Design
+The five targets share the parent section `Continuous Integration and Design
 Documentation`. Run one target at a time while iterating; the writer reuses the
 parent and only replaces nodes and connectors managed by the requested child
 section.
@@ -92,7 +93,8 @@ alone when you only want to inspect the contract without changing visuals.
 | 12 | `ci.pullRequestIntegration` | Detailed PR pipeline, jobs, checks, and merge gate | Effective TeamCity job or published check missing from Figma | Nodes and summarized steps match `content.ci.teamCity`. |
 | 13 | `ci.postMergeDesignDocumentation` | Official model generation and operator-assisted visual update loop | Automatic Figma write implied, artifact missing, or rerun loop absent | `design-model.json`, the operator/Codex handoff, and `Rerun via HTTPS client` are visible. |
 | 14 | `ci.infrastructureAndAccess` | GitHub, Cloudflare, TeamCity, Figma, browser, CLI, and operator topology | Connection collapsed or external system duplicated from TeamCity DSL | Nodes and directed connections match `content.ci.externalTopology`. |
-| 15 | `metadata` | Shared plugin sync metadata | Metadata written before visual targets complete | Figma shared plugin data matches the TeamCity artifact. |
+| 15 | `ci.windowsRuntime` | TeamCity Server, TeamCity Build Agent, and Cloudflared Windows services | Runtime block hidden, stale service identity, or incorrect icon environment | Three nodes match `content.ci.windowsRuntime`, expose complete runtime fields, and have no inferred connectors. |
+| 16 | `metadata` | Shared plugin sync metadata | Metadata written before visual targets complete | Figma shared plugin data matches the TeamCity artifact. |
 
 ## Subtree Scoped Runs
 

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -100,7 +100,8 @@ must be the top layer. The background is opaque, so reversing this order keeps
 the text in the document but makes it disappear visually.
 `Overview`, `Pull Request Integration`, and `Post-merge Design Documentation`
 use a left-to-right flow. `Infrastructure and Access` keeps its two-dimensional
-topology grid. Horizontal flows connect from the side anchors of their node
+topology grid. `Windows Service Runtime` is a connector-free grid whose service
+nodes share one row. Horizontal flows connect from the side anchors of their node
 groups and vertically align node centers. Their inter-node gap grows when
 necessary so the connector label fits centered on the horizontal connector.
 Disconnected horizontal flows are stacked as separate rows and each row starts
@@ -128,6 +129,11 @@ The visual plan maps every node explicitly; there is no generic fallback. The
 preflight must fail when the nested instance is absent or duplicated, belongs
 to another component set, lacks the `environment` property, or exposes a
 different set of variant values.
+The `.ci node` component also exposes `runtime platform`, `runtime service`,
+`runtime startup`, `runtime identity`, and `show runtime`. The writer sets all
+four text properties and enables the runtime block only when the visual node
+contains complete runtime data. The preflight requires these properties even
+for targets whose instances keep the runtime block hidden.
 Text alignment is owned by `.ci node`, `.Header`, and the connector template;
 the writer does not override sublayer alignment because the MCP text proxy does
 not expose that style mutation consistently.

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiWindowsRuntime.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/CiWindowsRuntime.kt
@@ -1,0 +1,48 @@
+package com.marmatsan.figmaDesignSync.domain.model.ci
+
+import java.time.LocalDate
+
+/**
+ * Versioned snapshot of the Windows services that host the local CI runtime.
+ */
+data class CiWindowsRuntime(
+    val schemaVersion: Int,
+    val validation: Validation,
+    val platform: String,
+    val services: List<Service>
+) {
+    init {
+        require(schemaVersion > 0) { "CI Windows runtime schemaVersion must be positive" }
+        require(validation.warnAfterDays > 0) { "CI Windows runtime warnAfterDays must be positive" }
+        require(platform.isNotBlank()) { "CI Windows runtime platform must not be blank" }
+        require(services.isNotEmpty()) { "CI Windows runtime must declare at least one service" }
+
+        val serviceIds = services.map(Service::id)
+        require(serviceIds.size == serviceIds.toSet().size) {
+            "CI Windows runtime service ids must be unique"
+        }
+    }
+
+    data class Validation(
+        val lastValidatedOn: LocalDate,
+        val warnAfterDays: Int
+    )
+
+    data class Service(
+        val id: String,
+        val name: String,
+        val description: String,
+        val service: String,
+        val startup: String,
+        val identity: String
+    ) {
+        init {
+            require(id.isNotBlank()) { "CI Windows runtime service id must not be blank" }
+            require(name.isNotBlank()) { "CI Windows runtime service name must not be blank" }
+            require(description.isNotBlank()) { "CI Windows runtime service description must not be blank" }
+            require(service.isNotBlank()) { "CI Windows runtime service identifier must not be blank" }
+            require(startup.isNotBlank()) { "CI Windows runtime startup must not be blank" }
+            require(identity.isNotBlank()) { "CI Windows runtime identity must not be blank" }
+        }
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiWindowsRuntimePort.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiWindowsRuntimePort.kt
@@ -1,0 +1,10 @@
+package com.marmatsan.figmaDesignSync.domain.port.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+
+/**
+ * Reads the versioned Windows service runtime used by CI documentation.
+ */
+interface CiWindowsRuntimePort {
+    fun readRuntime(source: CiWindowsRuntimeSource): CiWindowsRuntime
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiWindowsRuntimeSource.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/port/ci/CiWindowsRuntimeSource.kt
@@ -1,0 +1,8 @@
+package com.marmatsan.figmaDesignSync.domain.port.ci
+
+/**
+ * Location of the repository-owned Windows CI runtime YAML.
+ */
+data class CiWindowsRuntimeSource(
+    val filePath: String
+)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiWindowsRuntimeFreshnessChecker.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiWindowsRuntimeFreshnessChecker.kt
@@ -1,0 +1,35 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.ci
+
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimeSource
+import me.tatarka.inject.annotations.Inject
+import java.io.File
+import java.time.LocalDate
+
+/**
+ * Evaluates whether the manually verified Windows CI runtime is still fresh.
+ */
+@Inject
+internal class CiWindowsRuntimeFreshnessChecker(
+    private val ciWindowsRuntimePort: CiWindowsRuntimePort
+) {
+    fun check(runtimeFile: File, currentDate: LocalDate): Result {
+        val runtime = ciWindowsRuntimePort.readRuntime(
+            CiWindowsRuntimeSource(runtimeFile.absolutePath)
+        )
+        val warningDate = runtime.validation.lastValidatedOn
+            .plusDays(runtime.validation.warnAfterDays.toLong())
+
+        return Result(
+            lastValidatedOn = runtime.validation.lastValidatedOn,
+            warningDate = warningDate,
+            warningRequired = currentDate.isAfter(warningDate)
+        )
+    }
+
+    data class Result(
+        val lastValidatedOn: LocalDate,
+        val warningDate: LocalDate,
+        val warningRequired: Boolean
+    )
+}

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncCheckRequest.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncCheckRequest.kt
@@ -21,6 +21,7 @@ internal data class FigmaTrunkSyncCheckRequest(
     val versionsFile: File,
     val rootSettingsFile: File,
     val ciExternalTopologyFile: File,
+    val ciWindowsRuntimeFile: File,
     val teamCityGeneratedConfigurationDirectory: File,
     val projectRootDirectory: File,
     val includedBuilds: List<FigmaDesignModelIncludedBuildSource>

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncChecker.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/sync/FigmaTrunkSyncChecker.kt
@@ -36,6 +36,7 @@ internal class FigmaTrunkSyncChecker(
                 versionsFile = request.versionsFile,
                 rootSettingsFile = request.rootSettingsFile,
                 ciExternalTopologyFile = request.ciExternalTopologyFile,
+                ciWindowsRuntimeFile = request.ciWindowsRuntimeFile,
                 teamCityGeneratedConfigurationDirectory = request.teamCityGeneratedConfigurationDirectory,
                 projectRootDirectory = request.projectRootDirectory,
                 includedBuilds = request.includedBuilds

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/di/FigmaCatalogChecksComponent.kt
@@ -2,6 +2,7 @@ package com.marmatsan.figmaDesignSync.plugin.di
 
 import com.marmatsan.figmaDesignSync.data.datasource.catalog.ProjectCatalogTreesDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.ci.CiExternalTopologyDataSource
+import com.marmatsan.figmaDesignSync.data.datasource.ci.CiWindowsRuntimeDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.ci.TeamCityConfigurationDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.modules.ProjectModuleDependenciesDataSource
 import com.marmatsan.figmaDesignSync.data.datasource.modules.ProjectModulesDataSource
@@ -9,6 +10,7 @@ import com.marmatsan.figmaDesignSync.data.datasource.versions.RepositoryVersions
 import com.marmatsan.figmaDesignSync.data.figma.client.FigmaFileContentClient
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModulesPort
@@ -18,6 +20,7 @@ import com.marmatsan.figmaDesignSync.plugin.checker.sync.FigmaTrunkSyncChecker
 import com.marmatsan.figmaDesignSync.plugin.checker.versions.VersionNamingChecker
 import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelGenerator
 import com.marmatsan.figmaDesignSync.plugin.checker.ci.CiExternalTopologyFreshnessChecker
+import com.marmatsan.figmaDesignSync.plugin.checker.ci.CiWindowsRuntimeFreshnessChecker
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 
@@ -39,6 +42,11 @@ internal abstract class figmaDesignSyncComponent {
      * Service used by the non-blocking external topology freshness check.
      */
     abstract val ciExternalTopologyFreshnessChecker: CiExternalTopologyFreshnessChecker
+
+    /**
+     * Service used by the non-blocking Windows runtime freshness check.
+     */
+    abstract val ciWindowsRuntimeFreshnessChecker: CiWindowsRuntimeFreshnessChecker
 
     /**
      * Service used by `checkFigmaTrunkSync`.
@@ -73,6 +81,10 @@ internal abstract class figmaDesignSyncComponent {
 
     @Provides
     protected fun ciExternalTopologyPort(dataSource: CiExternalTopologyDataSource): CiExternalTopologyPort =
+        dataSource
+
+    @Provides
+    protected fun ciWindowsRuntimePort(dataSource: CiWindowsRuntimeDataSource): CiWindowsRuntimePort =
         dataSource
 
     @Provides

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerationRequest.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerationRequest.kt
@@ -16,6 +16,7 @@ import java.time.Instant
  * @property versionsFile Source `repo/dependency-catalog/versions.properties` file.
  * @property rootSettingsFile Root `settings.gradle.kts`.
  * @property ciExternalTopologyFile Versioned external CI topology.
+ * @property ciWindowsRuntimeFile Versioned Windows service runtime.
  * @property teamCityGeneratedConfigurationDirectory Effective TeamCity
  * configuration generated from `.teamcity/settings.kts`.
  * @property projectRootDirectory Repository root.
@@ -29,6 +30,7 @@ internal data class FigmaDesignModelGenerationRequest(
     val versionsFile: File,
     val rootSettingsFile: File,
     val ciExternalTopologyFile: File,
+    val ciWindowsRuntimeFile: File,
     val teamCityGeneratedConfigurationDirectory: File,
     val projectRootDirectory: File,
     val includedBuilds: List<FigmaDesignModelIncludedBuildSource>

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGenerator.kt
@@ -4,6 +4,8 @@ import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSourc
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimeSource
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
 import com.marmatsan.figmaDesignSync.domain.port.gradle.IncludedBuildSource
@@ -37,6 +39,7 @@ internal class FigmaDesignModelGenerator(
     private val projectModulesPort: ProjectModulesPort,
     private val projectModuleDependenciesPort: ProjectModuleDependenciesPort,
     private val ciExternalTopologyPort: CiExternalTopologyPort,
+    private val ciWindowsRuntimePort: CiWindowsRuntimePort,
     private val teamCityConfigurationPort: TeamCityConfigurationPort
 ) {
     /**
@@ -104,6 +107,12 @@ internal class FigmaDesignModelGenerator(
                 "externalTopology",
                 ciExternalTopologyPort
                     .readTopology(CiExternalTopologySource(request.ciExternalTopologyFile.absolutePath))
+                    .toDesignJson()
+            )
+            put(
+                "windowsRuntime",
+                ciWindowsRuntimePort
+                    .readRuntime(CiWindowsRuntimeSource(request.ciWindowsRuntimeFile.absolutePath))
                     .toDesignJson()
             )
             put(
@@ -225,6 +234,6 @@ internal class FigmaDesignModelGenerator(
         }
 
     private companion object {
-        const val SCHEMA_VERSION = 3
+        const val SCHEMA_VERSION = 4
     }
 }

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelJson.kt
@@ -9,6 +9,7 @@ import com.marmatsan.figmaDesignSync.domain.model.catalog.LibraryCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
 import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
@@ -260,6 +261,38 @@ internal fun CiExternalTopology.toDesignJson(): JsonObject =
                         put("path", connection.path.toJsonPrimitiveOrNull())
                         put("automation", connection.automation.serializedName)
                         put("annotation", connection.annotation.toJsonPrimitiveOrNull())
+                    }
+                }
+                .let(::JsonArray)
+        )
+    }
+
+/**
+ * Converts the versioned Windows CI runtime to its stable model shape.
+ */
+internal fun CiWindowsRuntime.toDesignJson(): JsonObject =
+    buildJsonObject {
+        put("schemaVersion", schemaVersion)
+        put(
+            "validation",
+            buildJsonObject {
+                put("lastValidatedOn", validation.lastValidatedOn.toString())
+                put("warnAfterDays", validation.warnAfterDays)
+            }
+        )
+        put("platform", platform)
+        put(
+            "services",
+            services
+                .sortedBy(CiWindowsRuntime.Service::id)
+                .map { service ->
+                    buildJsonObject {
+                        put("id", service.id)
+                        put("name", service.name)
+                        put("description", service.description)
+                        put("service", service.service)
+                        put("startup", service.startup)
+                        put("identity", service.identity)
                     }
                 }
                 .let(::JsonArray)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaCatalogChecksExtension.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaCatalogChecksExtension.kt
@@ -89,6 +89,11 @@ abstract class figmaDesignSyncExtension @Inject constructor(
     val ciExternalTopologyFile: RegularFileProperty = objects.fileProperty()
 
     /**
+     * Versioned Windows services rendered in CI documentation.
+     */
+    val ciWindowsRuntimeFile: RegularFileProperty = objects.fileProperty()
+
+    /**
      * Effective TeamCity configuration generated from the versioned Kotlin DSL.
      */
     val teamCityGeneratedConfigurationDirectory: DirectoryProperty = objects.directoryProperty()
@@ -110,6 +115,7 @@ abstract class figmaDesignSyncExtension @Inject constructor(
         versionsFile.convention(layout.projectDirectory.file("repo/dependency-catalog/versions.properties"))
         rootSettingsFile.convention(layout.projectDirectory.file("settings.gradle.kts"))
         ciExternalTopologyFile.convention(layout.projectDirectory.file("docs/ci/external-topology.yaml"))
+        ciWindowsRuntimeFile.convention(layout.projectDirectory.file("docs/ci/windows-runtime.yaml"))
         teamCityGeneratedConfigurationDirectory.convention(
             layout.projectDirectory.dir(".teamcity/target/generated-configs")
         )

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
@@ -3,6 +3,7 @@ package com.marmatsan.figmaDesignSync.plugin.gradle
 import com.marmatsan.figmaDesignSync.plugin.generator.FigmaDesignModelIncludedBuildSource
 import com.marmatsan.figmaDesignSync.plugin.task.catalog.CheckFigmaCatalogUsageTask
 import com.marmatsan.figmaDesignSync.plugin.task.ci.CheckCiExternalTopologyFreshnessTask
+import com.marmatsan.figmaDesignSync.plugin.task.ci.CheckCiWindowsRuntimeFreshnessTask
 import com.marmatsan.figmaDesignSync.plugin.task.generate.GenerateFigmaDesignModelTask
 import com.marmatsan.figmaDesignSync.plugin.task.sync.CheckFigmaTrunkSyncTask
 import com.marmatsan.figmaDesignSync.plugin.task.versions.CheckFigmaVersionNamingTask
@@ -70,11 +71,19 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
 
                 ciExternalTopologyFile.set(extension.ciExternalTopologyFile)
             }
+        val checkCiWindowsRuntimeFreshness =
+            project.tasks.register<CheckCiWindowsRuntimeFreshnessTask>("checkCiWindowsRuntimeFreshness") {
+                group = "verification"
+                description = "Warns when the Windows CI runtime has not been validated recently."
+
+                ciWindowsRuntimeFile.set(extension.ciWindowsRuntimeFile)
+            }
 
         project.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
             dependsOn(checkFigmaCatalogUsage)
             dependsOn(checkFigmaVersionNaming)
             dependsOn(checkCiExternalTopologyFreshness)
+            dependsOn(checkCiWindowsRuntimeFreshness)
         }
 
         project.tasks.register<GenerateFigmaDesignModelTask>("generateFigmaDesignModel") {
@@ -84,6 +93,7 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
             versionsFile.set(extension.versionsFile)
             rootSettingsFile.set(extension.rootSettingsFile)
             ciExternalTopologyFile.set(extension.ciExternalTopologyFile)
+            ciWindowsRuntimeFile.set(extension.ciWindowsRuntimeFile)
             teamCityGeneratedConfigurationDirectory.set(extension.teamCityGeneratedConfigurationDirectory)
             includedBuildSettingsFiles.from(
                 includedBuildSources.map { sources -> sources.map { source -> source.settingsFile } }
@@ -113,6 +123,7 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
             versionsFile.set(extension.versionsFile)
             rootSettingsFile.set(extension.rootSettingsFile)
             ciExternalTopologyFile.set(extension.ciExternalTopologyFile)
+            ciWindowsRuntimeFile.set(extension.ciWindowsRuntimeFile)
             teamCityGeneratedConfigurationDirectory.set(extension.teamCityGeneratedConfigurationDirectory)
             includedBuildSettingsFiles.from(
                 includedBuildSources.map { sources -> sources.map { source -> source.settingsFile } }

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiWindowsRuntimeFreshnessTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiWindowsRuntimeFreshnessTask.kt
@@ -1,0 +1,41 @@
+package com.marmatsan.figmaDesignSync.plugin.task.ci
+
+import com.marmatsan.figmaDesignSync.plugin.di.create
+import com.marmatsan.figmaDesignSync.plugin.di.figmaDesignSyncComponent
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Emits a non-blocking warning when Windows CI runtime validation is stale.
+ */
+abstract class CheckCiWindowsRuntimeFreshnessTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ciWindowsRuntimeFile: RegularFileProperty
+
+    @TaskAction
+    fun checkFreshness() {
+        val result = figmaDesignSyncComponent::class.create()
+            .ciWindowsRuntimeFreshnessChecker
+            .check(
+                runtimeFile = ciWindowsRuntimeFile.get().asFile,
+                currentDate = LocalDate.now(ZoneOffset.UTC)
+            )
+
+        if (result.warningRequired) {
+            logger.warn(
+                "Windows CI runtime was last validated on ${result.lastValidatedOn}. " +
+                    "Validate docs/ci/windows-runtime.yaml against the installed services " +
+                    "and update validation.lastValidatedOn."
+            )
+        } else {
+            logger.lifecycle("Windows CI runtime validation is current until ${result.warningDate}.")
+        }
+    }
+}

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/generate/GenerateFigmaDesignModelTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/generate/GenerateFigmaDesignModelTask.kt
@@ -47,6 +47,10 @@ abstract class GenerateFigmaDesignModelTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val ciExternalTopologyFile: RegularFileProperty
 
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ciWindowsRuntimeFile: RegularFileProperty
+
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val teamCityGeneratedConfigurationDirectory: DirectoryProperty
@@ -93,6 +97,7 @@ abstract class GenerateFigmaDesignModelTask : DefaultTask() {
                 versionsFile = versionsFile.get().asFile,
                 rootSettingsFile = rootSettingsFile.get().asFile,
                 ciExternalTopologyFile = ciExternalTopologyFile.get().asFile,
+                ciWindowsRuntimeFile = ciWindowsRuntimeFile.get().asFile,
                 teamCityGeneratedConfigurationDirectory = teamCityGeneratedConfigurationDirectory.get().asFile,
                 projectRootDirectory = projectRootDirectory.get().asFile,
                 includedBuilds = includedBuildSources()

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/sync/CheckFigmaTrunkSyncTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/sync/CheckFigmaTrunkSyncTask.kt
@@ -46,6 +46,10 @@ abstract class CheckFigmaTrunkSyncTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val ciExternalTopologyFile: RegularFileProperty
 
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val ciWindowsRuntimeFile: RegularFileProperty
+
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val teamCityGeneratedConfigurationDirectory: DirectoryProperty
@@ -93,6 +97,7 @@ abstract class CheckFigmaTrunkSyncTask : DefaultTask() {
                 versionsFile = versionsFile.get().asFile,
                 rootSettingsFile = rootSettingsFile.get().asFile,
                 ciExternalTopologyFile = ciExternalTopologyFile.get().asFile,
+                ciWindowsRuntimeFile = ciWindowsRuntimeFile.get().asFile,
                 teamCityGeneratedConfigurationDirectory = teamCityGeneratedConfigurationDirectory.get().asFile,
                 projectRootDirectory = projectRootDirectory.get().asFile,
                 includedBuilds = includedBuildSources()

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/DesignModelSteps.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/DesignModelSteps.kt
@@ -8,6 +8,7 @@ import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
 import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityPipeline
@@ -17,6 +18,8 @@ import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSourc
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimeSource
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
@@ -50,6 +53,7 @@ class DesignModelSteps : En {
     private var repositoryProjectModulesAvailable = false
     private var repositoryModuleDependenciesAvailable = false
     private var externalCiTopologyAvailable = false
+    private var windowsCiRuntimeAvailable = false
     private var effectiveTeamCityConfigurationAvailable = false
     private lateinit var generator: FigmaDesignModelGenerator
     private lateinit var firstResult: FigmaDesignModelGenerationResult
@@ -78,6 +82,11 @@ class DesignModelSteps : En {
 
         Given("the external CI topology is available") {
             externalCiTopologyAvailable = true
+            configureGenerator()
+        }
+
+        Given("the Windows CI runtime is available") {
+            windowsCiRuntimeAvailable = true
             configureGenerator()
         }
 
@@ -162,10 +171,10 @@ class DesignModelSteps : En {
                 } shouldBe listOf("Main project dependencies", "Libraries", "Plugins")
         }
 
-        Then("the CI model contains external topology and effective TeamCity configuration") {
+        Then("the CI model contains external topology Windows runtime and effective TeamCity configuration") {
             firstResult.content["ci"]!!
                 .jsonObject
-                .keys shouldContainAll listOf("externalTopology", "teamCity")
+                .keys shouldContainAll listOf("externalTopology", "windowsRuntime", "teamCity")
         }
 
         Then("the model hash is stored in the generated model") {
@@ -218,6 +227,7 @@ class DesignModelSteps : En {
             projectModulesPort = FakeProjectModulesPort,
             projectModuleDependenciesPort = FakeProjectModuleDependenciesPort,
             ciExternalTopologyPort = FakeCiExternalTopologyPort,
+            ciWindowsRuntimePort = FakeCiWindowsRuntimePort,
             teamCityConfigurationPort = FakeTeamCityConfigurationPort
         )
     }
@@ -228,6 +238,7 @@ class DesignModelSteps : En {
         check(repositoryProjectModulesAvailable) { "Repository project modules are not available." }
         check(repositoryModuleDependenciesAvailable) { "Repository module dependencies are not available." }
         check(externalCiTopologyAvailable) { "External CI topology is not available." }
+        check(windowsCiRuntimeAvailable) { "Windows CI runtime is not available." }
         check(effectiveTeamCityConfigurationAvailable) { "Effective TeamCity configuration is not available." }
     }
 
@@ -242,6 +253,7 @@ class DesignModelSteps : En {
             versionsFile = File("versions.properties"),
             rootSettingsFile = File("settings.gradle.kts"),
             ciExternalTopologyFile = File("docs/ci/external-topology.yaml"),
+            ciWindowsRuntimeFile = File("docs/ci/windows-runtime.yaml"),
             teamCityGeneratedConfigurationDirectory = File(".teamcity/target/generated-configs"),
             projectRootDirectory = File("."),
             includedBuilds = listOf(
@@ -351,6 +363,28 @@ private object FakeCiExternalTopologyPort : CiExternalTopologyPort {
                 )
             ),
             connections = emptyList()
+        )
+}
+
+private object FakeCiWindowsRuntimePort : CiWindowsRuntimePort {
+    override fun readRuntime(source: CiWindowsRuntimeSource): CiWindowsRuntime =
+        CiWindowsRuntime(
+            schemaVersion = 1,
+            validation = CiWindowsRuntime.Validation(
+                lastValidatedOn = LocalDate.parse("2026-07-16"),
+                warnAfterDays = 90
+            ),
+            platform = "Windows",
+            services = listOf(
+                CiWindowsRuntime.Service(
+                    id = "teamcity-server",
+                    name = "TeamCity Server",
+                    description = "Hosts TeamCity.",
+                    service = "TeamCity",
+                    startup = "Automatic",
+                    identity = "NT SERVICE\\TeamCity"
+                )
+            )
         )
 }
 

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/GradleTaskSteps.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/bdd/GradleTaskSteps.kt
@@ -264,6 +264,22 @@ class GradleTaskSteps : En {
             connections: []
             """.trimIndent()
         )
+        resolve("docs/ci/windows-runtime.yaml").writeText(
+            """
+            schemaVersion: 1
+            validation:
+              lastValidatedOn: "2026-07-16"
+              warnAfterDays: 90
+            platform: Windows
+            services:
+              - id: teamcity-server
+                name: TeamCity Server
+                description: Hosts TeamCity.
+                service: TeamCity
+                startup: Automatic
+                identity: NT SERVICE\TeamCity
+            """.trimIndent()
+        )
         resolve(".teamcity/target/generated-configs/Root_Ci").mkdirs()
         resolve(".teamcity/target/generated-configs/Root_Ci/project-config.xml").writeText(
             """

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiWindowsRuntimeFreshnessCheckerTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/checker/ci/CiWindowsRuntimeFreshnessCheckerTest.kt
@@ -1,0 +1,47 @@
+package com.marmatsan.figmaDesignSync.plugin.checker.ci
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimeSource
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+internal class CiWindowsRuntimeFreshnessCheckerTest : FunSpec({
+
+    test("check requests a warning only after the configured validation window") {
+        val checker = CiWindowsRuntimeFreshnessChecker(FakeCiWindowsRuntimePort)
+
+        checker.check(
+            runtimeFile = java.io.File("windows-runtime.yaml"),
+            currentDate = LocalDate.parse("2026-10-14")
+        ).warningRequired shouldBe false
+
+        checker.check(
+            runtimeFile = java.io.File("windows-runtime.yaml"),
+            currentDate = LocalDate.parse("2026-10-15")
+        ).warningRequired shouldBe true
+    }
+})
+
+private object FakeCiWindowsRuntimePort : CiWindowsRuntimePort {
+    override fun readRuntime(source: CiWindowsRuntimeSource): CiWindowsRuntime =
+        CiWindowsRuntime(
+            schemaVersion = 1,
+            validation = CiWindowsRuntime.Validation(
+                lastValidatedOn = LocalDate.parse("2026-07-16"),
+                warnAfterDays = 90
+            ),
+            platform = "Windows",
+            services = listOf(
+                CiWindowsRuntime.Service(
+                    id = "teamcity-server",
+                    name = "TeamCity Server",
+                    description = "Hosts TeamCity.",
+                    service = "TeamCity",
+                    startup = "Automatic",
+                    identity = "LocalSystem"
+                )
+            )
+        )
+}

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/generator/FigmaDesignModelGeneratorTest.kt
@@ -10,6 +10,7 @@ import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogNode
 import com.marmatsan.figmaDesignSync.domain.model.catalog.PluginCatalogTree
 import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
 import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityConfiguration
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityJob
 import com.marmatsan.figmaDesignSync.domain.model.ci.TeamCityPipeline
@@ -19,6 +20,8 @@ import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreeSourc
 import com.marmatsan.figmaDesignSync.domain.port.catalog.ProjectCatalogTreesPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologyPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.CiExternalTopologySource
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimePort
+import com.marmatsan.figmaDesignSync.domain.port.ci.CiWindowsRuntimeSource
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityConfigurationPort
 import com.marmatsan.figmaDesignSync.domain.port.ci.TeamCityGeneratedConfigurationSource
 import com.marmatsan.figmaDesignSync.domain.port.modules.ProjectModuleDependenciesPort
@@ -242,16 +245,19 @@ internal class FigmaDesignModelGeneratorTest : FunSpec({
         gradlePluginsCatalog?.get("plugins") shouldBe null
     }
 
-    test("generate writes external topology and effective TeamCity configuration") {
+    test("generate writes external topology Windows runtime and effective TeamCity configuration") {
         // WHEN
         val result = generator().generate(request())
 
         // THEN
-        result.model["schemaVersion"]?.jsonPrimitive?.content shouldBe "3"
+        result.model["schemaVersion"]?.jsonPrimitive?.content shouldBe "4"
         val ci = result.model["content"]?.jsonObject?.get("ci")?.jsonObject
         ci?.get("externalTopology")?.jsonObject
             ?.get("nodes")?.jsonArray?.single()?.jsonObject
             ?.get("name")?.jsonPrimitive?.content shouldBe "Operator"
+        ci?.get("windowsRuntime")?.jsonObject
+            ?.get("services")?.jsonArray?.single()?.jsonObject
+            ?.get("service")?.jsonPrimitive?.content shouldBe "TeamCity"
         ci?.get("teamCity")?.jsonObject
             ?.get("pipelines")?.jsonArray?.single()?.jsonObject
             ?.get("name")?.jsonPrimitive?.content shouldBe "CI"
@@ -265,6 +271,7 @@ private fun generator(): FigmaDesignModelGenerator =
         projectModulesPort = FakeProjectModulesPort,
         projectModuleDependenciesPort = FakeProjectModuleDependenciesPort,
         ciExternalTopologyPort = FakeCiExternalTopologyPort,
+        ciWindowsRuntimePort = FakeCiWindowsRuntimePort,
         teamCityConfigurationPort = FakeTeamCityConfigurationPort
     )
 
@@ -279,6 +286,7 @@ private fun request(
         versionsFile = File("versions.properties"),
         rootSettingsFile = File("settings.gradle.kts"),
         ciExternalTopologyFile = File("docs/ci/external-topology.yaml"),
+        ciWindowsRuntimeFile = File("docs/ci/windows-runtime.yaml"),
         teamCityGeneratedConfigurationDirectory = File(".teamcity/target/generated-configs"),
         projectRootDirectory = File("."),
         includedBuilds = listOf(
@@ -440,6 +448,28 @@ private object FakeCiExternalTopologyPort : CiExternalTopologyPort {
                 )
             ),
             connections = emptyList()
+        )
+}
+
+private object FakeCiWindowsRuntimePort : CiWindowsRuntimePort {
+    override fun readRuntime(source: CiWindowsRuntimeSource): CiWindowsRuntime =
+        CiWindowsRuntime(
+            schemaVersion = 1,
+            validation = CiWindowsRuntime.Validation(
+                lastValidatedOn = LocalDate.parse("2026-07-16"),
+                warnAfterDays = 90
+            ),
+            platform = "Windows",
+            services = listOf(
+                CiWindowsRuntime.Service(
+                    id = "teamcity-server",
+                    name = "TeamCity Server",
+                    description = "Hosts TeamCity.",
+                    service = "TeamCity",
+                    startup = "Automatic",
+                    identity = "NT SERVICE\\TeamCity"
+                )
+            )
         )
 }
 

--- a/repo/figma-design-sync/plugin/src/test/resources/com/marmatsan/figmaDesignSync/plugin/bdd/figma-design-model.feature
+++ b/repo/figma-design-sync/plugin/src/test/resources/com/marmatsan/figmaDesignSync/plugin/bdd/figma-design-model.feature
@@ -10,6 +10,7 @@ Feature: Figma design model generation
     And repository project modules are available
     And repository module dependencies are available
     And the external CI topology is available
+    And the Windows CI runtime is available
     And the effective TeamCity configuration is available
 
   @domain
@@ -25,7 +26,7 @@ Feature: Figma design model generation
       | ci                 |
     And the version keys are sorted
     And the version sections keep repository order
-    And the CI model contains external topology and effective TeamCity configuration
+    And the CI model contains external topology Windows runtime and effective TeamCity configuration
     And the model hash is stored in the generated model
 
   @domain

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -36,6 +36,7 @@ const KNOWN_TARGETS = [
   "ci.pullRequestIntegration",
   "ci.postMergeDesignDocumentation",
   "ci.infrastructureAndAccess",
+  "ci.windowsRuntime",
   "metadata",
 ];
 

--- a/repo/figma-design-sync/tools/src/config/figma-config.ts
+++ b/repo/figma-design-sync/tools/src/config/figma-config.ts
@@ -38,8 +38,13 @@ export const CI_NODE_PROPS = {
   description: "description",
   steps: "steps",
   source: "source",
+  runtimePlatform: "runtime platform",
+  runtimeService: "runtime service",
+  runtimeStartup: "runtime startup",
+  runtimeIdentity: "runtime identity",
   showSteps: "show steps",
   showSource: "show source",
+  showRuntime: "show runtime",
 };
 export const VERSIONS_COLLECTION_NAME = "repo\\dependency-catalog\\versions.properties";
 export const VERSIONS_COLLECTION_NAMES = [VERSIONS_COLLECTION_NAME];

--- a/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
+++ b/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
@@ -5,6 +5,7 @@ export const CI_VISUAL_TARGET_NAMES = [
   "ci.pullRequestIntegration",
   "ci.postMergeDesignDocumentation",
   "ci.infrastructureAndAccess",
+  "ci.windowsRuntime",
 ] as const;
 
 export type CiVisualTargetName = typeof CI_VISUAL_TARGET_NAMES[number];
@@ -29,6 +30,13 @@ export type CiVisualEnvironment =
   | "operator"
   | "json";
 
+export type CiVisualRuntime = {
+  platform: string;
+  service: string;
+  startup: string;
+  identity: string;
+};
+
 export type CiVisualNode = {
   id: string;
   type: CiVisualNodeType;
@@ -36,6 +44,7 @@ export type CiVisualNode = {
   name: string;
   description: string;
   steps?: string;
+  runtime?: CiVisualRuntime;
   source: string;
   sourceUrl: string;
   row: number;
@@ -67,6 +76,8 @@ export type CiVisualPlan = {
 const GITHUB_MAIN_BLOB_URL = "https://github.com/marmatsan/water-my-plants/blob/main";
 const TEAMCITY_SOURCE = ".teamcity/settings.kts";
 const TOPOLOGY_SOURCE = "docs/ci/external-topology.yaml";
+const WINDOWS_RUNTIME_SOURCE = "docs/ci/windows-runtime.yaml";
+const WINDOWS_RUNTIME_RUNBOOK_SOURCE = "docs/runbooks/teamcity-cloudflare-access.md";
 const VISUAL_CONTRACT_SOURCE = "docs/ci/visual-model-contract.md";
 const BRANCH_PROTECTION_SOURCE = "docs/ci/main-branch-protection.md";
 const OFFICIAL_SYNC_SOURCE = "repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md";
@@ -83,6 +94,7 @@ export function createCiVisualPlan(designModel: DesignModel): CiVisualPlan {
       createPullRequestSection(ciPipeline),
       createPostMergeSection(ci, figmaPipeline),
       createInfrastructureSection(ci),
+      createWindowsRuntimeSection(ci),
     ],
   };
 }
@@ -97,6 +109,13 @@ export function requireCiContent(designModel: DesignModel) {
   }
   if (!ci.teamCity || !Array.isArray(ci.teamCity.pipelines) || !Array.isArray(ci.teamCity.vcsRoots)) {
     throw new Error("designModel.content.ci.teamCity must contain pipelines and vcsRoots.");
+  }
+  if (
+    !ci.windowsRuntime ||
+    typeof ci.windowsRuntime.platform !== "string" ||
+    !Array.isArray(ci.windowsRuntime.services)
+  ) {
+    throw new Error("designModel.content.ci.windowsRuntime must contain platform and services.");
   }
   return ci;
 }
@@ -266,6 +285,37 @@ function createInfrastructureSection(ci): CiVisualSection {
   );
 }
 
+function createWindowsRuntimeSection(ci): CiVisualSection {
+  const nodes = ci.windowsRuntime.services.map((service, index) => ({
+    ...visualNode(
+      `windows-runtime-${service.id}`,
+      "system",
+      windowsRuntimeEnvironment(service.id),
+      service.name,
+      service.description,
+      WINDOWS_RUNTIME_SOURCE,
+      0,
+      index
+    ),
+    runtime: {
+      platform: ci.windowsRuntime.platform,
+      service: service.service,
+      startup: service.startup,
+      identity: service.identity,
+    },
+  }));
+
+  return section(
+    "ci.windowsRuntime",
+    "Windows Service Runtime",
+    "Versioned inventory of the Windows services that host the local CI runtime.",
+    [WINDOWS_RUNTIME_SOURCE, WINDOWS_RUNTIME_RUNBOOK_SOURCE],
+    "grid",
+    nodes,
+    []
+  );
+}
+
 function section(target, name, description, sources, orientation, nodes, connections): CiVisualSection {
   return {
     target,
@@ -314,6 +364,17 @@ export function externalEnvironment(id: string): CiVisualEnvironment {
   };
   const environment = environments[id];
   if (!environment) throw new Error(`External CI node '${id}' has no .ci icon environment mapping.`);
+  return environment;
+}
+
+export function windowsRuntimeEnvironment(id: string): CiVisualEnvironment {
+  const environments: Record<string, CiVisualEnvironment> = {
+    "teamcity-server": "teamcity",
+    "teamcity-build-agent": "teamcity",
+    "cloudflared-agent": "cloudflare",
+  };
+  const environment = environments[id];
+  if (!environment) throw new Error(`Windows CI runtime service '${id}' has no .ci icon environment mapping.`);
   return environment;
 }
 

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -40,6 +40,7 @@ export type SyncTargetName =
   | "ci.pullRequestIntegration"
   | "ci.postMergeDesignDocumentation"
   | "ci.infrastructureAndAccess"
+  | "ci.windowsRuntime"
   | "metadata";
 
 export type SyncFigmaDesignModelOptions = {

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -171,12 +171,13 @@ async function syncParentHeader(parent, mutatedNodeIds) {
     sourceLink("docs/ci/visual-model-contract.md"),
     sourceLink(".teamcity/settings.kts"),
     sourceLink("docs/ci/external-topology.yaml"),
+    sourceLink("docs/ci/windows-runtime.yaml"),
   ];
   setComponentTextProperty(header, "Header", "Continuous Integration and Design Documentation");
   setComponentTextProperty(
     header,
     "Definition",
-    "Current pull request integration, post-merge design documentation, and CI infrastructure."
+    "Current pull request integration, post-merge design documentation, CI infrastructure, and Windows service runtime."
   );
   const linkText = links.map((link) => link.label).join("\n");
   setComponentTextProperty(header, "Link", linkText);
@@ -359,18 +360,40 @@ async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
   instance.setExplicitVariableModeForCollection(modeCollection, modeId);
   const icon = requireSingleNestedInstance(instance, CI_ICON_INSTANCE_NAME);
   setComponentVariantProperty(icon, CI_ICON_ENVIRONMENT_PROPERTY, nodePlan.environment);
-  setComponentTextProperty(instance, CI_NODE_PROPS.name, nodePlan.name);
-  setComponentTextProperty(instance, CI_NODE_PROPS.description, nodePlan.description);
-  setComponentTextProperty(instance, CI_NODE_PROPS.steps, nodePlan.steps || "");
-  setComponentTextProperty(instance, CI_NODE_PROPS.source, nodePlan.source);
-  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSteps, Boolean(nodePlan.steps));
-  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSource, true);
+  const properties = ciNodePropertyValues(nodePlan);
+  setComponentTextProperty(instance, CI_NODE_PROPS.name, properties.name);
+  setComponentTextProperty(instance, CI_NODE_PROPS.description, properties.description);
+  setComponentTextProperty(instance, CI_NODE_PROPS.steps, properties.steps);
+  setComponentTextProperty(instance, CI_NODE_PROPS.source, properties.source);
+  setComponentTextProperty(instance, CI_NODE_PROPS.runtimePlatform, properties.runtimePlatform);
+  setComponentTextProperty(instance, CI_NODE_PROPS.runtimeService, properties.runtimeService);
+  setComponentTextProperty(instance, CI_NODE_PROPS.runtimeStartup, properties.runtimeStartup);
+  setComponentTextProperty(instance, CI_NODE_PROPS.runtimeIdentity, properties.runtimeIdentity);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSteps, properties.showSteps);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSource, properties.showSource);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showRuntime, properties.showRuntime);
   await applyTextLinks(
     instance,
     "File",
     [{ label: nodePlan.source, url: nodePlan.sourceUrl }],
     nodePlan.source
   );
+}
+
+export function ciNodePropertyValues(nodePlan: CiVisualNode) {
+  return {
+    name: nodePlan.name,
+    description: nodePlan.description,
+    steps: nodePlan.steps || "",
+    source: nodePlan.source,
+    runtimePlatform: nodePlan.runtime?.platform || "",
+    runtimeService: nodePlan.runtime?.service || "",
+    runtimeStartup: nodePlan.runtime?.startup || "",
+    runtimeIdentity: nodePlan.runtime?.identity || "",
+    showSteps: Boolean(nodePlan.steps),
+    showSource: true,
+    showRuntime: Boolean(nodePlan.runtime),
+  };
 }
 
 function layoutNodeGroups(

--- a/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -104,8 +104,13 @@ async function checkCiDocumentationContract(
   requireComponentProperty(component, CI_NODE_PROPS.description, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.steps, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.source, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.runtimePlatform, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.runtimeService, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.runtimeStartup, "TEXT");
+  requireComponentProperty(component, CI_NODE_PROPS.runtimeIdentity, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.showSteps, "BOOLEAN");
   requireComponentProperty(component, CI_NODE_PROPS.showSource, "BOOLEAN");
+  requireComponentProperty(component, CI_NODE_PROPS.showRuntime, "BOOLEAN");
   checkedComponents.push(`${component.name}:${component.id}`);
 
   const iconSet = await requireComponentSet(CI_ICON_COMPONENT_SET_ID);

--- a/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
+++ b/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
@@ -228,6 +228,7 @@ const CI_SYNC_TARGETS: SyncTargetName[] = [
   "ci.pullRequestIntegration",
   "ci.postMergeDesignDocumentation",
   "ci.infrastructureAndAccess",
+  "ci.windowsRuntime",
 ];
 
 const ALL_SYNC_TARGETS: SyncTargetName[] = [

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -3,11 +3,13 @@ import test from "node:test";
 import {
   createCiVisualPlan,
   externalEnvironment,
+  windowsRuntimeEnvironment,
 } from "../src/domain/ci/create-ci-visual-plan";
 import {
   appendConnectorLabelLayers,
   centeredRowY,
   ciConnectorMagnets,
+  ciNodePropertyValues,
   ciVisualGridPosition,
   connectorBoundsLabelPosition,
   connectorLabelLayers,
@@ -17,7 +19,7 @@ import {
   managedCiRemovalPriority,
 } from "../src/figma/figma-ci-documentation-sync-gateway";
 
-test("CI visual plan creates the four documented granular sections", () => {
+test("CI visual plan creates the five documented granular sections", () => {
   const plan = createCiVisualPlan(designModel());
 
   assert.equal(plan.parentName, "Continuous Integration and Design Documentation");
@@ -28,11 +30,12 @@ test("CI visual plan creates the four documented granular sections", () => {
       "ci.pullRequestIntegration",
       "ci.postMergeDesignDocumentation",
       "ci.infrastructureAndAccess",
+      "ci.windowsRuntime",
     ]
   );
   assert.deepEqual(
     plan.sections.map((section) => section.orientation),
-    ["horizontal", "horizontal", "horizontal", "grid"]
+    ["horizontal", "horizontal", "horizontal", "grid", "grid"]
   );
 });
 
@@ -95,6 +98,50 @@ test("CI visual plan maps node ownership to explicit icon environments", () => {
   );
 });
 
+test("CI node properties hide runtime when the visual node has no runtime data", () => {
+  const node = createCiVisualPlan(designModel()).sections[0].nodes[0];
+
+  assert.deepEqual(ciNodePropertyValues(node), {
+    name: "Pull Request",
+    description: "Proposes a reviewed change to the repository.",
+    steps: "",
+    source: "docs/ci/main-branch-protection.md",
+    runtimePlatform: "",
+    runtimeService: "",
+    runtimeStartup: "",
+    runtimeIdentity: "",
+    showSteps: false,
+    showSource: true,
+    showRuntime: false,
+  });
+});
+
+test("CI node properties expose complete runtime data", () => {
+  const node = {
+    ...createCiVisualPlan(designModel()).sections[0].nodes[0],
+    runtime: {
+      platform: "Windows",
+      service: "TeamCity",
+      startup: "Automatic",
+      identity: "NT SERVICE\\TeamCity",
+    },
+  };
+
+  assert.deepEqual(ciNodePropertyValues(node), {
+    name: "Pull Request",
+    description: "Proposes a reviewed change to the repository.",
+    steps: "",
+    source: "docs/ci/main-branch-protection.md",
+    runtimePlatform: "Windows",
+    runtimeService: "TeamCity",
+    runtimeStartup: "Automatic",
+    runtimeIdentity: "NT SERVICE\\TeamCity",
+    showSteps: false,
+    showSource: true,
+    showRuntime: true,
+  });
+});
+
 test("external CI nodes require an explicit icon environment mapping", () => {
   assert.equal(externalEnvironment("operator"), "operator");
   assert.equal(externalEnvironment("browser"), "browser");
@@ -105,6 +152,60 @@ test("external CI nodes require an explicit icon environment mapping", () => {
   assert.equal(externalEnvironment("codex-mcp-client"), "codex");
   assert.equal(externalEnvironment("figma-api"), "figma");
   assert.throws(() => externalEnvironment("unknown-system"), /no \.ci icon environment mapping/);
+});
+
+test("Windows runtime services require an explicit icon environment mapping", () => {
+  assert.equal(windowsRuntimeEnvironment("teamcity-server"), "teamcity");
+  assert.equal(windowsRuntimeEnvironment("teamcity-build-agent"), "teamcity");
+  assert.equal(windowsRuntimeEnvironment("cloudflared-agent"), "cloudflare");
+  assert.throws(() => windowsRuntimeEnvironment("unknown-service"), /no \.ci icon environment mapping/);
+});
+
+test("CI visual plan maps Windows service data to runtime node properties", () => {
+  const runtime = createCiVisualPlan(designModel()).sections
+    .find((section) => section.target === "ci.windowsRuntime")!;
+
+  assert.equal(runtime.name, "Windows Service Runtime");
+  assert.deepEqual(runtime.connections, []);
+  assert.deepEqual(
+    runtime.nodes.map((node) => ({
+      name: node.name,
+      environment: node.environment,
+      runtime: node.runtime,
+    })),
+    [
+      {
+        name: "TeamCity Server",
+        environment: "teamcity",
+        runtime: {
+          platform: "Windows",
+          service: "TeamCity",
+          startup: "Automatic",
+          identity: "NT SERVICE\\TeamCity",
+        },
+      },
+      {
+        name: "TeamCity Build Agent",
+        environment: "teamcity",
+        runtime: {
+          platform: "Windows",
+          service: "TCBuildAgent",
+          startup: "Automatic",
+          identity: "NT SERVICE\\TCBuildAgent",
+        },
+      },
+      {
+        name: "Cloudflared Agent",
+        environment: "cloudflare",
+        runtime: {
+          platform: "Windows",
+          service: "Cloudflared",
+          startup: "Automatic",
+          identity: "LocalSystem",
+        },
+      },
+    ]
+  );
 });
 
 test("CI overview labels trigger, check, gate, merge, and model verification connections", () => {
@@ -330,6 +431,35 @@ function designModel() {
           ],
           connections: [
             { id: "operator-access", source: "operator", target: "cloudflare-access", label: "Open TeamCity" },
+          ],
+        },
+        windowsRuntime: {
+          platform: "Windows",
+          services: [
+            {
+              id: "teamcity-server",
+              name: "TeamCity Server",
+              description: "Hosts TeamCity.",
+              service: "TeamCity",
+              startup: "Automatic",
+              identity: "NT SERVICE\\TeamCity",
+            },
+            {
+              id: "teamcity-build-agent",
+              name: "TeamCity Build Agent",
+              description: "Runs builds.",
+              service: "TCBuildAgent",
+              startup: "Automatic",
+              identity: "NT SERVICE\\TCBuildAgent",
+            },
+            {
+              id: "cloudflared-agent",
+              name: "Cloudflared Agent",
+              description: "Publishes TeamCity through Cloudflare Tunnel.",
+              service: "Cloudflared",
+              startup: "Automatic",
+              identity: "LocalSystem",
+            },
           ],
         },
         teamCity: {

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -107,6 +107,28 @@ test("official runner accepts preflight plus a granular CI documentation target"
   }
 });
 
+test("official runner accepts the granular Windows runtime target", async () => {
+  const workspace = createRunnerFixture();
+  try {
+    runRunner([
+      "--mode=official",
+      `--model=${workspace.modelPath}`,
+      `--script=${workspace.scriptPath}`,
+      "--targets=preflight,ci.windowsRuntime",
+      `--out-dir=${workspace.outDir}`,
+    ]);
+
+    const runDir = join(
+      workspace.outDir,
+      "official-trunk-sync-preflight-ci-windowsRuntime-png-design-model-json"
+    );
+    const manifest = readManifest(runDir);
+    assert.deepEqual(manifest.targets, ["preflight", "ci.windowsRuntime"]);
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
 test("official runner can explicitly use chunk transport fallback", async () => {
   const workspace = createRunnerFixture();
 


### PR DESCRIPTION
## What changed

- add a versioned Windows runtime inventory for TeamCity Server, TeamCity Build Agent, and Cloudflared
- include the runtime in the official Figma design model and expose the granular `ci.windowsRuntime` visual target
- bind runtime fields to the validated `.ci node` component contract
- add a non-blocking 90-day freshness check and operational documentation

## Why

The CI visual documentation described logical pipelines and external topology but did not document the Windows services that keep the local TeamCity installation and Cloudflare Tunnel running. This makes that runtime explicit, reviewable, and synchronizable from the repository source of truth.

## Validation

- `npm run build`
- `npm test` (54 tests)
- `.\gradlew.bat check` (161 tasks)
- `git diff --check`
