### PR TITLE
fix(figma-design-sync): require complete visual synchronization

### DIFF
--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -72,7 +72,7 @@ Cloudflare appears as a simplified boundary in the overview. Its policies and
 authentication paths belong in `Infrastructure and Access`.
 
 `Windows Service Runtime` is a connector-free inventory. It shows TeamCity
-Server, TeamCity Build Agent, and Cloudflared as independent service nodes with
+Server, Build Agent, and Cloudflare Tunnel as independent service nodes with
 their platform, Windows service name, startup mode, and service identity. The
 operational recovery order remains in the linked runbook and is not modeled as
 a dependency between services.

--- a/docs/ci/windows-runtime.yaml
+++ b/docs/ci/windows-runtime.yaml
@@ -14,15 +14,15 @@ services:
     startup: Automatic
     identity: NT SERVICE\TeamCity
 
-  - id: teamcity-build-agent
-    name: TeamCity Build Agent
+  - id: build-agent
+    name: Build Agent
     description: Executes repository jobs in the agent work directories.
     service: TCBuildAgent
     startup: Automatic
     identity: NT SERVICE\TCBuildAgent
 
-  - id: cloudflared-agent
-    name: Cloudflared Agent
+  - id: cloudflare-tunnel
+    name: Cloudflare Tunnel
     description: Publishes the private TeamCity origin through Cloudflare Tunnel.
     service: Cloudflared
     startup: Automatic

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -44,11 +44,11 @@ before updating its validation date.
 
 The supported local runtime uses three automatic Windows services:
 
-| Service name | Display name | Service account | Responsibility |
-|--------------|--------------|-----------------|----------------|
-| `TeamCity` | `TeamCity Server` | `NT SERVICE\TeamCity` | Hosts the TeamCity server and owns its data directory. |
-| `TCBuildAgent` | `TeamCity Build Agent` | `NT SERVICE\TCBuildAgent` | Executes repository jobs in the agent work directories. |
-| `Cloudflared` | `Cloudflared agent` | `LocalSystem` | Publishes the private TeamCity origin through Cloudflare Tunnel. |
+| CI actor | Service name | Windows display name | Service account | Responsibility |
+|----------|--------------|----------------------|-----------------|----------------|
+| TeamCity Server | `TeamCity` | `TeamCity Server` | `NT SERVICE\TeamCity` | Hosts the TeamCity server and owns its data directory. |
+| Build Agent | `TCBuildAgent` | `TeamCity Build Agent` | `NT SERVICE\TCBuildAgent` | Executes repository jobs in the agent work directories. |
+| Cloudflare Tunnel | `Cloudflared` | `Cloudflared agent` | `LocalSystem` | Publishes the private TeamCity origin through Cloudflare Tunnel. |
 
 Inspect status, startup mode, and service identity from an elevated PowerShell
 session:

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -131,13 +131,15 @@ The strict flow is:
 2. Let TeamCity generate the effective configuration from `.teamcity/settings.kts`.
 3. Let the same job generate the official `design-model.json` from those effective files.
 4. Use the official artifact as the visual sync input.
-5. Run the MCP `preflight` target when Figma component contracts changed.
-6. Run the MCP visual write step against Figma.
+5. Run the official MCP runner without a target so `preflight` and every visual
+   target execute in contractual order without writing metadata.
+6. Validate all managed sections, then run the separate `metadata` target.
 7. Verify `checkFigmaTrunkSync` so Figma metadata matches `main`.
 
 Do not create official design-model metadata from a feature branch. Branch-local
 visual iteration may reuse an official `main` artifact for layout debugging, but
-it must not publish trunk metadata.
+it must use `--allow-partial=true` for focused diagnostics and must not publish
+trunk metadata. A partial run never completes the official synchronization.
 
 The official MCP runner uses PNG payload transport by default: the generated
 runner writes `10-official-sync-payload.png`, that image is uploaded to Figma,

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -36,14 +36,14 @@ run in the Figma MCP runtime because it uses the Figma plugin API.
 To generate MCP runner snippets for an official TeamCity artifact:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json
 ```
 
 To validate the Figma visual contract before mutating visual targets, generate a
 preflight runner:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=preflight
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=preflight --allow-partial=true
 ```
 
 `preflight` reads the same official model and validates variables, component
@@ -54,12 +54,13 @@ To make a visual write fail before mutation when the visual contract is stale,
 combine `preflight` with one visual target:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --targets=preflight,waterMyPlants.libraries
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --targets=preflight,waterMyPlants.libraries --allow-partial=true
 ```
 
-The generated `99-run-target.mcp.js` executes both targets in one atomic
-`use_figma` call. Do not combine `metadata` with any other target; metadata must
-run alone after all visuals are correct.
+The generated `99-run-target.mcp.js` executes the requested diagnostic targets
+in one atomic `use_figma` call. Partial runs cannot complete an official
+integration. Do not combine `metadata` with any other target; metadata must run
+alone after the complete visual runner succeeds.
 
 Official mode defaults to `--transport=png` and writes:
 
@@ -89,7 +90,7 @@ To run only one top-level catalog root against its child section, add `--roots`
 and `--section-node-id`:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.libraries --roots=androidx --section-node-id=63069:630
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.libraries --roots=androidx --section-node-id=63069:630 --allow-partial=true
 ```
 
 Use this for large catalog targets that hit MCP timeouts or generic Figma
@@ -100,14 +101,14 @@ If the generated PNG exceeds the supported upload size or asset upload is not
 usable, regenerate with chunk transport:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --transport=chunks
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --transport=chunks
 ```
 
 If a generated chunk runner file is too large for the MCP transport, reduce the
 chunk size instead of copying the long payload manually:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --transport=chunks --chunk-size=8000
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --transport=chunks --chunk-size=8000
 ```
 
 Use [visual-preview.md](visual-preview.md) instead when testing fixture-driven
@@ -225,88 +226,16 @@ return {
 };
 ```
 
-## Run A Visual Target
+## Run The Complete Visual Sync
 
-Run visual updates by granular target. Do not run `metadata` until every visual
-target has completed successfully.
+Execute the generated `99-run-target.mcp.js` without editing its target list.
+The official runner contains `preflight` followed by every visual target from
+[target-scopes.md](target-scopes.md), with `writeMetadata=false`.
 
-Reusable MCP target runner:
-
-```javascript
-const page = await figma.getNodeByIdAsync("62934:908");
-
-if (!page || page.type !== "PAGE") {
-  throw new Error("Expected sync page 62934:908 to be a PAGE");
-}
-
-const stagingNamespace = "water_my_plants_sync_staging";
-const stagedModelJson = page.getSharedPluginData(stagingNamespace, "designModelJson");
-const scriptBase64 = page.getSharedPluginData(stagingNamespace, "scriptBase64");
-
-if (!stagedModelJson || !scriptBase64) {
-  throw new Error("Missing staged model or script.");
-}
-
-const stagedModel = JSON.parse(stagedModelJson);
-const stagedModelHash = page.getSharedPluginData(stagingNamespace, "designModelHash");
-const stagedModelGitSha = page.getSharedPluginData(stagingNamespace, "designModelGitSha");
-const stagedModelLength = page.getSharedPluginData(stagingNamespace, "designModelLength");
-const scriptLength = page.getSharedPluginData(stagingNamespace, "scriptLength");
-const scriptBase64Length = page.getSharedPluginData(stagingNamespace, "scriptBase64Length");
-
-const requiredStagingValues = {
-  designModelHash: stagedModelHash,
-  designModelGitSha: stagedModelGitSha,
-  designModelLength: stagedModelLength,
-  scriptLength,
-  scriptBase64Length
-};
-
-for (const [key, value] of Object.entries(requiredStagingValues)) {
-  if (!value) {
-    throw new Error(`Missing staged ${key}.`);
-  }
-}
-
-if (stagedModelHash !== stagedModel.modelHash) {
-  throw new Error(`Staged modelHash mismatch: ${stagedModelHash} != ${stagedModel.modelHash}`);
-}
-
-if (stagedModelGitSha !== stagedModel.gitSha) {
-  throw new Error(`Staged gitSha mismatch: ${stagedModelGitSha} != ${stagedModel.gitSha}`);
-}
-
-if (Number(stagedModelLength) !== stagedModelJson.length) {
-  throw new Error(`Staged model length mismatch: ${stagedModelLength} != ${stagedModelJson.length}`);
-}
-
-if (Number(scriptBase64Length) !== scriptBase64.length) {
-  throw new Error(`Staged script length mismatch: ${scriptBase64Length} != ${scriptBase64.length}`);
-}
-
-let script = atob(scriptBase64);
-
-if (Number(scriptLength) !== script.length) {
-  throw new Error(`Decoded script length mismatch: ${scriptLength} != ${script.length}`);
-}
-
-script = script.replace(
-  "const DESIGN_MODEL = undefined;",
-  "const DESIGN_MODEL = stagedModel;"
-);
-script = script.replace(
-  "const SYNC_OPTIONS = undefined;",
-  "const SYNC_OPTIONS = {\"targets\":[\"TARGET_NAME\"],\"writeMetadata\":false};"
-);
-
-const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
-const run = new AsyncFunction("figma", "stagedModel", script);
-
-return await run(figma, stagedModel);
-```
-
-Replace `TARGET_NAME` with a granular target from
-[target-scopes.md](target-scopes.md).
+If a focused diagnostic is necessary, regenerate the runner with the target
+and `--allow-partial=true`. A partial runner may confirm a repair, but it cannot
+authorize metadata. Regenerate and execute the complete runner before closing
+the official synchronization.
 
 ## Write Metadata
 

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -41,8 +41,9 @@ behavior, layout, resize rules, spacing, or instance selection.
 
 Do not rerun TeamCity only to regenerate the JSON for those visual-only changes.
 Keep the official artifact as the stable input, build the MCP bundle from the
-branch, run only visual targets, and do not write official metadata from the
-branch.
+branch, and use `--allow-partial=true` only for focused visual diagnosis. Do not
+write official metadata from the branch. After merging the tooling change, the
+official integration must rerun the complete visual target set.
 
 Regenerate through TeamCity on `main` when the change affects model content:
 catalog extraction, module or plugin paths, usage data such as

--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -2,8 +2,9 @@
 
 ## Purpose
 
-Use this runbook to choose the smallest visual target that covers the Figma
-section being changed. Prefer granular target execution over broad reruns.
+Use this runbook to understand the ordered visual targets in the Figma model.
+An official integration always synchronizes the complete visual target set.
+Granular targets are reserved for supervised diagnosis and repair.
 
 ## Included Builds
 
@@ -45,21 +46,29 @@ CI documentation visual targets:
 | `ci.windowsRuntime` | `docs/ci/windows-runtime.yaml` | `Windows Service Runtime` inside page `63153:2876` |
 
 The five targets share the parent section `Continuous Integration and Design
-Documentation`. Run one target at a time while iterating; the writer reuses the
-parent and only replaces nodes and connectors managed by the requested child
-section.
+Documentation`. A diagnostic target reuses the parent and only replaces nodes
+and connectors managed by the requested child section, but it does not complete
+an official integration.
 
 ## Execution Order
 
-Run visual updates by granular target. Do not run `metadata` until every visual
-target has completed successfully. Run `preflight` first when the Figma
-component contract has changed, when a previous visual write failed before
-metadata, or before a full official sync after component edits.
-
-For a single visual target, prefer an atomic preflight-and-write runner:
+Generate the complete official visual runner by omitting `--target`, or by
+passing `--target=all`. It executes `preflight` followed by every visual target
+in the order below and never writes metadata:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --targets=preflight,waterMyPlants.libraries
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json
+```
+
+Do not run `metadata` until that complete visual execution has succeeded and
+all affected sections have been checked. Then generate a separate metadata
+runner.
+
+For supervised diagnosis only, an official-artifact runner may select one
+target by explicitly acknowledging that it is partial:
+
+```powershell
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --targets=preflight,waterMyPlants.libraries --allow-partial=true
 ```
 
 For an atomic granular runner, `completedTargets` is expected to contain both
@@ -71,10 +80,11 @@ For an atomic granular runner, `completedTargets` is expected to contain both
 ```
 
 Do not reject a runner because `preflight` appears alongside the visual target.
-Generate `--target=preflight` only when no visual mutation is intended.
+Generate `--target=preflight --allow-partial=true` only when no visual mutation
+is intended.
 
-If the preflight fails, the visual target is not executed. Use `--target=preflight`
-alone when you only want to inspect the contract without changing visuals.
+If the preflight fails, visual targets are not executed. A partial preflight or
+repair can diagnose the issue, but the complete runner must pass afterward.
 
 | Order | Target | Scope | Typical failure | Quick check |
 |-------|--------|-------|-----------------|-------------|
@@ -93,7 +103,7 @@ alone when you only want to inspect the contract without changing visuals.
 | 12 | `ci.pullRequestIntegration` | Detailed PR pipeline, jobs, checks, and merge gate | Effective TeamCity job or published check missing from Figma | Nodes and summarized steps match `content.ci.teamCity`. |
 | 13 | `ci.postMergeDesignDocumentation` | Official model generation and operator-assisted visual update loop | Automatic Figma write implied, artifact missing, or rerun loop absent | `design-model.json`, the operator/Codex handoff, and `Rerun via HTTPS client` are visible. |
 | 14 | `ci.infrastructureAndAccess` | GitHub, Cloudflare, TeamCity, Figma, browser, CLI, and operator topology | Connection collapsed or external system duplicated from TeamCity DSL | Nodes and directed connections match `content.ci.externalTopology`. |
-| 15 | `ci.windowsRuntime` | TeamCity Server, TeamCity Build Agent, and Cloudflared Windows services | Runtime block hidden, stale service identity, or incorrect icon environment | Three nodes match `content.ci.windowsRuntime`, expose complete runtime fields, and have no inferred connectors. |
+| 15 | `ci.windowsRuntime` | TeamCity Server, Build Agent, and Cloudflare Tunnel Windows services | Runtime block hidden, stale service identity, or incorrect icon environment | Three nodes match `content.ci.windowsRuntime`, expose complete runtime fields, and have no inferred connectors. |
 | 16 | `metadata` | Shared plugin sync metadata | Metadata written before visual targets complete | Figma shared plugin data matches the TeamCity artifact. |
 
 ## Subtree Scoped Runs
@@ -105,7 +115,7 @@ section and filter the TeamCity model with `--roots`.
 ```powershell
 cd repo\figma-design-sync\tools
 npm run build
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.libraries --roots=androidx --section-node-id=63069:630
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.libraries --roots=androidx --section-node-id=63069:630 --allow-partial=true
 ```
 
 `--roots` filters only top-level catalog roots before the tree is flattened.
@@ -139,7 +149,8 @@ not a different source of truth.
 
 ## Failure Rule
 
-When a target fails, fix that target's component or TypeScript contract, merge
-the fix to `main`, regenerate the official TeamCity artifact when model content
-changes, and resume from the failed target. Do not repeat already-successful
-targets unless the fix changes their source data or shared component contract.
+When a target fails, use a partial runner only to diagnose and verify the local
+repair. Fix the component or TypeScript contract, merge the fix to `main`, and
+regenerate the official TeamCity artifact when model content changes. Before
+writing metadata, rerun the complete official visual target set from
+`preflight`; a successful partial repair never closes the integration.

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -90,14 +90,14 @@ uploaded to Figma and that `10-stage-payload-from-png.mcp.js` completed. If PNG
 asset upload is blocked, regenerate with chunk transport:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --transport=chunks
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --transport=chunks
 ```
 
 If a chunk call is too large and never reaches Figma, regenerate the chunk
 runner with a smaller chunk size and rerun the files in lexical order:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --transport=chunks --chunk-size=8000
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --transport=chunks --chunk-size=8000
 ```
 
 For chunk transport, stage base64 chunks in temporary shared plugin data:
@@ -125,7 +125,7 @@ visual preview runner files:
 ```powershell
 cd repo\figma-design-sync\tools
 npm run build
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins --allow-partial=true
 node dist\write-mcp-runner.mjs --mode=preview --entrypoint=preview-catalog --fixture=catalog-tree --target=waterMyPlants.plugins --section-node-id=SANDBOX_SECTION_ID
 ```
 

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -13,7 +13,7 @@ fine-grained runbooks:
 |---------|------------|
 | [official-artifact-visual-sync.md](official-artifact-visual-sync.md) | Choosing and validating the TeamCity `design-model.json` artifact, and deciding whether branch-local visual iteration is allowed. |
 | [mcp-chunk-transport.md](mcp-chunk-transport.md) | Building the MCP bundle, staging official payloads through PNG or chunk fallback, running targets, and writing metadata. |
-| [target-scopes.md](target-scopes.md) | Choosing the granular visual target and understanding its Figma section. |
+| [target-scopes.md](target-scopes.md) | Understanding the complete target order and choosing partial diagnostic scopes. |
 | [visual-sync-contract.md](visual-sync-contract.md) | Validating the expected Figma component, connector, layout, and locking behavior. |
 | [troubleshooting.md](troubleshooting.md) | Diagnosing failed or visually incorrect sync runs. |
 
@@ -72,20 +72,17 @@ intentionally non-authoritative and must not write official metadata.
 5. Stage the official model and generated MCP script through the PNG payload
    transport, or the chunk fallback when needed, using the process
    documented in [mcp-chunk-transport.md](mcp-chunk-transport.md).
-6. Run the `preflight` target when component contracts changed or before a full
-   official visual sync. It must validate the Figma contract without mutating
-   nodes.
-7. Run visual targets one by one using the order in
-   [target-scopes.md](target-scopes.md). Keep `writeMetadata=false` for visual
-   targets.
-8. Check each changed Figma section against
+6. Generate and run the complete official visual runner without specifying a
+   target. It executes `preflight` and every visual target in the order defined
+   by [target-scopes.md](target-scopes.md), with `writeMetadata=false`.
+7. Check every managed Figma section against
    [visual-sync-contract.md](visual-sync-contract.md).
-9. After all visual targets are correct, run only the `metadata` target with
+8. After all visual targets are correct, run only the `metadata` target with
    `writeMetadata=true`.
-10. Optionally rerun only TeamCity `Check Figma trunk sync`, or run
+9. Optionally rerun only TeamCity `Check Figma trunk sync`, or run
     `checkFigmaTrunkSync` locally, as an early diagnostic after writing
     metadata.
-11. Rerun the complete TeamCity `Figma Sync` pipeline with
+10. Rerun the complete TeamCity `Figma Sync` pipeline with
     `pwsh -File tools/teamcity/invoke-figma-sync-rerun.ps1 -Wait`. Confirm that
     `Generate main design model`, `Check Figma trunk sync`, and the aggregate
     pipeline all succeed so TeamCity publishes a successful final status.
@@ -109,9 +106,9 @@ When a visual target fails:
 - Merge the fix to `main` if it affects generated model content or the official
   sync code used by TeamCity.
 - Regenerate the official TeamCity artifact when model content changes.
-- Resume from the failed target.
-- Do not repeat already-successful targets unless the fix changes their source
-  data or shared component contract.
+- Use `--allow-partial=true` only to diagnose or verify the focused repair.
+- Rerun the complete visual target set before writing metadata; partial success
+  does not complete an official synchronization.
 
 Branch-local visual iteration with an already-official artifact is allowed only
 for visual representation changes. The rules are in

--- a/repo/figma-design-sync/docs/runbooks/visual-preview.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-preview.md
@@ -161,13 +161,15 @@ artifact. Official mode defaults to PNG payload transport, and the source model
 must be the artifact from `Figma Sync > Generate main design model`:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.plugins
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json
 node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=metadata
 ```
 
 Official mode stages data under `water_my_plants_sync_staging`. Only the
 `metadata` target writes to the authoritative namespace, and it should be run
-after all visual targets have completed successfully.
+after the complete visual target set has completed successfully. Add
+`--allow-partial=true` only for supervised diagnosis; partial runs do not
+authorize a metadata write.
 
 ## Verification
 

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -40,6 +40,8 @@ const KNOWN_TARGETS = [
   "metadata",
 ];
 
+const FULL_VISUAL_TARGETS = KNOWN_TARGETS.filter((target) => target !== "metadata");
+
 const CATALOG_TARGETS = [
   "waterMyPlants.libraries",
   "waterMyPlants.plugins",
@@ -108,6 +110,7 @@ function readNpmConfigArgs() {
     "section-node-id": "npm_config_section_node_id",
     roots: "npm_config_roots",
     "allow-official-sections": "npm_config_allow_official_sections",
+    "allow-partial": "npm_config_allow_partial",
   };
   const values = {};
 
@@ -145,11 +148,13 @@ function resolveOptions(args) {
   }
 
   const fixture = args.fixture || (mode === "preview" && !args.model ? "catalog-tree" : undefined);
-  const targetValue = args.targets || args.target || (fixture ? DEFAULT_FIXTURE_TARGETS[fixture] : undefined);
+  const targetValue = args.targets || args.target || (fixture
+    ? DEFAULT_FIXTURE_TARGETS[fixture]
+    : mode === "official" ? "all" : undefined);
   if (!targetValue) {
     throw new Error("Missing --target. Preview fixtures can infer a default target.");
   }
-  const targets = parseTargets(targetValue);
+  const targets = targetValue === "all" ? [...FULL_VISUAL_TARGETS] : parseTargets(targetValue);
   if (targets.length === 0) {
     throw new Error("Missing --target.");
   }
@@ -162,6 +167,14 @@ function resolveOptions(args) {
   }
   if (targets.includes("metadata") && targets.length > 1) {
     throw new Error("The metadata target must run alone after every visual target is correct.");
+  }
+  const fullVisualSync = sameTargets(targets, FULL_VISUAL_TARGETS);
+  const allowPartial = args["allow-partial"] === "true";
+  if (mode === "official" && !fullVisualSync && targets[0] !== "metadata" && !allowPartial) {
+    throw new Error(
+      "Official visual sync must target the complete visual model. " +
+        "Omit --target or use --target=all. Use --allow-partial=true only for supervised diagnosis or repair."
+    );
   }
   const target = targets[0];
   if (mode === "preview" && targets.includes("metadata")) {
@@ -255,6 +268,8 @@ function resolveOptions(args) {
     sectionNodeId,
     roots,
     allowOfficialSections,
+    allowPartial,
+    fullVisualSync,
   };
 }
 
@@ -266,7 +281,8 @@ async function writeRunnerFiles(options) {
   validateDesignModel(designModel, options);
 
   const scriptBase64 = Buffer.from(script, "utf8").toString("base64");
-  const runDirName = `${options.mode}-${safeName(options.entrypoint)}-${safeName(options.targets.join("-"))}-${safeName(options.transport)}-${safeName(basename(options.modelPath, ".design-model.json"))}`;
+  const targetRunName = options.fullVisualSync ? "all-visual" : options.targets.join("-");
+  const runDirName = `${options.mode}-${safeName(options.entrypoint)}-${safeName(targetRunName)}-${safeName(options.transport)}-${safeName(basename(options.modelPath, ".design-model.json"))}`;
   const outDir = join(options.outRoot, runDirName);
   const files = [];
   let payloadImage = null;
@@ -363,6 +379,8 @@ async function writeManifest(outDir, files, options, designModel, modelJson, scr
         sectionNodeId: options.sectionNodeId || null,
         roots: options.roots,
         allowOfficialSections: options.allowOfficialSections,
+        allowPartial: options.allowPartial,
+        fullVisualSync: options.fullVisualSync,
         metadataPageId: METADATA_PAGE_ID,
         modelPath: relativeToToolRoot(options.modelPath),
         scriptPath: relativeToToolRoot(options.scriptPath),
@@ -869,6 +887,10 @@ function parseTargets(value) {
       .map((target) => target.trim())
       .filter(Boolean)
   )];
+}
+
+function sameTargets(actual, expected) {
+  return actual.length === expected.length && actual.every((target, index) => target === expected[index]);
 }
 
 function safeName(value) {

--- a/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
+++ b/repo/figma-design-sync/tools/src/domain/ci/create-ci-visual-plan.ts
@@ -370,8 +370,8 @@ export function externalEnvironment(id: string): CiVisualEnvironment {
 export function windowsRuntimeEnvironment(id: string): CiVisualEnvironment {
   const environments: Record<string, CiVisualEnvironment> = {
     "teamcity-server": "teamcity",
-    "teamcity-build-agent": "teamcity",
-    "cloudflared-agent": "cloudflare",
+    "build-agent": "teamcity",
+    "cloudflare-tunnel": "cloudflare",
   };
   const environment = environments[id];
   if (!environment) throw new Error(`Windows CI runtime service '${id}' has no .ci icon environment mapping.`);

--- a/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
+++ b/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
@@ -28,9 +28,15 @@ export async function syncFigmaDesignModel(
   requireMainBranchDesignModel(designModel);
 
   const requestedTargets = resolveRequestedTargets(options);
+  const shouldWriteMetadata = requestedTargets.has("metadata") || options.writeMetadata === true;
+  if (shouldWriteMetadata && requestedTargets.size > 1) {
+    throw new Error("Figma sync metadata must run alone after the complete visual sync.");
+  }
   const completedTargets: SyncTargetName[] = [];
   const skippedTargets = ALL_SYNC_TARGETS.filter((target) => !requestedTargets.has(target));
-  const visualTargets = [...requestedTargets].filter((target) => target !== "preflight");
+  const visualTargets = [...requestedTargets].filter(
+    (target) => target !== "preflight" && target !== "metadata"
+  );
   const preflightResult = requestedTargets.has("preflight")
     ? await dependencies.visualContractCheckGateway.checkVisualContract(
         designModel,
@@ -78,7 +84,6 @@ export async function syncFigmaDesignModel(
     : emptyCiDocumentationSyncResult();
   completedTargets.push(...ciTargets);
 
-  const shouldWriteMetadata = requestedTargets.has("metadata") || options.writeMetadata === true;
   const metadataSyncResult = shouldWriteMetadata
     ? await dependencies.metadataSyncGateway.writeMetadata(designModel)
     : emptyMetadataSyncResult();
@@ -134,7 +139,7 @@ function resolveRequestedTargets(options: SyncFigmaDesignModelOptions) {
   const requestedTargets = new Set<SyncTargetName>(
     options.targets && options.targets.length > 0
       ? options.targets.map(canonicalTargetName)
-      : ALL_SYNC_TARGETS
+      : FULL_VISUAL_SYNC_TARGETS
   );
   const unknownTargets = (options.targets || []).filter((target) =>
     !KNOWN_SYNC_TARGETS.includes(target)
@@ -208,10 +213,6 @@ function emptyVisualContractCheckResult() {
   };
 }
 
-const PREFLIGHT_SYNC_TARGETS: SyncTargetName[] = [
-  "preflight",
-];
-
 const CATALOG_SYNC_TARGETS: SyncTargetName[] = [
   "waterMyPlants.libraries",
   "waterMyPlants.plugins",
@@ -231,17 +232,25 @@ const CI_SYNC_TARGETS: SyncTargetName[] = [
   "ci.windowsRuntime",
 ];
 
-const ALL_SYNC_TARGETS: SyncTargetName[] = [
+const VISUAL_SYNC_TARGETS: SyncTargetName[] = [
   "headers",
   "versions",
   ...CATALOG_SYNC_TARGETS,
   ...CI_SYNC_TARGETS,
+];
+
+const FULL_VISUAL_SYNC_TARGETS: SyncTargetName[] = [
+  "preflight",
+  ...VISUAL_SYNC_TARGETS,
+];
+
+const ALL_SYNC_TARGETS: SyncTargetName[] = [
+  ...FULL_VISUAL_SYNC_TARGETS,
   "metadata",
 ];
 
 const TARGET_ALIASES: Partial<Record<SyncTargetName, SyncTargetName>> = {};
 
 const KNOWN_SYNC_TARGETS: SyncTargetName[] = [
-  ...PREFLIGHT_SYNC_TARGETS,
   ...ALL_SYNC_TARGETS,
 ];

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -156,8 +156,8 @@ test("external CI nodes require an explicit icon environment mapping", () => {
 
 test("Windows runtime services require an explicit icon environment mapping", () => {
   assert.equal(windowsRuntimeEnvironment("teamcity-server"), "teamcity");
-  assert.equal(windowsRuntimeEnvironment("teamcity-build-agent"), "teamcity");
-  assert.equal(windowsRuntimeEnvironment("cloudflared-agent"), "cloudflare");
+  assert.equal(windowsRuntimeEnvironment("build-agent"), "teamcity");
+  assert.equal(windowsRuntimeEnvironment("cloudflare-tunnel"), "cloudflare");
   assert.throws(() => windowsRuntimeEnvironment("unknown-service"), /no \.ci icon environment mapping/);
 });
 
@@ -185,7 +185,7 @@ test("CI visual plan maps Windows service data to runtime node properties", () =
         },
       },
       {
-        name: "TeamCity Build Agent",
+        name: "Build Agent",
         environment: "teamcity",
         runtime: {
           platform: "Windows",
@@ -195,7 +195,7 @@ test("CI visual plan maps Windows service data to runtime node properties", () =
         },
       },
       {
-        name: "Cloudflared Agent",
+        name: "Cloudflare Tunnel",
         environment: "cloudflare",
         runtime: {
           platform: "Windows",
@@ -445,16 +445,16 @@ function designModel() {
               identity: "NT SERVICE\\TeamCity",
             },
             {
-              id: "teamcity-build-agent",
-              name: "TeamCity Build Agent",
+              id: "build-agent",
+              name: "Build Agent",
               description: "Runs builds.",
               service: "TCBuildAgent",
               startup: "Automatic",
               identity: "NT SERVICE\\TCBuildAgent",
             },
             {
-              id: "cloudflared-agent",
-              name: "Cloudflared Agent",
+              id: "cloudflare-tunnel",
+              name: "Cloudflare Tunnel",
               description: "Publishes TeamCity through Cloudflare Tunnel.",
               service: "Cloudflared",
               startup: "Automatic",

--- a/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
+++ b/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
@@ -2,6 +2,60 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { syncFigmaDesignModel } from "../src/usecases/sync-figma-design-model";
 
+const FULL_VISUAL_TARGETS = [
+  "preflight",
+  "headers",
+  "versions",
+  "waterMyPlants.libraries",
+  "waterMyPlants.plugins",
+  "waterMyPlants.customGradleConventionPlugins",
+  "waterMyPlants.customGradlePlugins",
+  "gradlePlugins.libraries",
+  "gradlePlugins.plugins",
+  "figmaDesignSync.libraries",
+  "figmaDesignSync.plugins",
+  "ci.overview",
+  "ci.pullRequestIntegration",
+  "ci.postMergeDesignDocumentation",
+  "ci.infrastructureAndAccess",
+  "ci.windowsRuntime",
+];
+
+test("default sync executes the complete visual contract without metadata", async () => {
+  const calls: string[] = [];
+
+  const result = await syncFigmaDesignModel(mainDesignModel(), fakeDependencies(calls));
+
+  assert.deepEqual(calls, ["preflight", "headers", "versions", "catalog", "ci"]);
+  assert.deepEqual(result.requestedTargets, FULL_VISUAL_TARGETS);
+  assert.deepEqual(result.completedTargets, FULL_VISUAL_TARGETS);
+  assert.equal(result.metadata, null);
+});
+
+test("metadata must be requested independently from visual targets", async () => {
+  const calls: string[] = [];
+
+  await assert.rejects(
+    syncFigmaDesignModel(mainDesignModel(), fakeDependencies(calls), {
+      targets: ["preflight", "metadata"],
+    }),
+    /metadata must run alone/
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("metadata writes after being requested as the only target", async () => {
+  const calls: string[] = [];
+
+  const result = await syncFigmaDesignModel(mainDesignModel(), fakeDependencies(calls), {
+    targets: ["metadata"],
+  });
+
+  assert.deepEqual(calls, ["metadata"]);
+  assert.deepEqual(result.completedTargets, ["metadata"]);
+  assert.equal(result.metadata.modelHash, "hash");
+});
+
 test("preflight target validates the visual contract without mutating visual targets", async () => {
   const calls: string[] = [];
   const dependencies = fakeDependencies(calls);

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -8,7 +8,99 @@ import test from "node:test";
 
 const runnerPath = join(process.cwd(), "dist", "write-mcp-runner.mjs");
 
-test("official runner defaults to PNG transport and supports atomic preflight plus visual target", async () => {
+const FULL_VISUAL_TARGETS = [
+  "preflight",
+  "headers",
+  "versions",
+  "waterMyPlants.libraries",
+  "waterMyPlants.plugins",
+  "waterMyPlants.customGradleConventionPlugins",
+  "waterMyPlants.customGradlePlugins",
+  "gradlePlugins.libraries",
+  "gradlePlugins.plugins",
+  "figmaDesignSync.libraries",
+  "figmaDesignSync.plugins",
+  "ci.overview",
+  "ci.pullRequestIntegration",
+  "ci.postMergeDesignDocumentation",
+  "ci.infrastructureAndAccess",
+  "ci.windowsRuntime",
+];
+
+test("official runner defaults to the complete visual sync without metadata", async () => {
+  const workspace = createRunnerFixture();
+
+  try {
+    runRunner([
+      "--mode=official",
+      `--model=${workspace.modelPath}`,
+      `--script=${workspace.scriptPath}`,
+      `--out-dir=${workspace.outDir}`,
+    ]);
+
+    const runDir = join(
+      workspace.outDir,
+      "official-trunk-sync-all-visual-png-design-model-json"
+    );
+    const manifest = readManifest(runDir);
+    const runTargetSource = readFileSync(join(runDir, "99-run-target.mcp.js"), "utf8");
+
+    assert.deepEqual(manifest.targets, FULL_VISUAL_TARGETS);
+    assert.equal(manifest.fullVisualSync, true);
+    assert.equal(manifest.allowPartial, false);
+    assert.equal(manifest.writeMetadata, false);
+    assert.match(runTargetSource, /"targets":\["preflight","headers","versions"/);
+    assert.doesNotMatch(runTargetSource, /writeMetadata":true/);
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
+test("official all alias selects the same complete visual target set", async () => {
+  const workspace = createRunnerFixture();
+
+  try {
+    runRunner([
+      "--mode=official",
+      `--model=${workspace.modelPath}`,
+      `--script=${workspace.scriptPath}`,
+      "--target=all",
+      `--out-dir=${workspace.outDir}`,
+    ]);
+
+    const runDir = join(
+      workspace.outDir,
+      "official-trunk-sync-all-visual-png-design-model-json"
+    );
+    const manifest = readManifest(runDir);
+
+    assert.deepEqual(manifest.targets, FULL_VISUAL_TARGETS);
+    assert.equal(manifest.fullVisualSync, true);
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
+test("official runner requires an explicit override for partial visual diagnosis", async () => {
+  const workspace = createRunnerFixture();
+
+  try {
+    assert.throws(
+      () => runRunner([
+        "--mode=official",
+        `--model=${workspace.modelPath}`,
+        `--script=${workspace.scriptPath}`,
+        "--targets=preflight,waterMyPlants.libraries",
+        `--out-dir=${workspace.outDir}`,
+      ]),
+      /must target the complete visual model/
+    );
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
+test("official runner supports an explicitly partial diagnostic target", async () => {
   const workspace = createRunnerFixture();
 
   try {
@@ -17,6 +109,7 @@ test("official runner defaults to PNG transport and supports atomic preflight pl
       `--model=${workspace.modelPath}`,
       `--script=${workspace.scriptPath}`,
       "--targets=preflight,waterMyPlants.libraries",
+      "--allow-partial=true",
       `--out-dir=${workspace.outDir}`,
     ]);
 
@@ -30,6 +123,8 @@ test("official runner defaults to PNG transport and supports atomic preflight pl
     assert.equal(manifest.transport, "png");
     assert.deepEqual(manifest.targets, ["preflight", "waterMyPlants.libraries"]);
     assert.equal(manifest.writeMetadata, false);
+    assert.equal(manifest.fullVisualSync, false);
+    assert.equal(manifest.allowPartial, true);
     assert.equal(manifest.payloadImage.fileName, "10-official-sync-payload.png");
     assert.deepEqual(
       manifest.files,
@@ -77,6 +172,7 @@ test("official runner accepts preflight plus the granular headers target", async
       `--model=${workspace.modelPath}`,
       `--script=${workspace.scriptPath}`,
       "--targets=preflight,headers",
+      "--allow-partial=true",
       `--out-dir=${workspace.outDir}`,
     ]);
 
@@ -96,6 +192,7 @@ test("official runner accepts preflight plus a granular CI documentation target"
       `--model=${workspace.modelPath}`,
       `--script=${workspace.scriptPath}`,
       "--targets=preflight,ci.overview",
+      "--allow-partial=true",
       `--out-dir=${workspace.outDir}`,
     ]);
 
@@ -115,6 +212,7 @@ test("official runner accepts the granular Windows runtime target", async () => 
       `--model=${workspace.modelPath}`,
       `--script=${workspace.scriptPath}`,
       "--targets=preflight,ci.windowsRuntime",
+      "--allow-partial=true",
       `--out-dir=${workspace.outDir}`,
     ]);
 
@@ -138,6 +236,7 @@ test("official runner can explicitly use chunk transport fallback", async () => 
       `--model=${workspace.modelPath}`,
       `--script=${workspace.scriptPath}`,
       "--target=preflight",
+      "--allow-partial=true",
       "--transport=chunks",
       "--chunk-size=1000",
       `--out-dir=${workspace.outDir}`,


### PR DESCRIPTION
## What changed

- make official MCP runs synchronize preflight and every visual target by default
- require `--allow-partial=true` for focused diagnostics and keep metadata isolated
- align Windows runtime actor names across the CI topology and Figma model
- update the human workflow and troubleshooting runbooks

## Why

A granular visual run could leave unrelated Figma sections stale while metadata made the model appear synchronized. Official integration now has one complete visual contract; partial runs remain available only for supervised diagnosis.

## Verification

- `npm test`
- `npm run build`
- `.\gradlew.bat check`
- `git diff --check`