### PR TITLE
fix(figma-design-sync): split complete sync into bounded MCP calls

### DIFF
--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -144,7 +144,9 @@ trunk metadata. A partial run never completes the official synchronization.
 The official MCP runner uses PNG payload transport by default: the generated
 runner writes `10-official-sync-payload.png`, that image is uploaded to Figma,
 and the staging runner extracts and validates the model plus MCP script before
-running visual targets. Chunked staging remains a fallback for oversized or
+running each visual target in a separate, lexically ordered MCP call. This
+keeps the complete synchronization mandatory without exceeding the MCP timeout
+with one monolithic call. Chunked staging remains a fallback for oversized or
 blocked asset uploads.
 
 ## Human Workflow

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -68,13 +68,15 @@ Official mode defaults to `--transport=png` and writes:
 - `00-clear-staging.mcp.js`
 - `10-stage-payload-from-png.mcp.js`
 - `90-finalize-staging.mcp.js`
-- `99-run-target.mcp.js`
+- `99-00-preflight.mcp.js` through the final ordered visual target runner
 - `manifest.json`
 
 Upload `10-official-sync-payload.png` to the Figma file before running
-`10-stage-payload-from-png.mcp.js`. Then run the generated `.mcp.js` snippets in
-lexical order. The PNG asset is a transport artifact only; the staging runner
-removes the uploaded image node after extracting the payload.
+`10-stage-payload-from-png.mcp.js`. Then run every generated `.mcp.js` snippet
+in lexical order. Full official runners use one `99-*.mcp.js` call per target
+so no individual MCP call must reconcile the complete document. The PNG asset
+is a transport artifact only; the staging runner removes the uploaded image
+node after extracting the payload.
 
 `upload_assets` returns a single-use URL under `https://mcp.figma.com`. Upload
 the PNG as multipart form data with an explicit `image/png` content type.
@@ -142,8 +144,8 @@ The staging namespace is not authoritative state. It is a transport mechanism
 for the current sync run. The authoritative namespace remains
 `water_my_plants_sync`, and only the final `metadata` target writes to it.
 
-Staging may be reused across consecutive granular `99-run-target.mcp.js`
-executions only when all of these values remain identical:
+Staging is reused across consecutive `99-*.mcp.js` target executions only when
+all of these values remain identical:
 
 - `designModelHash`;
 - `designModelGitSha`;
@@ -203,7 +205,7 @@ full runner from `00-clear-staging.mcp.js`.
 Before diagnosing a visual no-op as a model or component bug, confirm that the
 official payload was actually staged. A common interrupted-sync symptom is
 `designModelJson.length = 0` in `water_my_plants_sync_staging`, which means
-`99-run-target.mcp.js` has no model to apply:
+the first `99-*.mcp.js` target runner has no model to apply:
 
 ```javascript
 const page = await figma.getNodeByIdAsync("62934:908");
@@ -228,9 +230,10 @@ return {
 
 ## Run The Complete Visual Sync
 
-Execute the generated `99-run-target.mcp.js` without editing its target list.
-The official runner contains `preflight` followed by every visual target from
-[target-scopes.md](target-scopes.md), with `writeMetadata=false`.
+Execute every generated `99-*.mcp.js` file in lexical order without editing its
+target. The official runner contains one bounded MCP call for `preflight` and
+one for every visual target from [target-scopes.md](target-scopes.md), all with
+`writeMetadata=false`.
 
 If a focused diagnostic is necessary, regenerate the runner with the target
 and `--allow-partial=true`. A partial runner may confirm a repair, but it cannot

--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -53,8 +53,8 @@ an official integration.
 ## Execution Order
 
 Generate the complete official visual runner by omitting `--target`, or by
-passing `--target=all`. It executes `preflight` followed by every visual target
-in the order below and never writes metadata:
+passing `--target=all`. It creates one bounded MCP runner file for `preflight`
+and each visual target in the order below, and never writes metadata:
 
 ```powershell
 node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -72,9 +72,10 @@ intentionally non-authoritative and must not write official metadata.
 5. Stage the official model and generated MCP script through the PNG payload
    transport, or the chunk fallback when needed, using the process
    documented in [mcp-chunk-transport.md](mcp-chunk-transport.md).
-6. Generate and run the complete official visual runner without specifying a
-   target. It executes `preflight` and every visual target in the order defined
-   by [target-scopes.md](target-scopes.md), with `writeMetadata=false`.
+6. Generate the complete official visual runner without specifying a target,
+   then execute every generated MCP file in lexical order. The sequence runs
+   `preflight` and every visual target as bounded calls in the order defined by
+   [target-scopes.md](target-scopes.md), with `writeMetadata=false`.
 7. Check every managed Figma section against
    [visual-sync-contract.md](visual-sync-contract.md).
 8. After all visual targets are correct, run only the `metadata` target with

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -327,14 +327,28 @@ async function writeRunnerFiles(options) {
   }
 
   files.push(await writeFileIn(outDir, "90-finalize-staging.mcp.js", finalizeStagingSource(options, designModel, minifiedModelJson, script, scriptBase64)));
-  files.push(await writeFileIn(outDir, "99-run-target.mcp.js", runTargetSource(options)));
+  files.push(...await writeTargetRunnerFiles(outDir, options));
   files.push(await writeManifest(outDir, files, options, designModel, minifiedModelJson, script, scriptBase64, payloadImage));
 
   console.log(`Wrote ${files.length} MCP runner files to ${outDir}`);
   if (payloadImage) {
     console.log(`Upload ${PAYLOAD_PNG_FILE_NAME} to Figma before running 10-stage-payload-from-png.mcp.js.`);
   }
-  console.log(`Run them in lexical order, ending with 99-run-target.mcp.js.`);
+  console.log("Run every generated .mcp.js file in lexical order.");
+}
+
+async function writeTargetRunnerFiles(outDir, options) {
+  if (!options.fullVisualSync) {
+    return [await writeFileIn(outDir, "99-run-target.mcp.js", runTargetSource(options))];
+  }
+
+  const files = [];
+  for (let index = 0; index < options.targets.length; index += 1) {
+    const target = options.targets[index];
+    const fileName = `99-${String(index).padStart(2, "0")}-${safeName(target)}.mcp.js`;
+    files.push(await writeFileIn(outDir, fileName, runTargetSource(options, [target])));
+  }
+  return files;
 }
 
 async function writeChunkSources(outDir, key, value, options) {
@@ -716,9 +730,9 @@ return {
 `;
 }
 
-function runTargetSource(options) {
+function runTargetSource(options, targets = options.targets) {
   const syncOptions = {
-    targets: options.targets,
+    targets,
     writeMetadata: options.writeMetadata,
     ...(options.sectionNodeId ? { sectionNodeOverrides: { [options.target]: options.sectionNodeId } } : {}),
     ...(options.roots.length > 0 ? { catalogRootFilters: { [options.target]: options.roots } } : {}),

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -42,15 +42,22 @@ test("official runner defaults to the complete visual sync without metadata", as
       workspace.outDir,
       "official-trunk-sync-all-visual-png-design-model-json"
     );
+    const files = await readdir(runDir);
     const manifest = readManifest(runDir);
-    const runTargetSource = readFileSync(join(runDir, "99-run-target.mcp.js"), "utf8");
+    const preflightSource = readFileSync(join(runDir, "99-00-preflight.mcp.js"), "utf8");
+    const versionsSource = readFileSync(join(runDir, "99-02-versions.mcp.js"), "utf8");
+    const runtimeSource = readFileSync(join(runDir, "99-15-ci-windowsRuntime.mcp.js"), "utf8");
 
     assert.deepEqual(manifest.targets, FULL_VISUAL_TARGETS);
     assert.equal(manifest.fullVisualSync, true);
     assert.equal(manifest.allowPartial, false);
     assert.equal(manifest.writeMetadata, false);
-    assert.match(runTargetSource, /"targets":\["preflight","headers","versions"/);
-    assert.doesNotMatch(runTargetSource, /writeMetadata":true/);
+    assert.ok(!files.includes("99-run-target.mcp.js"));
+    assert.equal(files.filter((fileName) => fileName.startsWith("99-")).length, FULL_VISUAL_TARGETS.length);
+    assert.match(preflightSource, /"targets":\["preflight"\]/);
+    assert.match(versionsSource, /"targets":\["versions"\]/);
+    assert.match(runtimeSource, /"targets":\["ci\.windowsRuntime"\]/);
+    assert.doesNotMatch(runtimeSource, /writeMetadata":true/);
   } finally {
     await rm(workspace.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- Generate one ordered MCP runner per complete-sync target.
- Keep partial and metadata runners unchanged.
- Document lexical, bounded execution as the official complete-sync contract.

## Why

The previous complete runner reconciled every managed Figma section in one MCP call and exceeded the 300-second transport timeout. The visual sync remained atomic and no sections were updated.

## Verification

- npm run test:write-mcp-runner
- npm run build
- npm test
- .\gradlew.bat check
- git diff --check