### PR TITLE
fix(figma-design-sync): split catalog sync by root

### DIFF
--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -144,10 +144,11 @@ trunk metadata. A partial run never completes the official synchronization.
 The official MCP runner uses PNG payload transport by default: the generated
 runner writes `10-official-sync-payload.png`, that image is uploaded to Figma,
 and the staging runner extracts and validates the model plus MCP script before
-running each visual target in a separate, lexically ordered MCP call. This
-keeps the complete synchronization mandatory without exceeding the MCP timeout
-with one monolithic call. Chunked staging remains a fallback for oversized or
-blocked asset uploads.
+running each visual target in a separate, lexically ordered MCP call. Catalog
+targets are further split by declared root and end with a cleanup-only call.
+This keeps the complete synchronization mandatory without exceeding the MCP
+timeout with one monolithic call. Chunked staging remains a fallback for
+oversized or blocked asset uploads.
 
 ## Human Workflow
 

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -68,15 +68,16 @@ Official mode defaults to `--transport=png` and writes:
 - `00-clear-staging.mcp.js`
 - `10-stage-payload-from-png.mcp.js`
 - `90-finalize-staging.mcp.js`
-- `99-00-preflight.mcp.js` through the final ordered visual target runner
+- `99-00-preflight.mcp.js` through the final ordered visual execution unit
 - `manifest.json`
 
 Upload `10-official-sync-payload.png` to the Figma file before running
 `10-stage-payload-from-png.mcp.js`. Then run every generated `.mcp.js` snippet
-in lexical order. Full official runners use one `99-*.mcp.js` call per target
-so no individual MCP call must reconcile the complete document. The PNG asset
-is a transport artifact only; the staging runner removes the uploaded image
-node after extracting the payload.
+in lexical order. Full official runners use one `99-*.mcp.js` call per bounded
+execution unit. Non-catalog targets use one call; catalog targets with declared
+roots use one call per root followed by a cleanup-only call. The PNG asset is a
+transport artifact only; the staging runner removes the uploaded image node
+after extracting the payload.
 
 `upload_assets` returns a single-use URL under `https://mcp.figma.com`. Upload
 the PNG as multipart form data with an explicit `image/png` content type.
@@ -231,9 +232,10 @@ return {
 ## Run The Complete Visual Sync
 
 Execute every generated `99-*.mcp.js` file in lexical order without editing its
-target. The official runner contains one bounded MCP call for `preflight` and
-one for every visual target from [target-scopes.md](target-scopes.md), all with
-`writeMetadata=false`.
+target or root. The official runner contains bounded calls for `preflight` and
+every visual target from [target-scopes.md](target-scopes.md). Catalog calls are
+split by roots from the official model and finish with stale-node cleanup. All
+calls use `writeMetadata=false`.
 
 If a focused diagnostic is necessary, regenerate the runner with the target
 and `--allow-partial=true`. A partial runner may confirm a repair, but it cannot

--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -53,8 +53,9 @@ an official integration.
 ## Execution Order
 
 Generate the complete official visual runner by omitting `--target`, or by
-passing `--target=all`. It creates one bounded MCP runner file for `preflight`
-and each visual target in the order below, and never writes metadata:
+passing `--target=all`. It creates bounded MCP runner files for `preflight` and
+each visual target in the order below, and never writes metadata. Catalog
+targets are expanded into one file per declared root plus a final cleanup file:
 
 ```powershell
 node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -75,7 +75,8 @@ intentionally non-authoritative and must not write official metadata.
 6. Generate the complete official visual runner without specifying a target,
    then execute every generated MCP file in lexical order. The sequence runs
    `preflight` and every visual target as bounded calls in the order defined by
-   [target-scopes.md](target-scopes.md), with `writeMetadata=false`.
+   [target-scopes.md](target-scopes.md). Catalog targets run root by root and
+   finish with cleanup-only calls. Every call uses `writeMetadata=false`.
 7. Check every managed Figma section against
    [visual-sync-contract.md](visual-sync-contract.md).
 8. After all visual targets are correct, run only the `metadata` target with

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -327,7 +327,7 @@ async function writeRunnerFiles(options) {
   }
 
   files.push(await writeFileIn(outDir, "90-finalize-staging.mcp.js", finalizeStagingSource(options, designModel, minifiedModelJson, script, scriptBase64)));
-  files.push(...await writeTargetRunnerFiles(outDir, options));
+  files.push(...await writeTargetRunnerFiles(outDir, options, designModel));
   files.push(await writeManifest(outDir, files, options, designModel, minifiedModelJson, script, scriptBase64, payloadImage));
 
   console.log(`Wrote ${files.length} MCP runner files to ${outDir}`);
@@ -337,7 +337,7 @@ async function writeRunnerFiles(options) {
   console.log("Run every generated .mcp.js file in lexical order.");
 }
 
-async function writeTargetRunnerFiles(outDir, options) {
+async function writeTargetRunnerFiles(outDir, options, designModel) {
   if (!options.fullVisualSync) {
     return [await writeFileIn(outDir, "99-run-target.mcp.js", runTargetSource(options))];
   }
@@ -345,10 +345,46 @@ async function writeTargetRunnerFiles(outDir, options) {
   const files = [];
   for (let index = 0; index < options.targets.length; index += 1) {
     const target = options.targets[index];
-    const fileName = `99-${String(index).padStart(2, "0")}-${safeName(target)}.mcp.js`;
-    files.push(await writeFileIn(outDir, fileName, runTargetSource(options, [target])));
+    const roots = catalogRoots(designModel, target);
+    if (roots.length === 0) {
+      const fileName = `99-${String(index).padStart(2, "0")}-${safeName(target)}.mcp.js`;
+      files.push(await writeFileIn(outDir, fileName, runTargetSource(options, [target])));
+      continue;
+    }
+
+    for (let rootIndex = 0; rootIndex < roots.length; rootIndex += 1) {
+      const root = roots[rootIndex];
+      const fileName = `99-${String(index).padStart(2, "0")}-${String(rootIndex).padStart(2, "0")}-${safeName(target)}-${safeName(root)}.mcp.js`;
+      files.push(await writeFileIn(
+        outDir,
+        fileName,
+        runTargetSource(options, [target], { roots: [root] })
+      ));
+    }
+
+    const cleanupFileName = `99-${String(index).padStart(2, "0")}-99-${safeName(target)}-cleanup.mcp.js`;
+    files.push(await writeFileIn(
+      outDir,
+      cleanupFileName,
+      runTargetSource(options, [target], { cleanupOnly: true })
+    ));
   }
   return files;
+}
+
+function catalogRoots(designModel, target) {
+  if (!CATALOG_TARGETS.includes(target)) {
+    return [];
+  }
+
+  const [catalogName, treeName] = target.split(".");
+  const nodes = designModel.content?.catalogs?.[catalogName]?.[treeName];
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    return [];
+  }
+
+  const rootKey = treeName === "libraries" ? "group" : "id";
+  return [...new Set(nodes.map((node) => node?.[rootKey]).filter(Boolean))];
 }
 
 async function writeChunkSources(outDir, key, value, options) {
@@ -730,12 +766,15 @@ return {
 `;
 }
 
-function runTargetSource(options, targets = options.targets) {
+function runTargetSource(options, targets = options.targets, runOptions = {}) {
+  const target = targets[0];
+  const roots = runOptions.roots || options.roots;
   const syncOptions = {
     targets,
     writeMetadata: options.writeMetadata,
     ...(options.sectionNodeId ? { sectionNodeOverrides: { [options.target]: options.sectionNodeId } } : {}),
-    ...(options.roots.length > 0 ? { catalogRootFilters: { [options.target]: options.roots } } : {}),
+    ...(roots.length > 0 ? { catalogRootFilters: { [target]: roots } } : {}),
+    ...(runOptions.cleanupOnly ? { catalogCleanupOnlyTargets: [target] } : {}),
   };
 
   const invokeScript = options.entrypoint === "preview-catalog"

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -48,4 +48,5 @@ export type SyncFigmaDesignModelOptions = {
   writeMetadata?: boolean;
   sectionNodeOverrides?: Record<string, string>;
   catalogRootFilters?: Partial<Record<SyncTargetName, string[]>>;
+  catalogCleanupOnlyTargets?: SyncTargetName[];
 };

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -81,6 +81,10 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     }
 
     const rootFilter = options.rootFilters?.[target.name];
+    const cleanupOnly = options.cleanupOnlyTargetNames?.includes(target.name) === true;
+    if (cleanupOnly && rootFilter && rootFilter.length > 0) {
+      throw new Error(`Catalog cleanup for ${target.name} cannot be combined with root filters.`);
+    }
     const isPartialRootSync = Boolean(rootFilter && rootFilter.length > 0);
     const modelRootLabels = modelNodes.map((node) => rootLabel(target, node));
     const scopedModelNodes = filterModelRoots(target, modelNodes, rootFilter);
@@ -108,6 +112,21 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     showCatalogTreeSection(section, mutatedNodeIds);
     const instancesByLabel = collectTreeNodeInstancesByLabel(section, target.type);
     let connectors = collectTreeConnectors(section);
+
+    if (cleanupOnly) {
+      const cleanupResult = cleanupCatalogTreeTarget({
+        target,
+        section,
+        modelNodes,
+        instancesByLabel,
+        connectors,
+        outlineVariable,
+        mutatedNodeIds,
+      });
+      removedCatalogNodes.push(...cleanupResult.removedCatalogNodes);
+      removedCatalogConnectors.push(...cleanupResult.removedCatalogConnectors);
+      continue;
+    }
 
     if (!isPartialRootSync) {
       const disconnectedConnectors = connectors.filter((connector) =>
@@ -212,6 +231,61 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     mutatedNodeIds,
   };
   }
+}
+
+function cleanupCatalogTreeTarget({
+  target,
+  section,
+  modelNodes,
+  instancesByLabel,
+  connectors,
+  outlineVariable,
+  mutatedNodeIds,
+}) {
+  const expectedNodes = flattenCatalogNodes(modelNodes, target.type);
+  requireUniqueLabels(target, expectedNodes);
+  const disconnectedConnectors = connectors.filter((connector) =>
+    !connector.getSharedPluginData?.(METADATA_NAMESPACE, TREE_CONNECTOR_EDGE_PLUGIN_DATA_KEY) &&
+      (!connector.connectorStart?.endpointNodeId || !connector.connectorEnd?.endpointNodeId)
+  );
+  for (const connector of disconnectedConnectors) {
+    connector.remove();
+  }
+  connectors = connectors.filter((connector) => !disconnectedConnectors.includes(connector));
+
+  const staleResult = removeStaleCatalogNodes(
+    target,
+    expectedNodes,
+    instancesByLabel,
+    connectors,
+    undefined
+  );
+  const removedRootSections = removeEmptyStaleCatalogRootSections(
+    target,
+    section,
+    modelNodes.map((node) => rootLabel(target, node)),
+    mutatedNodeIds
+  );
+
+  resizeSectionsToFit(section, [...instancesByLabel.values()], mutatedNodeIds);
+  stackDescendantSectionsWithGap(section, mutatedNodeIds);
+  stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds);
+  resizeAncestorSectionsToFit(section, mutatedNodeIds);
+  removeCatalogTreeSectionFills(section, mutatedNodeIds);
+  applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
+  applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
+  lockOnlyRootSection(section, mutatedNodeIds);
+
+  return {
+    removedCatalogNodes: [
+      ...staleResult.removedCatalogNodes,
+      ...removedRootSections,
+    ],
+    removedCatalogConnectors: [
+      ...disconnectedConnectors.map((connector) => `${target.name}/${connector.id}`),
+      ...staleResult.removedCatalogConnectors,
+    ],
+  };
 }
 
 export function filterModelRoots(target, modelNodes, rootFilter) {

--- a/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
+++ b/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
@@ -32,6 +32,7 @@ export type CatalogTreeSyncOptions = {
   targetNames?: string[];
   sectionNodeOverrides?: Record<string, string>;
   rootFilters?: Record<string, string[]>;
+  cleanupOnlyTargetNames?: string[];
 };
 
 export type MetadataSyncResult = {

--- a/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
+++ b/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
@@ -73,6 +73,7 @@ export async function syncFigmaDesignModel(
           targetNames: catalogTargets,
           sectionNodeOverrides: options.sectionNodeOverrides,
           rootFilters: options.catalogRootFilters,
+          cleanupOnlyTargetNames: options.catalogCleanupOnlyTargets,
         }
       )
     : emptyCatalogTreeSyncResult();

--- a/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
+++ b/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
@@ -97,6 +97,32 @@ test("preflight runs before a requested visual target and scopes the contract ch
   assert.deepEqual(result.updatedCatalogNodes, ["waterMyPlants.libraries/androidx"]);
 });
 
+test("catalog cleanup-only execution is forwarded independently from root filters", async () => {
+  const calls: string[] = [];
+  const dependencies = fakeDependencies(calls);
+  let receivedOptions;
+  dependencies.catalogTreeSyncGateway.syncCatalogTrees = async (_designModel, options) => {
+    receivedOptions = options;
+    return {
+      updatedCatalogNodes: [],
+      createdCatalogNodes: [],
+      createdCatalogConnectors: [],
+      removedCatalogNodes: [],
+      removedCatalogConnectors: [],
+      mutatedNodeIds: [],
+    };
+  };
+
+  await syncFigmaDesignModel(mainDesignModel(), dependencies, {
+    targets: ["waterMyPlants.libraries"],
+    writeMetadata: false,
+    catalogCleanupOnlyTargets: ["waterMyPlants.libraries"],
+  });
+
+  assert.deepEqual(receivedOptions.cleanupOnlyTargetNames, ["waterMyPlants.libraries"]);
+  assert.equal(receivedOptions.rootFilters, undefined);
+});
+
 test("headers can be synchronized as an independent visual target", async () => {
   const calls: string[] = [];
   const result = await syncFigmaDesignModel(

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -46,6 +46,14 @@ test("official runner defaults to the complete visual sync without metadata", as
     const manifest = readManifest(runDir);
     const preflightSource = readFileSync(join(runDir, "99-00-preflight.mcp.js"), "utf8");
     const versionsSource = readFileSync(join(runDir, "99-02-versions.mcp.js"), "utf8");
+    const androidxSource = readFileSync(
+      join(runDir, "99-03-00-waterMyPlants-libraries-androidx.mcp.js"),
+      "utf8"
+    );
+    const libraryCleanupSource = readFileSync(
+      join(runDir, "99-03-99-waterMyPlants-libraries-cleanup.mcp.js"),
+      "utf8"
+    );
     const runtimeSource = readFileSync(join(runDir, "99-15-ci-windowsRuntime.mcp.js"), "utf8");
 
     assert.deepEqual(manifest.targets, FULL_VISUAL_TARGETS);
@@ -53,9 +61,17 @@ test("official runner defaults to the complete visual sync without metadata", as
     assert.equal(manifest.allowPartial, false);
     assert.equal(manifest.writeMetadata, false);
     assert.ok(!files.includes("99-run-target.mcp.js"));
-    assert.equal(files.filter((fileName) => fileName.startsWith("99-")).length, FULL_VISUAL_TARGETS.length);
+    assert.equal(files.filter((fileName) => fileName.startsWith("99-")).length, 24);
     assert.match(preflightSource, /"targets":\["preflight"\]/);
     assert.match(versionsSource, /"targets":\["versions"\]/);
+    assert.match(
+      androidxSource,
+      /"catalogRootFilters":\{"waterMyPlants\.libraries":\["androidx"\]\}/
+    );
+    assert.match(
+      libraryCleanupSource,
+      /"catalogCleanupOnlyTargets":\["waterMyPlants\.libraries"\]/
+    );
     assert.match(runtimeSource, /"targets":\["ci\.windowsRuntime"\]/);
     assert.doesNotMatch(runtimeSource, /writeMetadata":true/);
   } finally {
@@ -282,7 +298,23 @@ function createRunnerFixture() {
       branch: "main",
       gitSha: "git-sha",
       modelHash: "sha256:model-hash",
-      content: {},
+      content: {
+        catalogs: {
+          waterMyPlants: {
+            libraries: [{ group: "androidx" }, { group: "com" }],
+            plugins: [{ id: "com" }],
+            customGradleConventionPlugins: [{ id: "com" }],
+            customGradlePlugins: [{ id: "com" }],
+          },
+          gradlePlugins: {
+            libraries: [{ group: "org" }],
+          },
+          figmaDesignSync: {
+            libraries: [{ group: "io" }],
+            plugins: [{ id: "com" }],
+          },
+        },
+      },
     }),
     "utf8"
   );


### PR DESCRIPTION
## What changed

- Expand complete catalog targets into one ordered MCP call per declared root.
- Add a final cleanup-only call per non-empty catalog target.
- Keep omitted or empty catalog targets as one full call so their sections are hidden or removed.
- Document the bounded complete-sync execution contract.

## Why

After splitting the complete sync by target, waterMyPlants.libraries still exceeded the 300-second MCP timeout. Root-level calls fit the existing granular contract, while the cleanup-only call preserves complete stale-node and connector removal.

## Verification

- npm run build
- npm test
- .\gradlew.bat check
- git diff --check