### PR TITLE
fix(figma-design-sync): stage raw MCP script from PNG

### DIFF
--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -144,7 +144,9 @@ trunk metadata. A partial run never completes the official synchronization.
 The official MCP runner uses PNG payload transport by default: the generated
 runner writes `10-official-sync-payload.png`, that image is uploaded to Figma,
 and the staging runner extracts and validates the model plus MCP script before
-running each visual target in a separate, lexically ordered MCP call. Catalog
+storing the script as plain text in temporary shared plugin data. Avoiding a
+second Base64 encoding keeps the staging entry below Figma's per-entry limit.
+Each visual target then runs in a separate, lexically ordered MCP call. Catalog
 targets are further split by declared root and end with a cleanup-only call.
 This keeps the complete synchronization mandatory without exceeding the MCP
 timeout with one monolithic call. Chunked staging remains a fallback for

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -151,8 +151,7 @@ all of these values remain identical:
 - `designModelHash`;
 - `designModelGitSha`;
 - `designModelLength`;
-- `scriptLength`;
-- `scriptBase64Length`.
+- `scriptLength`.
 
 Restage from `00-clear-staging.mcp.js` whenever the TeamCity artifact or the
 generated MCP bundle changes. A stable `modelHash` is not sufficient: a
@@ -170,19 +169,20 @@ Stage these keys on page `62934:908` under
 | `designModelHash` | The artifact `modelHash`, used to validate the staged model. |
 | `designModelGitSha` | The artifact `gitSha`, used to validate the staged model. |
 | `designModelLength` | Character length of `designModelJson`, used to catch truncated staging writes. |
-| `scriptBase64` | Base64-encoded generated `sync-trunk-design-model.mcp.js` content. |
-| `scriptLength` | Character length of the decoded script. |
-| `scriptBase64Length` | Character length of `scriptBase64`, used to catch truncated staging writes. |
+| `script` | Generated `sync-trunk-design-model.mcp.js` content in plain text. |
+| `scriptLength` | Character length of `script`, used to catch truncated staging writes. |
 
 The PNG transport writes all keys in one staging step after validating the
-payload hash, Git SHA, model length, script length, and script base64 length.
+payload hash, Git SHA, model length, and script length.
 Chunk transport writes the same keys incrementally.
 
 The Figma MCP `use_figma` call has a practical source-size limit near 50k
 characters. Stage large payloads in temporary shared plugin data, validate
-lengths before execution, and do not copy long base64 payloads manually from
-terminal output. If chunking is needed for staging, validate chunk count and
-encoded length before assembling the final `scriptBase64` value.
+lengths before execution, and do not copy long payloads manually from terminal
+output. Figma limits each shared plugin data entry to about 100k characters, so
+runner generation fails locally when either `designModelJson` or `script`
+exceeds 100,000 characters. Chunk transport can reduce each MCP call size, but
+cannot bypass the final per-entry limit.
 
 Generated `.mcp.js` runner files are source snippets for the Figma MCP
 `use_figma` call. They are not local scripts that can talk to Figma from
@@ -197,9 +197,9 @@ TeamCity artifact used to generate the runner. In chunk mode, each chunk
 validates its own length and the previously staged length before writing. A
 failed `use_figma` call is atomic, so a chunk length failure does not append
 partial data. If `designModelJson` is already fully staged and only a
-`scriptBase64` chunk fails, clear only `scriptBase64`, `scriptLength`, and
-`scriptBase64Length`, regenerate the runner with a smaller `--chunk-size`, and
-rerun the `20-scriptBase64-*.mcp.js`, `90-finalize-staging.mcp.js`, and target
+`script` chunk fails, clear only `script` and `scriptLength`, regenerate the
+runner with a smaller `--chunk-size`, and rerun the `20-script-*.mcp.js`,
+`90-finalize-staging.mcp.js`, and target
 runner files in lexical order. If the model chunks are uncertain, rerun the
 full runner from `00-clear-staging.mcp.js`.
 
@@ -222,9 +222,9 @@ return {
     "water_my_plants_sync_staging",
     "designModelJson"
   ).length,
-  scriptBase64Length: page.getSharedPluginData(
+  scriptLength: page.getSharedPluginData(
     "water_my_plants_sync_staging",
-    "scriptBase64"
+    "script"
   ).length
 };
 ```

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -77,9 +77,9 @@ return {
     "water_my_plants_sync_staging",
     "designModelJson"
   ).length,
-  scriptBase64Length: page.getSharedPluginData(
+  scriptLength: page.getSharedPluginData(
     "water_my_plants_sync_staging",
-    "scriptBase64"
+    "script"
   ).length
 };
 ```

--- a/repo/figma-design-sync/docs/runbooks/visual-preview.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-preview.md
@@ -84,7 +84,7 @@ Run the generated `.mcp.js` files with Figma MCP in lexical order:
 
 1. `00-clear-staging.mcp.js`
 2. `10-designModelJson-*.mcp.js`
-3. `20-scriptBase64-*.mcp.js`
+3. `20-script-*.mcp.js`
 4. `90-finalize-staging.mcp.js`
 5. `99-run-target.mcp.js`
 

--- a/repo/figma-design-sync/tools/scripts/payload-png.ts
+++ b/repo/figma-design-sync/tools/scripts/payload-png.ts
@@ -3,15 +3,14 @@ import { deflateSync } from "node:zlib";
 export const PAYLOAD_PNG_TEXT_KEYWORD = "figmaSyncPayload";
 export const MAX_FIGMA_UPLOAD_ASSET_BYTES = 10 * 1024 * 1024;
 
-export function buildOfficialSyncPayload({ designModel, modelJson, script, scriptBase64 }) {
+export function buildOfficialSyncPayload({ designModel, modelJson, script }) {
   return {
     designModelJson: modelJson,
     designModelHash: designModel.modelHash,
     designModelGitSha: designModel.gitSha,
     designModelLength: modelJson.length,
-    scriptBase64,
+    script,
     scriptLength: script.length,
-    scriptBase64Length: scriptBase64.length,
   };
 }
 

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -19,6 +19,7 @@ const PREVIEW_STAGING_NAMESPACE = "water_my_plants_sync_preview";
 const METADATA_PAGE_ID = "62934:908";
 const DEFAULT_CHUNK_SIZE = 30_000;
 const PAYLOAD_PNG_FILE_NAME = "10-official-sync-payload.png";
+const MAX_SHARED_PLUGIN_DATA_ENTRY_LENGTH = 100_000;
 
 const KNOWN_TARGETS = [
   "preflight",
@@ -280,7 +281,8 @@ async function writeRunnerFiles(options) {
   const script = await readFile(options.scriptPath, "utf8");
   validateDesignModel(designModel, options);
 
-  const scriptBase64 = Buffer.from(script, "utf8").toString("base64");
+  validateStagingEntryLength("designModelJson", minifiedModelJson);
+  validateStagingEntryLength("script", script);
   const targetRunName = options.fullVisualSync ? "all-visual" : options.targets.join("-");
   const runDirName = `${options.mode}-${safeName(options.entrypoint)}-${safeName(targetRunName)}-${safeName(options.transport)}-${safeName(basename(options.modelPath, ".design-model.json"))}`;
   const outDir = join(options.outRoot, runDirName);
@@ -296,7 +298,6 @@ async function writeRunnerFiles(options) {
       designModel,
       modelJson: minifiedModelJson,
       script,
-      scriptBase64,
     });
     const payloadJson = stringifyAsciiJson(payload);
     const payloadPng = createPayloadPng(payloadJson);
@@ -318,17 +319,16 @@ async function writeRunnerFiles(options) {
       designModel,
       minifiedModelJson,
       script,
-      scriptBase64,
       PAYLOAD_PNG_FILE_NAME
     )));
   } else {
     files.push(...await writeChunkSources(outDir, "designModelJson", minifiedModelJson, options));
-    files.push(...await writeChunkSources(outDir, "scriptBase64", scriptBase64, options));
+    files.push(...await writeChunkSources(outDir, "script", script, options));
   }
 
-  files.push(await writeFileIn(outDir, "90-finalize-staging.mcp.js", finalizeStagingSource(options, designModel, minifiedModelJson, script, scriptBase64)));
+  files.push(await writeFileIn(outDir, "90-finalize-staging.mcp.js", finalizeStagingSource(options, designModel, minifiedModelJson, script)));
   files.push(...await writeTargetRunnerFiles(outDir, options, designModel));
-  files.push(await writeManifest(outDir, files, options, designModel, minifiedModelJson, script, scriptBase64, payloadImage));
+  files.push(await writeManifest(outDir, files, options, designModel, minifiedModelJson, script, payloadImage));
 
   console.log(`Wrote ${files.length} MCP runner files to ${outDir}`);
   if (payloadImage) {
@@ -413,7 +413,7 @@ async function writeChunkSources(outDir, key, value, options) {
   return files;
 }
 
-async function writeManifest(outDir, files, options, designModel, modelJson, script, scriptBase64, payloadImage) {
+async function writeManifest(outDir, files, options, designModel, modelJson, script, payloadImage) {
   return writeFileIn(
     outDir,
     "manifest.json",
@@ -438,7 +438,6 @@ async function writeManifest(outDir, files, options, designModel, modelJson, scr
         gitSha: designModel.gitSha,
         designModelLength: modelJson.length,
         scriptLength: script.length,
-        scriptBase64Length: scriptBase64.length,
         payloadImage,
         files,
       },
@@ -468,6 +467,15 @@ function validateDesignModel(designModel, options) {
   }
 }
 
+function validateStagingEntryLength(key, value) {
+  if (value.length > MAX_SHARED_PLUGIN_DATA_ENTRY_LENGTH) {
+    throw new Error(
+      `${key} is ${value.length} characters and exceeds the ${MAX_SHARED_PLUGIN_DATA_ENTRY_LENGTH}-character ` +
+        "sharedPluginData staging limit. Reduce the generated payload before creating the runner."
+    );
+  }
+}
+
 function clearStagingSource(namespace) {
   return `${runtimeHeader()}
 const namespace = ${JSON.stringify(namespace)};
@@ -476,6 +484,7 @@ const keys = [
   "designModelHash",
   "designModelGitSha",
   "designModelLength",
+  "script",
   "scriptBase64",
   "scriptLength",
   "scriptBase64Length"
@@ -518,7 +527,7 @@ return {
 `;
 }
 
-function stagePayloadFromPngSource(options, designModel, modelJson, script, scriptBase64, payloadFileName) {
+function stagePayloadFromPngSource(options, designModel, modelJson, script, payloadFileName) {
   return `${runtimeHeader()}
 const namespace = ${JSON.stringify(options.namespace)};
 const payloadKeyword = ${JSON.stringify(PAYLOAD_PNG_TEXT_KEYWORD)};
@@ -527,8 +536,7 @@ const expected = {
   designModelHash: ${JSON.stringify(designModel.modelHash)},
   designModelGitSha: ${JSON.stringify(designModel.gitSha)},
   designModelLength: ${JSON.stringify(String(modelJson.length))},
-  scriptLength: ${JSON.stringify(String(script.length))},
-  scriptBase64Length: ${JSON.stringify(String(scriptBase64.length))}
+  scriptLength: ${JSON.stringify(String(script.length))}
 };
 
 if (typeof figma.loadAllPagesAsync === "function") {
@@ -574,7 +582,7 @@ for (const imageHash of imageHashes) {
   if (
     payload.designModelHash === expected.designModelHash &&
     String(payload.designModelLength) === expected.designModelLength &&
-    String(payload.scriptBase64Length) === expected.scriptBase64Length
+    String(payload.scriptLength) === expected.scriptLength
   ) {
     candidates.push({ imageHash, payload });
   }
@@ -591,12 +599,11 @@ const { imageHash, payload } = candidates[0];
 validatePayload(payload, expected);
 
 page.setSharedPluginData(namespace, "designModelJson", payload.designModelJson);
-page.setSharedPluginData(namespace, "scriptBase64", payload.scriptBase64);
+page.setSharedPluginData(namespace, "script", payload.script);
 page.setSharedPluginData(namespace, "designModelHash", expected.designModelHash);
 page.setSharedPluginData(namespace, "designModelGitSha", expected.designModelGitSha);
 page.setSharedPluginData(namespace, "designModelLength", expected.designModelLength);
 page.setSharedPluginData(namespace, "scriptLength", expected.scriptLength);
-page.setSharedPluginData(namespace, "scriptBase64Length", expected.scriptBase64Length);
 
 let payloadNodesRemoved = 0;
 for (const node of imageNodes) {
@@ -614,13 +621,13 @@ return {
   modelHash: expected.designModelHash,
   gitSha: expected.designModelGitSha,
   designModelLength: expected.designModelLength,
-  scriptBase64Length: expected.scriptBase64Length
+  scriptLength: expected.scriptLength
 };
 
 function validatePayload(payload, expected) {
   for (const [key, value] of Object.entries({
     designModelJson: payload.designModelJson,
-    scriptBase64: payload.scriptBase64,
+    script: payload.script,
     designModelHash: payload.designModelHash,
     designModelGitSha: payload.designModelGitSha
   })) {
@@ -644,11 +651,8 @@ function validatePayload(payload, expected) {
   if (String(payload.scriptLength) !== expected.scriptLength) {
     throw new Error(\`Payload script length metadata mismatch: \${payload.scriptLength} != \${expected.scriptLength}\`);
   }
-  if (String(payload.scriptBase64Length) !== expected.scriptBase64Length) {
-    throw new Error(\`Payload scriptBase64 length metadata mismatch: \${payload.scriptBase64Length} != \${expected.scriptBase64Length}\`);
-  }
-  if (payload.scriptBase64.length !== Number(expected.scriptBase64Length)) {
-    throw new Error(\`Payload scriptBase64 length mismatch: \${payload.scriptBase64.length} != \${expected.scriptBase64Length}\`);
+  if (payload.script.length !== Number(expected.scriptLength)) {
+    throw new Error(\`Payload script length mismatch: \${payload.script.length} != \${expected.scriptLength}\`);
   }
 
   const parsedModel = JSON.parse(payload.designModelJson);
@@ -659,10 +663,6 @@ function validatePayload(payload, expected) {
     throw new Error(\`Payload model JSON gitSha mismatch: \${parsedModel.gitSha} != \${expected.designModelGitSha}\`);
   }
 
-  const decodedScript = atob(payload.scriptBase64);
-  if (decodedScript.length !== Number(expected.scriptLength)) {
-    throw new Error(\`Payload decoded script length mismatch: \${decodedScript.length} != \${expected.scriptLength}\`);
-  }
 }
 
 function readPayloadFromPngText(bytes, keyword) {
@@ -718,26 +718,25 @@ function readLatin1(bytes, start, end) {
 `;
 }
 
-function finalizeStagingSource(options, designModel, modelJson, script, scriptBase64) {
+function finalizeStagingSource(options, designModel, modelJson, script) {
   return `${runtimeHeader()}
 const namespace = ${JSON.stringify(options.namespace)};
 const expected = {
   designModelHash: ${JSON.stringify(designModel.modelHash)},
   designModelGitSha: ${JSON.stringify(designModel.gitSha)},
   designModelLength: ${JSON.stringify(String(modelJson.length))},
-  scriptLength: ${JSON.stringify(String(script.length))},
-  scriptBase64Length: ${JSON.stringify(String(scriptBase64.length))}
+  scriptLength: ${JSON.stringify(String(script.length))}
 };
 
 const stagedModelJson = page.getSharedPluginData(namespace, "designModelJson");
-const stagedScriptBase64 = page.getSharedPluginData(namespace, "scriptBase64");
+const stagedScript = page.getSharedPluginData(namespace, "script");
 
 if (String(stagedModelJson.length) !== expected.designModelLength) {
   throw new Error(\`Staged model length mismatch: \${stagedModelJson.length} != \${expected.designModelLength}\`);
 }
 
-if (String(stagedScriptBase64.length) !== expected.scriptBase64Length) {
-  throw new Error(\`Staged scriptBase64 length mismatch: \${stagedScriptBase64.length} != \${expected.scriptBase64Length}\`);
+if (String(stagedScript.length) !== expected.scriptLength) {
+  throw new Error(\`Staged script length mismatch: \${stagedScript.length} != \${expected.scriptLength}\`);
 }
 
 const parsedModel = JSON.parse(stagedModelJson);
@@ -752,7 +751,6 @@ page.setSharedPluginData(namespace, "designModelHash", expected.designModelHash)
 page.setSharedPluginData(namespace, "designModelGitSha", expected.designModelGitSha);
 page.setSharedPluginData(namespace, "designModelLength", expected.designModelLength);
 page.setSharedPluginData(namespace, "scriptLength", expected.scriptLength);
-page.setSharedPluginData(namespace, "scriptBase64Length", expected.scriptBase64Length);
 
 return {
   namespace,
@@ -761,7 +759,7 @@ return {
   modelHash: expected.designModelHash,
   gitSha: expected.designModelGitSha,
   designModelLength: expected.designModelLength,
-  scriptBase64Length: expected.scriptBase64Length
+  scriptLength: expected.scriptLength
 };
 `;
 }
@@ -801,9 +799,9 @@ if (
 }
 
 const stagedModelJson = page.getSharedPluginData(namespace, "designModelJson");
-const scriptBase64 = page.getSharedPluginData(namespace, "scriptBase64");
+let script = page.getSharedPluginData(namespace, "script");
 
-if (!stagedModelJson || !scriptBase64) {
+if (!stagedModelJson || !script) {
   throw new Error("Missing staged model or script.");
 }
 
@@ -812,14 +810,12 @@ const stagedModelHash = page.getSharedPluginData(namespace, "designModelHash");
 const stagedModelGitSha = page.getSharedPluginData(namespace, "designModelGitSha");
 const stagedModelLength = page.getSharedPluginData(namespace, "designModelLength");
 const scriptLength = page.getSharedPluginData(namespace, "scriptLength");
-const scriptBase64Length = page.getSharedPluginData(namespace, "scriptBase64Length");
 
 for (const [key, value] of Object.entries({
   designModelHash: stagedModelHash,
   designModelGitSha: stagedModelGitSha,
   designModelLength: stagedModelLength,
-  scriptLength,
-  scriptBase64Length
+  scriptLength
 })) {
   if (!value) {
     throw new Error(\`Missing staged \${key}.\`);
@@ -838,14 +834,8 @@ if (Number(stagedModelLength) !== stagedModelJson.length) {
   throw new Error(\`Staged model length mismatch: \${stagedModelLength} != \${stagedModelJson.length}\`);
 }
 
-if (Number(scriptBase64Length) !== scriptBase64.length) {
-  throw new Error(\`Staged script length mismatch: \${scriptBase64Length} != \${scriptBase64.length}\`);
-}
-
-let script = atob(scriptBase64);
-
 if (Number(scriptLength) !== script.length) {
-  throw new Error(\`Decoded script length mismatch: \${scriptLength} != \${script.length}\`);
+  throw new Error(\`Staged script length mismatch: \${scriptLength} != \${script.length}\`);
 }
 
 ${invokeScript}

--- a/repo/figma-design-sync/tools/tests/payload-png.test.ts
+++ b/repo/figma-design-sync/tools/tests/payload-png.test.ts
@@ -26,12 +26,10 @@ test("createPayloadPng stores the official sync payload as a PNG text chunk", ()
   };
   const modelJson = JSON.stringify(designModel);
   const script = "const value = 'sync';";
-  const scriptBase64 = Buffer.from(script, "utf8").toString("base64");
   const payload = buildOfficialSyncPayload({
     designModel,
     modelJson,
     script,
-    scriptBase64,
   });
   const payloadJson = stringifyAsciiJson(payload);
 
@@ -43,6 +41,8 @@ test("createPayloadPng stores the official sync payload as a PNG text chunk", ()
     JSON.parse(Buffer.from(encodedPayload, "base64").toString("utf8")),
     payload
   );
+  assert.equal(payload.script, script);
+  assert.equal(payload.scriptLength, script.length);
 });
 
 function readPayloadFromPngText(bytes: Buffer, keyword: string): string | null {

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -160,7 +160,12 @@ test("official runner supports an explicitly partial diagnostic target", async (
     );
     assert.ok(files.includes("10-official-sync-payload.png"));
 
+    const stageSource = readFileSync(join(runDir, "10-stage-payload-from-png.mcp.js"), "utf8");
     const runTargetSource = readFileSync(join(runDir, "99-run-target.mcp.js"), "utf8");
+    assert.match(stageSource, /setSharedPluginData\(namespace, "script", payload\.script\)/);
+    assert.doesNotMatch(stageSource, /setSharedPluginData\(namespace, "scriptBase64"/);
+    assert.match(runTargetSource, /getSharedPluginData\(namespace, "script"\)/);
+    assert.doesNotMatch(runTargetSource, /getSharedPluginData\(namespace, "scriptBase64"\)/);
     assert.match(runTargetSource, /"targets":\["preflight","waterMyPlants\.libraries"\]/);
     assert.doesNotMatch(runTargetSource, /writeMetadata":true/);
   } finally {
@@ -272,7 +277,29 @@ test("official runner can explicitly use chunk transport fallback", async () => 
     assert.equal(manifest.transport, "chunks");
     assert.equal(manifest.payloadImage, null);
     assert.ok(files.some((fileName) => fileName.startsWith("10-designModelJson-")));
-    assert.ok(files.some((fileName) => fileName.startsWith("20-scriptBase64-")));
+    assert.ok(files.some((fileName) => fileName.startsWith("20-script-")));
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
+test("runner rejects staging entries that exceed Figma shared plugin data limits", async () => {
+  const workspace = createRunnerFixture();
+
+  try {
+    writeFileSync(workspace.scriptPath, "x".repeat(100_001), "utf8");
+
+    assert.throws(
+      () => runRunner([
+        "--mode=official",
+        `--model=${workspace.modelPath}`,
+        `--script=${workspace.scriptPath}`,
+        "--target=preflight",
+        "--allow-partial=true",
+        `--out-dir=${workspace.outDir}`,
+      ]),
+      /script is 100001 characters and exceeds the 100000-character sharedPluginData staging limit/
+    );
   } finally {
     await rm(workspace.root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- keep PNG as the official Figma payload transport
- stage the decoded MCP script as plain text instead of applying a redundant Base64 layer
- reject shared plugin data entries above 100,000 characters during runner generation
- update tests and runbooks for the raw script staging contract

## Verification
- npm run build
- npm test
- .\\gradlew.bat check
- generated a complete runner from TeamCity artifact 1396 (script: 77,148 characters)