### PR TITLE
fix(figma-design-sync): version PNG payload candidates

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -176,6 +176,12 @@ The PNG transport writes all keys in one staging step after validating the
 payload hash, Git SHA, model length, and script length.
 Chunk transport writes the same keys incrementally.
 
+The PNG payload also carries a `payloadSchemaVersion`. Candidate discovery must
+match that version before comparing model metadata, so an uploaded image from
+an older transport contract cannot be selected merely because it has the same
+model hash and lengths. The staging runner removes only the selected compatible
+payload node after a successful write.
+
 The Figma MCP `use_figma` call has a practical source-size limit near 50k
 characters. Stage large payloads in temporary shared plugin data, validate
 lengths before execution, and do not copy long payloads manually from terminal

--- a/repo/figma-design-sync/tools/scripts/payload-png.ts
+++ b/repo/figma-design-sync/tools/scripts/payload-png.ts
@@ -1,10 +1,12 @@
 import { deflateSync } from "node:zlib";
 
 export const PAYLOAD_PNG_TEXT_KEYWORD = "figmaSyncPayload";
+export const PAYLOAD_PNG_SCHEMA_VERSION = 2;
 export const MAX_FIGMA_UPLOAD_ASSET_BYTES = 10 * 1024 * 1024;
 
 export function buildOfficialSyncPayload({ designModel, modelJson, script }) {
   return {
+    payloadSchemaVersion: PAYLOAD_PNG_SCHEMA_VERSION,
     designModelJson: modelJson,
     designModelHash: designModel.modelHash,
     designModelGitSha: designModel.gitSha,

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -5,6 +5,7 @@ import {
   buildOfficialSyncPayload,
   createPayloadPng,
   MAX_FIGMA_UPLOAD_ASSET_BYTES,
+  PAYLOAD_PNG_SCHEMA_VERSION,
   PAYLOAD_PNG_TEXT_KEYWORD,
   stringifyAsciiJson,
 } from "./payload-png";
@@ -533,6 +534,7 @@ const namespace = ${JSON.stringify(options.namespace)};
 const payloadKeyword = ${JSON.stringify(PAYLOAD_PNG_TEXT_KEYWORD)};
 const payloadFileName = ${JSON.stringify(payloadFileName)};
 const expected = {
+  payloadSchemaVersion: ${JSON.stringify(PAYLOAD_PNG_SCHEMA_VERSION)},
   designModelHash: ${JSON.stringify(designModel.modelHash)},
   designModelGitSha: ${JSON.stringify(designModel.gitSha)},
   designModelLength: ${JSON.stringify(String(modelJson.length))},
@@ -580,6 +582,7 @@ for (const imageHash of imageHashes) {
 
   const payload = JSON.parse(atob(encodedPayload));
   if (
+    payload.payloadSchemaVersion === expected.payloadSchemaVersion &&
     payload.designModelHash === expected.designModelHash &&
     String(payload.designModelLength) === expected.designModelLength &&
     String(payload.scriptLength) === expected.scriptLength
@@ -617,6 +620,7 @@ for (const node of imageNodes) {
 return {
   namespace,
   transport: "png",
+  payloadSchemaVersion: expected.payloadSchemaVersion,
   payloadNodesRemoved,
   modelHash: expected.designModelHash,
   gitSha: expected.designModelGitSha,
@@ -636,6 +640,9 @@ function validatePayload(payload, expected) {
     }
   }
 
+  if (payload.payloadSchemaVersion !== expected.payloadSchemaVersion) {
+    throw new Error(\`Payload schema version mismatch: \${payload.payloadSchemaVersion} != \${expected.payloadSchemaVersion}\`);
+  }
   if (payload.designModelHash !== expected.designModelHash) {
     throw new Error(\`Payload modelHash mismatch: \${payload.designModelHash} != \${expected.designModelHash}\`);
   }

--- a/repo/figma-design-sync/tools/tests/payload-png.test.ts
+++ b/repo/figma-design-sync/tools/tests/payload-png.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildOfficialSyncPayload,
   createPayloadPng,
+  PAYLOAD_PNG_SCHEMA_VERSION,
   PAYLOAD_PNG_TEXT_KEYWORD,
   stringifyAsciiJson,
 } from "../scripts/payload-png";
@@ -43,6 +44,7 @@ test("createPayloadPng stores the official sync payload as a PNG text chunk", ()
   );
   assert.equal(payload.script, script);
   assert.equal(payload.scriptLength, script.length);
+  assert.equal(payload.payloadSchemaVersion, PAYLOAD_PNG_SCHEMA_VERSION);
 });
 
 function readPayloadFromPngText(bytes: Buffer, keyword: string): string | null {

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -162,6 +162,7 @@ test("official runner supports an explicitly partial diagnostic target", async (
 
     const stageSource = readFileSync(join(runDir, "10-stage-payload-from-png.mcp.js"), "utf8");
     const runTargetSource = readFileSync(join(runDir, "99-run-target.mcp.js"), "utf8");
+    assert.match(stageSource, /payload\.payloadSchemaVersion === expected\.payloadSchemaVersion/);
     assert.match(stageSource, /setSharedPluginData\(namespace, "script", payload\.script\)/);
     assert.doesNotMatch(stageSource, /setSharedPluginData\(namespace, "scriptBase64"/);
     assert.match(runTargetSource, /getSharedPluginData\(namespace, "script"\)/);


### PR DESCRIPTION
## Summary
- add an explicit schema version to official PNG payloads
- ignore stale uploaded payloads from older transport contracts during discovery
- validate the selected schema before staging and document the behavior

## Verification
- npm run build
- npm test
- .\\gradlew.bat check

## Reproduction
The first raw-script staging call found an older Base64 payload with the same model hash and lengths. The MCP call failed atomically before changing staging.