### PR TITLE
fix(figma-design-sync): keep catalog subtrees inside sections

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -259,6 +259,10 @@ For each section:
   versions, and artifact visibility.
 - Update existing library artifact name/version text overrides when the
   instance structure can represent the model.
+- After preserving an existing root position during a root-scoped sync, shift
+  the complete subtree when necessary so its leftmost group remains at least
+  100 px inside the owning root section. A wider regenerated descendant must
+  not extend outside its section.
 - When a `.tree node` contains an `artifacts` frame, select its direct
   `.artifact` / `.artifacts bundle` children first, including hidden template
   slots that can be made visible. Do not let visible nested `.artifact` rows

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -580,6 +580,7 @@ function layoutCatalogTreeNodes(
         layout.maxX += offset.x;
         layout.nextX += offset.x;
       }
+      constrainCatalogLayoutToPadding(layout);
       applyCatalogPlacements(layout.placements, mutatedNodeIds);
       nextX = layout.maxX + CATALOG_TREE_SIBLING_GAP;
     }
@@ -686,6 +687,19 @@ function alignCatalogPlacementsToCurrentRoot(placements, rootInstance, rootLayou
     placement.y += offsetY;
   }
   return { x: offsetX, y: offsetY };
+}
+
+export function constrainCatalogLayoutToPadding(layout, padding = CATALOG_TREE_LAYOUT_PADDING) {
+  const offsetX = Math.max(0, padding - layout.minX);
+  if (offsetX === 0) return 0;
+
+  for (const placement of layout.placements.values()) {
+    placement.x += offsetX;
+  }
+  layout.minX += offsetX;
+  layout.maxX += offsetX;
+  layout.nextX += offsetX;
+  return offsetX;
 }
 
 function syncCatalogConnectors(section, nodes, instancesByLabel, connectors, mutatedNodeIds) {

--- a/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
+++ b/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildPartialCatalogSyncScope,
+  constrainCatalogLayoutToPadding,
   removeEmptyStaleCatalogRootSections,
   removeStaleCatalogNodes,
 } from "../src/figma/figma-catalog-tree-sync-gateway";
@@ -174,6 +175,30 @@ test("child section reflow normalizes a single remaining root", () => {
   assert.equal(section.children[0].x, 100);
   assert.equal(section.children[0].y, 100);
   assert.deepEqual(mutatedNodeIds, ["org-id"]);
+});
+
+test("partial root layout shifts a wide subtree inside its section padding", () => {
+  const placements = new Map([
+    ["root", { x: 824, y: 100 }],
+    ["wide-leaf", { x: -280.5, y: 542 }],
+    ["right-leaf", { x: 1329.5, y: 321 }],
+  ]);
+  const layout = {
+    placements,
+    minX: -280.5,
+    maxX: 1986.5,
+    nextX: 2106.5,
+  };
+
+  const offset = constrainCatalogLayoutToPadding(layout, 100);
+
+  assert.equal(offset, 380.5);
+  assert.equal(layout.minX, 100);
+  assert.equal(layout.maxX, 2367);
+  assert.equal(layout.nextX, 2487);
+  assert.equal(placements.get("root").x, 1204.5);
+  assert.equal(placements.get("wide-leaf").x, 100);
+  assert.equal(placements.get("right-leaf").x, 1710);
 });
 
 function catalogNode(label: string, parentPath: string[] = []) {


### PR DESCRIPTION
## Summary
- constrain root-scoped catalog layouts to the documented 100 px section padding
- cover wide descendant layouts with a regression test
- document the subtree padding contract

## Verification
- npm run build
- npm test
- .\gradlew.bat check
- focused Figma sync against the official TeamCity main design model