### PR TITLE
feat(ci): optimize documentation-only pipeline runs

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -75,8 +75,14 @@ The GitHub ruleset for `main` is documented in
 The pipeline:
 
 - monitors all branches;
-- runs `Verify` with `.\gradlew.bat check --stacktrace` so Gradle failures keep
-  their diagnostic context in the TeamCity build log;
+- validates documentation coverage before Gradle: changes to TeamCity,
+  Figma-sync implementation, dependency-catalog model, or CI topology must
+  update their mapped canonical documentation in
+  [`.teamcity/documentation-coverage.json`](documentation-coverage.json);
+- uses `Verify change scope` to run `git diff --check` and local Markdown-link
+  validation for documentation-only changes; every other change runs
+  `.\gradlew.bat check --stacktrace` so Gradle failures retain their diagnostic
+  context in the TeamCity build log;
 - blocks invalid dependency version key names through
   `checkFigmaVersionNaming`, which is wired into the Gradle `check` lifecycle;
 - blocks unused dependency catalog entries through `checkFigmaCatalogUsage`,
@@ -97,14 +103,28 @@ requests.
 The pipeline:
 
 - triggers after `CI` finishes successfully on `<default>`;
-- generates `.teamcity/target/generated-configs` from the versioned Kotlin DSL
-  before each model generation or hash verification;
-- generates `build/reports/figma-sync/design-model.json` from `main`;
+- classifies the merged `main` revision before doing expensive work;
+- for a model-affecting revision, generates `.teamcity/target/generated-configs`
+  once and shares it with the verification job;
+- generates `build/reports/figma-sync/design-model.json` from `main` only for a
+  model-affecting revision;
 - sets `FIGMA_DESIGN_SYNC_OFFICIAL=true` and `FIGMA_DESIGN_SYNC_BRANCH` so the
   Gradle task can verify it is running under the official Figma Sync pipeline;
-- publishes the generated model as an artifact;
-- runs `Check Figma trunk sync` against the metadata currently stored in Figma;
+- publishes the Figma report directory and effective TeamCity configuration as
+  job artifacts;
+- runs `Check Figma trunk sync` against the metadata currently stored in Figma
+  only when the model can change;
 - publishes the optional `TeamCity Figma Sync` GitHub status on `main`.
+
+For a documentation-only `main` revision, the first Figma job publishes only a
+`sync-scope.json` artifact and the final job exits successfully without Maven,
+Gradle, model generation, metadata validation, or an MCP write. The previous
+official Figma metadata remains authoritative because the model is unchanged.
+
+Gradle configuration cache and local build cache are enabled in
+[`gradle.properties`](../gradle.properties). The current checked-in Pipeline DSL
+does not expose TeamCity Build Cache, so cache reuse remains agent-local; do not
+add untyped YAML just to force that feature.
 
 The visual write step is still MCP-operated outside TeamCity. Until that write
 step is automated, `Figma Sync` is expected to fail after a model-affecting
@@ -129,6 +149,21 @@ allowReuse = false
 This prevents TeamCity from satisfying a branch or pull request pipeline with a
 previously successful job from another branch. The generated design model must
 belong to the same branch revision as the pipeline chain being validated.
+
+### Queue And Cache Behaviour
+
+Keep TeamCity's built-in build queue optimization enabled for the VCS trigger.
+It coalesces obsolete queued runs when a newer revision arrives. The Pipeline
+DSL used by this repository has no typed, versioned setting to cancel a job that
+has already started; do not add a self-cancellation REST script because it can
+race with a newer revision and cancel the wrong run.
+
+The repository enables Gradle configuration cache and build cache in
+[`gradle.properties`](../gradle.properties). The current TeamCity DSL artifact
+does not expose the Pipeline-compatible Build Cache API, so the active cache is
+the local Gradle cache on the Windows build agent. Re-evaluate TeamCity artifact
+caching only after the exact DSL dependency used by `.teamcity/pom.xml` exposes
+that feature and a generated configuration validates it.
 
 ## Repository Checkout
 
@@ -182,10 +217,10 @@ repositories:
     path: ""
 ```
 
-The generated script content should remain a direct Gradle call:
+The generated CI script content should invoke the versioned scope wrapper:
 
 ```yaml
-script-content: .\gradlew.bat check --stacktrace
+script-content: powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\invoke-ci-verification.ps1
 ```
 
 Do not perform `git init`, `git fetch`, or `git checkout` from build script

--- a/.teamcity/documentation-coverage.json
+++ b/.teamcity/documentation-coverage.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "documentationOnlyPaths": [
+    "README.md",
+    "docs/*.md",
+    ".teamcity/README.md",
+    "repo/*/README.md",
+    "repo/*/docs/*.md"
+  ],
+  "rules": [
+    {
+      "id": "teamcity-pipelines",
+      "sourcePaths": [".teamcity/settings.kts", ".teamcity/pom.xml", ".teamcity/scripts/*"],
+      "documentationPaths": [".teamcity/README.md", "docs/runbooks/teamcity-cloudflare-access.md"]
+    },
+    {
+      "id": "figma-sync-implementation",
+      "sourcePaths": [
+        "repo/figma-design-sync/tools/*",
+        "repo/figma-design-sync/data/src/*",
+        "repo/figma-design-sync/domain/src/*",
+        "repo/figma-design-sync/plugin/src/*",
+        "repo/figma-design-sync/*/build.gradle.kts",
+        "repo/figma-design-sync/settings.gradle.kts"
+      ],
+      "documentationPaths": ["repo/figma-design-sync/README.md", "repo/figma-design-sync/docs/runbooks/*.md"]
+    },
+    {
+      "id": "dependency-catalog-model",
+      "sourcePaths": [
+        "repo/dependency-catalog/*/src/*",
+        "repo/dependency-catalog/*/build.gradle.kts",
+        "repo/dependency-catalog/settings.gradle.kts",
+        "repo/dependency-catalog/versions.properties",
+        "repo/gradle-plugins/*/src/*",
+        "repo/gradle-plugins/*/build.gradle.kts",
+        "repo/gradle-plugins/settings.gradle.kts",
+        "settings.gradle.kts",
+        "build.gradle.kts",
+        "gradle.properties"
+      ],
+      "documentationPaths": [
+        "repo/dependency-catalog/README.md",
+        "repo/gradle-plugins/README.md",
+        "repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md",
+        "repo/figma-design-sync/docs/runbooks/dependency-version-naming.md",
+        "repo/figma-design-sync/docs/runbooks/visual-sync-contract.md"
+      ]
+    },
+    {
+      "id": "ci-topology",
+      "sourcePaths": ["docs/ci/external-topology.yaml", "docs/ci/windows-runtime.yaml"],
+      "documentationPaths": [
+        "docs/ci/external-topology-validation.md",
+        "docs/ci/windows-runtime-validation.md",
+        "docs/ci/visual-model-contract.md"
+      ]
+    }
+  ]
+}

--- a/.teamcity/scripts/get-change-impact.ps1
+++ b/.teamcity/scripts/get-change-impact.ps1
@@ -1,0 +1,97 @@
+[CmdletBinding()]
+param(
+    [string]$ManifestPath = (Join-Path $PSScriptRoot "../documentation-coverage.json"),
+    [string[]]$ChangedPath,
+    [switch]$FailOnDocumentationGap,
+    [switch]$AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+function Normalize-Path([string]$Path) {
+    return $Path.Trim().Replace("\\", "/")
+}
+
+function Test-PathMatchesAny([string]$Path, [object[]]$Patterns) {
+    $normalizedPath = Normalize-Path $Path
+    return @($Patterns | Where-Object { $normalizedPath -like (Normalize-Path $_) }).Count -gt 0
+}
+
+function Get-RepositoryChangedPaths {
+    & git rev-parse --verify origin/main 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Cannot resolve origin/main. Documentation coverage fails closed because the change scope is unknown."
+    }
+
+    $head = (& git rev-parse HEAD).Trim()
+    $main = (& git rev-parse origin/main).Trim()
+    if ($head -eq $main) {
+        $base = (& git rev-parse "$head^").Trim()
+    } else {
+        $base = (& git merge-base HEAD origin/main).Trim()
+    }
+
+    return [PSCustomObject]@{
+        baseRevision = $base
+        paths = @(& git diff --name-only --diff-filter=ACMR "$base..$head" | ForEach-Object { Normalize-Path $_ })
+    }
+}
+
+if (-not (Test-Path -LiteralPath $ManifestPath)) {
+    throw "Documentation coverage manifest was not found: $ManifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+$changeSet = if ($PSBoundParameters.ContainsKey("ChangedPath")) {
+    [PSCustomObject]@{
+        baseRevision = $null
+        paths = @($ChangedPath | ForEach-Object { Normalize-Path $_ } | Where-Object { $_ })
+    }
+} else {
+    Get-RepositoryChangedPaths
+}
+$changedPaths = @($changeSet.paths)
+
+$violations = @()
+$affectedRules = @()
+foreach ($rule in @($manifest.rules)) {
+    $changedSources = @($changedPaths | Where-Object { Test-PathMatchesAny $_ @($rule.sourcePaths) })
+    if ($changedSources.Count -eq 0) {
+        continue
+    }
+
+    $affectedRules += $rule.id
+    $changedDocumentation = @($changedPaths | Where-Object { Test-PathMatchesAny $_ @($rule.documentationPaths) })
+    if ($changedDocumentation.Count -eq 0) {
+        $violations += [PSCustomObject]@{
+            rule = $rule.id
+            changedSources = $changedSources
+            requiredDocumentation = @($rule.documentationPaths)
+        }
+    }
+}
+
+$documentationOnly = $changedPaths.Count -gt 0 -and @(
+    $changedPaths | Where-Object { -not (Test-PathMatchesAny $_ @($manifest.documentationOnlyPaths)) }
+).Count -eq 0
+
+$result = [PSCustomObject]@{
+    scope = if ($documentationOnly) { "documentation-only" } else { "full-verification" }
+    comparisonBase = $changeSet.baseRevision
+    changedPaths = $changedPaths
+    affectedDocumentationRules = $affectedRules
+    documentationViolations = $violations
+}
+
+if ($FailOnDocumentationGap -and $violations.Count -gt 0) {
+    $details = $violations | ForEach-Object {
+        "[$($_.rule)] changed: $($_.changedSources -join ', '); update one of: $($_.requiredDocumentation -join ', ')"
+    }
+    throw "Documentation coverage is incomplete.`n$($details -join "`n")"
+}
+
+if ($AsJson) {
+    $result | ConvertTo-Json -Depth 5
+} else {
+    $result
+}

--- a/.teamcity/scripts/get-change-impact.ps1
+++ b/.teamcity/scripts/get-change-impact.ps1
@@ -1,12 +1,16 @@
 [CmdletBinding()]
 param(
-    [string]$ManifestPath = (Join-Path $PSScriptRoot "../documentation-coverage.json"),
+    [string]$ManifestPath,
     [string[]]$ChangedPath,
     [switch]$FailOnDocumentationGap,
     [switch]$AsJson
 )
 
 $ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
+    $ManifestPath = Join-Path $PSScriptRoot "../documentation-coverage.json"
+}
 
 function Normalize-Path([string]$Path) {
     return $Path.Trim().Replace("\\", "/")

--- a/.teamcity/scripts/invoke-ci-verification.ps1
+++ b/.teamcity/scripts/invoke-ci-verification.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+Push-Location $repositoryRoot
+try {
+    $impact = & (Join-Path $PSScriptRoot "get-change-impact.ps1") -FailOnDocumentationGap -AsJson |
+        ConvertFrom-Json
+
+    if ($impact.scope -eq "documentation-only") {
+        if ([string]::IsNullOrWhiteSpace($impact.comparisonBase)) {
+            throw "Documentation-only verification requires a comparison base."
+        }
+
+        & git diff --check "$($impact.comparisonBase)..HEAD"
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+
+        foreach ($path in @($impact.changedPaths | Where-Object { $_ -like "*.md" })) {
+            $file = Join-Path $repositoryRoot $path
+            $sourceDirectory = Split-Path -Parent $file
+            $matches = [regex]::Matches((Get-Content -LiteralPath $file -Raw), '(?<!\!)\[[^\]]*\]\((?<target>[^ )]+)')
+            foreach ($match in $matches) {
+                $target = $match.Groups["target"].Value.Trim("<>")
+                if ($target -match "^(https?:|mailto:|#)") {
+                    continue
+                }
+
+                $targetPath = ($target -split "[#?]", 2)[0]
+                if ([string]::IsNullOrWhiteSpace($targetPath)) {
+                    continue
+                }
+
+                $resolvedTarget = if ($targetPath.StartsWith("/")) {
+                    Join-Path $repositoryRoot $targetPath.TrimStart("/")
+                } else {
+                    Join-Path $sourceDirectory $targetPath
+                }
+                if (-not (Test-Path -LiteralPath $resolvedTarget)) {
+                    throw "Broken local Markdown link in '$path': $target"
+                }
+            }
+        }
+
+        Write-Host "Documentation-only change verified; Gradle check is not required."
+        exit 0
+    }
+
+    & .\gradlew.bat check --stacktrace
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/.teamcity/scripts/prepare-figma-sync.ps1
+++ b/.teamcity/scripts/prepare-figma-sync.ps1
@@ -1,0 +1,37 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$reportDirectory = Join-Path $repositoryRoot "build/reports/figma-sync"
+$generatedConfigurationDirectory = Join-Path $repositoryRoot ".teamcity/target/generated-configs"
+Push-Location $repositoryRoot
+try {
+    $impact = & (Join-Path $PSScriptRoot "get-change-impact.ps1") -FailOnDocumentationGap -AsJson |
+        ConvertFrom-Json
+
+    New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+    New-Item -ItemType Directory -Path $generatedConfigurationDirectory -Force | Out-Null
+
+    if ($impact.scope -eq "full-verification") {
+        & .\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+
+        & .\gradlew.bat generateFigmaDesignModel
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
+    }
+
+    $scope = [PSCustomObject]@{
+        scope = $impact.scope
+        comparisonBase = $impact.comparisonBase
+        gitSha = (& git rev-parse HEAD).Trim()
+    }
+    $scope | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $reportDirectory "sync-scope.json") -Encoding utf8
+    Write-Host "Prepared Figma Sync scope: $($scope.scope)"
+} finally {
+    Pop-Location
+}

--- a/.teamcity/scripts/tests/documentation-only-pipeline.tests.ps1
+++ b/.teamcity/scripts/tests/documentation-only-pipeline.tests.ps1
@@ -1,0 +1,64 @@
+$ErrorActionPreference = "Stop"
+
+$sourceRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+$testRoot = Join-Path $env:TEMP ("water-my-plants-ci-scope-" + [guid]::NewGuid())
+
+function Assert-Equal([object]$Actual, [object]$Expected, [string]$Message) {
+    if ($Actual -ne $Expected) {
+        throw "$Message. Expected '$Expected', got '$Actual'."
+    }
+}
+
+function Invoke-Git([string[]]$Arguments) {
+    & git @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path "$testRoot/.teamcity/scripts" -Force | Out-Null
+    New-Item -ItemType Directory -Path "$testRoot/docs" -Force | Out-Null
+    Copy-Item -LiteralPath "$sourceRoot/.teamcity/documentation-coverage.json" -Destination "$testRoot/.teamcity/documentation-coverage.json"
+    @("get-change-impact.ps1", "invoke-ci-verification.ps1", "prepare-figma-sync.ps1", "verify-figma-trunk-sync.ps1") |
+        ForEach-Object {
+            Copy-Item -LiteralPath "$sourceRoot/.teamcity/scripts/$_" -Destination "$testRoot/.teamcity/scripts/$_"
+        }
+
+    Push-Location $testRoot
+    try {
+        Invoke-Git @("init")
+        Invoke-Git @("config", "user.name", "CI test")
+        Invoke-Git @("config", "user.email", "ci@example.invalid")
+        Set-Content -LiteralPath "docs/guide.md" -Value "# Guide"
+        Invoke-Git @("add", ".")
+        Invoke-Git @("commit", "-m", "test: base")
+        Invoke-Git @("branch", "-M", "main")
+        Invoke-Git @("remote", "add", "origin", $testRoot)
+        Invoke-Git @("fetch", "origin", "main:refs/remotes/origin/main")
+
+        Set-Content -LiteralPath "docs/guide.md" -Value "# Guide`n`nDocumented change."
+        Invoke-Git @("add", "docs/guide.md")
+        Invoke-Git @("commit", "-m", "docs: update guide")
+
+        & "$testRoot/.teamcity/scripts/invoke-ci-verification.ps1"
+        Assert-Equal $LASTEXITCODE 0 "Documentation-only CI verification must succeed without Gradle"
+
+        & "$testRoot/.teamcity/scripts/prepare-figma-sync.ps1"
+        Assert-Equal $LASTEXITCODE 0 "Documentation-only Figma preparation must succeed"
+        $scope = Get-Content -LiteralPath "build/reports/figma-sync/sync-scope.json" -Raw | ConvertFrom-Json
+        Assert-Equal $scope.scope "documentation-only" "Figma scope artifact must preserve documentation-only classification"
+        Assert-Equal (Test-Path -LiteralPath "build/reports/figma-sync/design-model.json") $false "Documentation-only Figma preparation must not generate a model"
+
+        & "$testRoot/.teamcity/scripts/verify-figma-trunk-sync.ps1"
+        Assert-Equal $LASTEXITCODE 0 "Documentation-only Figma verification must be a successful no-op"
+    } finally {
+        Pop-Location
+    }
+} finally {
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}
+
+Write-Host "documentation-only pipeline tests passed"

--- a/.teamcity/scripts/tests/get-change-impact.tests.ps1
+++ b/.teamcity/scripts/tests/get-change-impact.tests.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = "Stop"
+
+$scriptPath = Join-Path $PSScriptRoot "../get-change-impact.ps1"
+
+function Assert-Equal([object]$Actual, [object]$Expected, [string]$Message) {
+    if ($Actual -ne $Expected) {
+        throw "$Message. Expected '$Expected', got '$Actual'."
+    }
+}
+
+function Invoke-Impact([string[]]$Paths) {
+    return (& $scriptPath -ChangedPath $Paths -AsJson | ConvertFrom-Json)
+}
+
+$documentationOnly = Invoke-Impact @("repo/figma-design-sync/docs/runbooks/troubleshooting.md")
+Assert-Equal $documentationOnly.scope "documentation-only" "Markdown-only changes must be classified as documentation-only"
+Assert-Equal @($documentationOnly.documentationViolations).Count 0 "Markdown-only changes must not require extra coverage"
+Assert-Equal $documentationOnly.comparisonBase $null "Explicit test paths must not invent a Git comparison base"
+
+$coveredImplementation = Invoke-Impact @(
+    "repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts",
+    "repo/figma-design-sync/docs/runbooks/visual-sync-contract.md"
+)
+Assert-Equal $coveredImplementation.scope "full-verification" "Implementation changes must retain full verification"
+Assert-Equal @($coveredImplementation.documentationViolations).Count 0 "Mapped implementation documentation must satisfy coverage"
+
+$uncoveredTeamCityChangeFailed = $false
+try {
+    & $scriptPath -ChangedPath @(".teamcity/settings.kts") -FailOnDocumentationGap | Out-Null
+} catch {
+    $uncoveredTeamCityChangeFailed = $_.Exception.Message -like "*teamcity-pipelines*"
+}
+Assert-Equal $uncoveredTeamCityChangeFailed $true "TeamCity changes must fail without mapped documentation"
+
+Write-Host "get-change-impact tests passed"

--- a/.teamcity/scripts/verify-figma-trunk-sync.ps1
+++ b/.teamcity/scripts/verify-figma-trunk-sync.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$scopeFile = Join-Path $repositoryRoot "build/reports/figma-sync/sync-scope.json"
+Push-Location $repositoryRoot
+try {
+    if (-not (Test-Path -LiteralPath $scopeFile)) {
+        throw "Missing Figma Sync scope artifact: $scopeFile"
+    }
+
+    $scope = Get-Content -LiteralPath $scopeFile -Raw | ConvertFrom-Json
+    $currentSha = (& git rev-parse HEAD).Trim()
+    if ($scope.gitSha -ne $currentSha) {
+        throw "Figma Sync scope artifact belongs to '$($scope.gitSha)', not '$currentSha'."
+    }
+
+    if ($scope.scope -eq "documentation-only") {
+        Write-Host "Documentation-only main change; Figma model and metadata are unchanged."
+        exit 0
+    }
+
+    $modelFile = Join-Path $repositoryRoot "build/reports/figma-sync/design-model.json"
+    if (-not (Test-Path -LiteralPath $modelFile)) {
+        throw "Missing official Figma design model artifact: $modelFile"
+    }
+
+    & .\gradlew.bat checkFigmaTrunkSync
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -68,8 +68,12 @@ object WaterMyPlantsCi : Pipeline({
 
         steps {
             step(PipelineScriptStep {
-                name = "Run Gradle check"
-                scriptContent = """.\gradlew.bat check --stacktrace"""
+                name = "Validate documentation coverage"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\get-change-impact.ps1 -FailOnDocumentationGap"""
+            })
+            step(PipelineScriptStep {
+                name = "Verify change scope"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\invoke-ci-verification.ps1"""
             })
         }
 
@@ -127,19 +131,18 @@ object WaterMyPlantsFigmaSync : Pipeline({
 
         steps {
             step(PipelineScriptStep {
-                name = "Generate effective TeamCity configuration"
-                scriptContent = """.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate"""
-            })
-            step(PipelineScriptStep {
-                name = "Generate Figma design model"
-                scriptContent = """.\gradlew.bat generateFigmaDesignModel"""
+                name = "Prepare Figma Sync"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\prepare-figma-sync.ps1"""
             })
         }
 
         outputFiles {
-            pipelineArtifacts("build/reports/figma-sync/design-model.json")
-            sharedWithJobs("build/reports/figma-sync/design-model.json")
+            pipelineArtifacts("build/reports/figma-sync")
+            sharedWithJobs("build/reports/figma-sync")
+            pipelineArtifacts(".teamcity/target/generated-configs")
+            sharedWithJobs(".teamcity/target/generated-configs")
         }
+
     }
 
     job {
@@ -153,12 +156,8 @@ object WaterMyPlantsFigmaSync : Pipeline({
 
         steps {
             step(PipelineScriptStep {
-                name = "Generate effective TeamCity configuration"
-                scriptContent = """.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate"""
-            })
-            step(PipelineScriptStep {
                 name = "Verify Figma sync metadata"
-                scriptContent = """.\gradlew.bat checkFigmaTrunkSync"""
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\verify-figma-trunk-sync.ps1"""
             })
         }
 
@@ -166,7 +165,10 @@ object WaterMyPlantsFigmaSync : Pipeline({
             feature(GitHubStatusPublisher("TeamCity Figma Sync"))
         }
 
-        dependency("figma_sync_generate_design_model", listOf("build/reports/figma-sync/design-model.json"))
+        dependency(
+            "figma_sync_generate_design_model",
+            listOf("build/reports/figma-sync", ".teamcity/target/generated-configs")
+        )
     }
 })
 

--- a/docs/ci/documentation-coverage.md
+++ b/docs/ci/documentation-coverage.md
@@ -1,0 +1,51 @@
+# CI Documentation Coverage
+
+`.teamcity/documentation-coverage.json` is the versioned documentation contract
+for changes that can alter the CI or Figma documentation state.
+
+`get-change-impact.ps1` compares the build revision with `origin/main`. It
+classifies the change as `documentation-only` only when every changed path is an
+explicitly allowed Markdown path. Every other change remains
+`full-verification`.
+
+For each affected rule, the script requires at least one changed file matching
+that rule's `documentationPaths`. CI fails before Gradle when the source surface
+changes without its canonical documentation.
+
+The contract is deliberately conservative:
+
+- An unknown path is never documentation-only.
+- If `origin/main` is unavailable, the script fails instead of guessing a diff.
+- Updating unrelated Markdown does not satisfy a rule.
+- Figma-only component edits cannot be inferred from Git. Update the matching
+  runbook in the same pull request when a component contract changes.
+- PlantUML publication remains governed by `AGENTS.md`: a changed `.puml` must
+  be rendered and published to Figma before its merge is complete.
+
+When adding a new Figma-relevant source area, add a narrow rule to the manifest
+and a matching test in `.teamcity/scripts/tests/get-change-impact.tests.ps1`.
+
+## CI Execution
+
+`WaterMyPlantsCi` executes this contract before Gradle. A documentation-only
+revision validates whitespace and local Markdown links, then publishes the same
+required `TeamCity CI` status without running Gradle. All other revisions run
+the complete Gradle `check` lifecycle.
+
+After a successful `main` CI run, `Figma Sync` reads the same classification. A
+documentation-only revision publishes a scope artifact and exits successfully
+without generating a design model or checking Figma metadata. The pipeline still
+runs, so the CI-to-Figma ordering and visible post-merge status remain stable.
+
+## Cache And Queue Policy
+
+Gradle configuration cache and build cache are enabled in `gradle.properties`.
+The current TeamCity Pipeline DSL dependency does not expose the typed Build
+Cache feature, so CI relies on the Windows agent's local Gradle cache rather
+than a manually authored TeamCity cache feature.
+
+TeamCity's VCS-trigger queue optimization must remain enabled. It coalesces
+queued work when a newer revision exists. Running jobs are not automatically
+cancelled: the checked-in Pipeline DSL has no safe typed control for that, and a
+custom REST cancellation race would be less reliable than allowing the current
+job to finish.

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,5 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true
+org.gradle.caching=true
 android.experimental.reportAggregationSupport=true

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -31,6 +31,35 @@ The MCP sync code rejects models whose `branch` is not `main`. A branch-local
 model is never an authorized Figma write input, even when its `modelHash`
 matches the expected content.
 
+## Documentation-Only Changes
+
+A change that only edits Markdown documentation or runbooks does not change the
+design model, visual writer, Figma component contract, or visual state. For
+that scope, the normal pull request CI is sufficient: do not manually generate
+a TeamCity design model, run an MCP visual sync, or rewrite Figma metadata.
+
+This exemption applies only when every changed file is documentation that is
+not itself rendered or synchronized into Figma. It does not apply when the
+change includes any of the following:
+
+- PlantUML sources or other documentation artifacts published into Figma.
+- Model extraction, serialization, catalog, module, plugin, version, or CI
+  topology sources.
+- TypeScript visual writer, runner, transport, layout, or component-binding
+  code.
+- A Figma component or visual contract change that requires the checked-in
+  documentation to be updated with it.
+
+Do not trigger Figma Sync merely to make its metadata point at a
+documentation-only commit. The previous metadata remains valid because
+`modelHash` and the visual state are unchanged.
+
+On `main`, TeamCity still starts the `Figma Sync` pipeline after a successful
+`CI` run so the post-merge status chain remains visible. Its scope artifact
+marks documentation-only revisions and makes both jobs successful no-ops: they
+do not invoke Maven or Gradle, generate `design-model.json`, validate metadata,
+or request an MCP write.
+
 ## Branch Visual Iteration
 
 If the TeamCity `main` artifact already represents the model state being tested,

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -45,6 +45,28 @@ Do not infer success from elapsed time, and do not infer failure only because
 the local runner returned no result. Keep metadata unchanged until every target
 has a confirmed successful result.
 
+## Transient Figma Memory Failures
+
+Figma may return a direct `Out of memory` error from operations such as
+`get_locked` or `findAllWithCriteria`, particularly during catalog cleanup
+execution units. Unlike a caller timeout, this is an explicit failed
+`use_figma` response: the unit is atomic and does not commit partial visual
+mutations.
+
+When this happens:
+
+1. Retry exactly the failed `99-*.mcp.js` execution unit with the same staged
+   official payload.
+2. Do not restart already completed roots or targets.
+3. Confirm that the retried unit reports its requested target in
+   `completedTargets` before continuing.
+4. Keep metadata unchanged until every visual execution unit has completed.
+
+Cleanup-only units are idempotent, so an exact retry is the expected recovery.
+If the same unit fails repeatedly, stop retrying and inspect its target scope
+and Figma document size before changing the transport or restarting the full
+sync.
+
 ## Payload Transport Failures
 
 The Figma MCP `use_figma` call has a practical source-size limit near 50k


### PR DESCRIPTION
Classifies CI changes, enforces mapped documentation, skips Gradle and Figma model work for Markdown-only revisions, and shares generated TeamCity configuration between Figma jobs.