### PR TITLE
feat(figma-design-sync): expose catalog root execution scopes

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -89,11 +89,10 @@ does not have to be the metadata page. The staging runner searches document
 image fills and does not rely on `loadAllPagesAsync`; this MCP runtime may
 expose that API while rejecting it at execution time.
 
-To run only one top-level catalog root against its child section, add `--roots`
-and `--section-node-id`:
+To run only one top-level catalog root, use its explicit execution scope:
 
 ```powershell
-node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.libraries --roots=androidx --section-node-id=63069:630 --allow-partial=true
+node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=waterMyPlants.libraries.androidx --allow-partial=true
 ```
 
 Use this for large catalog targets that hit MCP timeouts or generic Figma

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -156,7 +156,9 @@ function resolveOptions(args) {
   if (!targetValue) {
     throw new Error("Missing --target. Preview fixtures can infer a default target.");
   }
-  const targets = targetValue === "all" ? [...FULL_VISUAL_TARGETS] : parseTargets(targetValue);
+  const requestedTargets = targetValue === "all" ? [...FULL_VISUAL_TARGETS] : parseTargets(targetValue);
+  const scopedTargets = requestedTargets.map(parseTargetScope);
+  const targets = scopedTargets.map(({ target }) => target);
   if (targets.length === 0) {
     throw new Error("Missing --target.");
   }
@@ -235,7 +237,11 @@ function resolveOptions(args) {
     : OFFICIAL_STAGING_NAMESPACE;
   const writeMetadata = mode === "official" && target === "metadata";
   const sectionNodeId = args["section-node-id"];
-  const roots = parseRoots(args.roots);
+  const scopedRoots = scopedTargets.flatMap(({ root }) => root ? [root] : []);
+  if (scopedRoots.length > 0 && args.roots) {
+    throw new Error("A root-qualified target cannot be combined with --roots.");
+  }
+  const roots = scopedRoots.length > 0 ? scopedRoots : parseRoots(args.roots);
   const allowOfficialSections = args["allow-official-sections"] === "true";
 
   if ((sectionNodeId || roots.length > 0) && targets.length !== 1) {
@@ -260,6 +266,7 @@ function resolveOptions(args) {
     entrypoint,
     target,
     targets,
+    requestedTargets,
     modelPath,
     scriptPath,
     outRoot,
@@ -349,7 +356,7 @@ async function writeTargetRunnerFiles(outDir, options, designModel) {
     const roots = catalogRoots(designModel, target);
     if (roots.length === 0) {
       const fileName = `99-${String(index).padStart(2, "0")}-${safeName(target)}.mcp.js`;
-      files.push(await writeFileIn(outDir, fileName, runTargetSource(options, [target])));
+      files.push(await writeFileIn(outDir, fileName, runTargetSource(options, [target], { executionScope: target })));
       continue;
     }
 
@@ -359,7 +366,7 @@ async function writeTargetRunnerFiles(outDir, options, designModel) {
       files.push(await writeFileIn(
         outDir,
         fileName,
-        runTargetSource(options, [target], { roots: [root] })
+        runTargetSource(options, [target], { roots: [root], executionScope: `${target}.${root}` })
       ));
     }
 
@@ -367,7 +374,7 @@ async function writeTargetRunnerFiles(outDir, options, designModel) {
     files.push(await writeFileIn(
       outDir,
       cleanupFileName,
-      runTargetSource(options, [target], { cleanupOnly: true })
+      runTargetSource(options, [target], { cleanupOnly: true, executionScope: `${target}.cleanup` })
     ));
   }
   return files;
@@ -781,10 +788,11 @@ function runTargetSource(options, targets = options.targets, runOptions = {}) {
     ...(roots.length > 0 ? { catalogRootFilters: { [target]: roots } } : {}),
     ...(runOptions.cleanupOnly ? { catalogCleanupOnlyTargets: [target] } : {}),
   };
+  const executionScope = runOptions.executionScope || options.requestedTargets?.[0] || target;
 
   const invokeScript = options.entrypoint === "preview-catalog"
     ? previewCatalogInvocationSource()
-    : trunkSyncInvocationSource();
+    : trunkSyncInvocationSource(executionScope, target);
 
   return `${runtimeHeader()}
 const namespace = ${JSON.stringify(options.namespace)};
@@ -849,7 +857,7 @@ ${invokeScript}
 `;
 }
 
-function trunkSyncInvocationSource() {
+function trunkSyncInvocationSource(executionScope, target) {
   return `
 script = script.replace(
   "const DESIGN_MODEL = undefined;",
@@ -863,7 +871,8 @@ script = script.replace(
 const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
 const run = new AsyncFunction("figma", "stagedModel", script);
 
-return await run(figma, stagedModel);
+const result = await run(figma, stagedModel);
+return { ...result, executionScope: ${JSON.stringify(executionScope)}, modelTarget: ${JSON.stringify(target)} };
 `;
 }
 
@@ -937,6 +946,17 @@ function parseTargets(value) {
       .map((target) => target.trim())
       .filter(Boolean)
   )];
+}
+
+function parseTargetScope(value) {
+  if (KNOWN_TARGETS.includes(value)) return { target: value, root: null };
+  const catalogTarget = [...CATALOG_TARGETS].sort((left, right) => right.length - left.length)
+    .find((target) => value.startsWith(`${target}.`));
+  if (!catalogTarget) return { target: value, root: null };
+  const root = value.slice(catalogTarget.length + 1);
+  return !root || root === "cleanup" || root.includes(".")
+    ? { target: value, root: null }
+    : { target: catalogTarget, root };
 }
 
 function sameTargets(actual, expected) {

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -256,6 +256,28 @@ test("official runner accepts the granular Windows runtime target", async () => 
   }
 });
 
+test("official runner accepts a root-qualified catalog execution scope", async () => {
+  const workspace = createRunnerFixture();
+  try {
+    runRunner([
+      "--mode=official",
+      `--model=${workspace.modelPath}`,
+      `--script=${workspace.scriptPath}`,
+      "--target=waterMyPlants.libraries.androidx",
+      "--allow-partial=true",
+      `--out-dir=${workspace.outDir}`,
+    ]);
+
+    const runDir = join(workspace.outDir, "official-trunk-sync-waterMyPlants-libraries-png-design-model-json");
+    const source = readFileSync(join(runDir, "99-run-target.mcp.js"), "utf8");
+    assert.match(source, /"catalogRootFilters":\{"waterMyPlants\.libraries":\["androidx"\]\}/);
+    assert.match(source, /executionScope: "waterMyPlants\.libraries\.androidx"/);
+    assert.match(source, /modelTarget: "waterMyPlants\.libraries"/);
+  } finally {
+    await rm(workspace.root, { recursive: true, force: true });
+  }
+});
+
 test("official runner can explicitly use chunk transport fallback", async () => {
   const workspace = createRunnerFixture();
 


### PR DESCRIPTION
## Summary
- expose catalog roots as explicit execution scopes
- preserve parent model targets and root filters
- document and test root-qualified runner invocation

## Verification
- npm run build
- npm run test:write-mcp-runner