### PR TITLE
fix(figma-design-sync): stabilize scoped visual sync

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -123,6 +123,13 @@ node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json
 Library roots match `group`; plugin roots match `id`. If the root is missing,
 the runner fails before mutating Figma and prints the available roots.
 
+Root-scoped execution also limits Figma traversal to the matching child
+section. Instance, connector, lock, stroke, fill, and descendant-layout scans
+must not visit sibling catalog roots or page-level connectors. The generated
+official runner uses one root-scoped `99-*.mcp.js` unit per declared root and a
+separate cleanup unit for stale nodes or sections that require a whole-catalog
+view. This keeps the runtime memory boundary aligned with the model scope.
+
 Known child sections:
 
 | Target | Root | Child section |

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-contract.md
@@ -66,12 +66,13 @@ required roots and all other official targets have completed successfully.
 The CI writer reads only `content.ci` from the official `main`
 `design-model.json`. It creates or updates one parent section named
 `Continuous Integration and Design Documentation` on Figma page `63153:2876`
-and exposes four independently runnable targets:
+and exposes five independently runnable targets:
 
 - `ci.overview`;
 - `ci.pullRequestIntegration`;
 - `ci.postMergeDesignDocumentation`;
-- `ci.infrastructureAndAccess`.
+- `ci.infrastructureAndAccess`;
+- `ci.windowsRuntime`.
 
 Each visual entity is an instance of `.ci node` (`64301:3927`). The writer
 selects the matching mode from the `ci/cd` variable collection: `Actor`,
@@ -104,6 +105,13 @@ topology grid. `Windows Service Runtime` is a connector-free grid whose service
 nodes share one row. Horizontal flows connect from the side anchors of their node
 groups and vertically align node centers. Their inter-node gap grows when
 necessary so the connector label fits centered on the horizontal connector.
+Figma can apply exposed boolean visibility properties after `setProperties`
+returns, which changes instance height after hidden blocks collapse. The writer
+must wait until managed node-group dimensions are stable before laying out a
+row, then wait for connector geometry to stabilize before centering labels on
+the resulting connector bounds. Calculating either position from the initial
+component dimensions top-aligns mixed-height nodes and leaves labels centered
+on stale connector coordinates.
 Disconnected horizontal flows are stacked as separate rows and each row starts
 at the same left edge. Post-merge job order is derived from declared artifact
 publication and job dependencies, never from the order of jobs in the generated

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -100,9 +100,15 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
 
       throw new Error(`Expected '${sectionNodeId}' to be a SECTION.`);
     }
-    unlockSectionTreeForMutation(section, mutatedNodeIds);
-    applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
-    applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
+    let traversalRoots = catalogTraversalRoots(section, isPartialRootSync ? scopedRootLabels : undefined);
+    unlockSectionTreeForMutation(section, mutatedNodeIds, isPartialRootSync ? traversalRoots : null);
+    applyCatalogSectionContract(
+      section,
+      traversalRoots,
+      isPartialRootSync,
+      outlineVariable,
+      mutatedNodeIds
+    );
 
     if (!isPartialRootSync && scopedModelNodes.length === 0) {
       removedCatalogNodes.push(...removeEmptyCatalogTreeTarget(target, section, mutatedNodeIds));
@@ -110,8 +116,8 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     }
 
     showCatalogTreeSection(section, mutatedNodeIds);
-    const instancesByLabel = collectTreeNodeInstancesByLabel(section, target.type);
-    let connectors = collectTreeConnectors(section);
+    const instancesByLabel = collectTreeNodeInstancesByLabel(section, target.type, traversalRoots);
+    let connectors = collectTreeConnectors(section, traversalRoots);
 
     if (cleanupOnly) {
       const cleanupResult = cleanupCatalogTreeTarget({
@@ -184,12 +190,9 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     removedCatalogNodes.push(...staleResult.removedCatalogNodes);
     removedCatalogConnectors.push(...staleResult.removedCatalogConnectors);
     connectors = staleResult.connectors;
-    const removedRootSections = removeEmptyStaleCatalogRootSections(
-      target,
-      section,
-      modelRootLabels,
-      mutatedNodeIds
-    );
+    const removedRootSections = isPartialRootSync
+      ? []
+      : removeEmptyStaleCatalogRootSections(target, section, modelRootLabels, mutatedNodeIds);
     removedCatalogNodes.push(...removedRootSections);
 
     connectors = createMissingCatalogConnectors(
@@ -201,6 +204,7 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
       createdCatalogConnectors,
       mutatedNodeIds
     );
+    traversalRoots = catalogTraversalRoots(section, isPartialRootSync ? scopedRootLabels : undefined);
 
     layoutCatalogTreeNodes(section, expectedNodes, instancesByLabel, mutatedNodeIds, {
       scopeLabels: partialScope?.labels,
@@ -213,13 +217,22 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
           .filter(Boolean)
       : [...instancesByLabel.values()];
     resizeSectionsToFit(section, nodesToResize, mutatedNodeIds);
-    stackDescendantSectionsWithGap(section, mutatedNodeIds);
+    for (const traversalRoot of traversalRoots) {
+      stackDescendantSectionsWithGap(traversalRoot, mutatedNodeIds);
+    }
+    if (isPartialRootSync) {
+      stackChildSectionsFromPadding(section, mutatedNodeIds);
+    }
     stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds);
     resizeAncestorSectionsToFit(section, mutatedNodeIds);
-    removeCatalogTreeSectionFills(section, mutatedNodeIds);
-    applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
-    applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
-    lockOnlyRootSection(section, mutatedNodeIds);
+    applyCatalogSectionContract(
+      section,
+      traversalRoots,
+      isPartialRootSync,
+      outlineVariable,
+      mutatedNodeIds
+    );
+    lockOnlyRootSection(section, mutatedNodeIds, isPartialRootSync ? traversalRoots : null);
   }
 
   return {
@@ -230,6 +243,38 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
     removedCatalogConnectors,
     mutatedNodeIds,
   };
+  }
+}
+
+export function catalogTraversalRoots(section, rootLabels) {
+  if (!rootLabels || rootLabels.length === 0) {
+    return [section];
+  }
+
+  const requestedRoots = new Set(rootLabels);
+  return section.children.filter((child) =>
+    child.type === "SECTION" && requestedRoots.has(child.name)
+  );
+}
+
+function applyCatalogSectionContract(
+  section,
+  traversalRoots,
+  isPartialRootSync,
+  outlineVariable,
+  mutatedNodeIds
+) {
+  if (!isPartialRootSync) {
+    removeCatalogTreeSectionFills(section, mutatedNodeIds);
+    applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
+    applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
+    return;
+  }
+
+  for (const traversalRoot of traversalRoots) {
+    removeCatalogTreeSectionFills(traversalRoot, mutatedNodeIds);
+    applySectionStrokeContractTree(traversalRoot, outlineVariable, mutatedNodeIds);
+    applyAncestorSectionStrokeContract(traversalRoot, outlineVariable, mutatedNodeIds);
   }
 }
 

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -276,9 +276,18 @@ async function syncSectionContent(
     mutatedNodeIds.push(label.id);
   }
 
+  await waitForStableCiLayout(groups.map(({ group }) => group));
   layoutNodeGroups(groups, plan.orientation, plan.connections, connectorLabelsByModelId);
+  await waitForStableCiLayout(groups.map(({ group }) => group));
   const positionedLabels: GroupNode[] = [];
   const parallelConnections = parallelConnectionInfo(plan.connections);
+  const connectorRecords: Array<{
+    source: GroupNode;
+    target: GroupNode;
+    label: GroupNode;
+    connector: ConnectorNode;
+    magnets: { start: string; end: string };
+  }> = [];
 
   for (const edge of plan.connections) {
     const source = groupsByModelId.get(edge.source);
@@ -310,6 +319,13 @@ async function syncSectionContent(
     connector.setSharedPluginData(METADATA_NAMESPACE, CI_MODEL_ID_KEY, edge.id);
     section.insertChild(0, connector);
     await clearNativeConnectorLabel(connector);
+    connectorRecords.push({ source, target, label, connector, magnets });
+    createdCiConnectors.push(connector.id);
+    mutatedNodeIds.push(connector.id);
+  }
+
+  await waitForStableCiLayout(connectorRecords.map(({ connector }) => connector));
+  for (const { source, target, label, connector, magnets } of connectorRecords) {
     const connectorBounds = connector.absoluteBoundingBox;
     const sectionBounds = section.absoluteBoundingBox;
     const position = centersLabelOnConnector(magnets) && connectorBounds && sectionBounds
@@ -331,8 +347,6 @@ async function syncSectionContent(
     label.x = position.x;
     label.y = position.y;
     positionedLabels.push(label);
-    createdCiConnectors.push(connector.id);
-    mutatedNodeIds.push(connector.id);
   }
 
   resizeChildSection(
@@ -361,6 +375,9 @@ async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
   const icon = requireSingleNestedInstance(instance, CI_ICON_INSTANCE_NAME);
   setComponentVariantProperty(icon, CI_ICON_ENVIRONMENT_PROPERTY, nodePlan.environment);
   const properties = ciNodePropertyValues(nodePlan);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSteps, properties.showSteps);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSource, properties.showSource);
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showRuntime, properties.showRuntime);
   setComponentTextProperty(instance, CI_NODE_PROPS.name, properties.name);
   setComponentTextProperty(instance, CI_NODE_PROPS.description, properties.description);
   setComponentTextProperty(instance, CI_NODE_PROPS.steps, properties.steps);
@@ -369,9 +386,6 @@ async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
   setComponentTextProperty(instance, CI_NODE_PROPS.runtimeService, properties.runtimeService);
   setComponentTextProperty(instance, CI_NODE_PROPS.runtimeStartup, properties.runtimeStartup);
   setComponentTextProperty(instance, CI_NODE_PROPS.runtimeIdentity, properties.runtimeIdentity);
-  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSteps, properties.showSteps);
-  setComponentBooleanProperty(instance, CI_NODE_PROPS.showSource, properties.showSource);
-  setComponentBooleanProperty(instance, CI_NODE_PROPS.showRuntime, properties.showRuntime);
   await applyTextLinks(
     instance,
     "File",
@@ -491,6 +505,29 @@ function requiredHorizontalColumnGaps(
 
 export function centeredRowY(rowTop: number, rowHeight: number, itemHeight: number) {
   return rowTop + (rowHeight - itemHeight) / 2;
+}
+
+export async function waitForStableCiLayout(
+  nodes: Array<Pick<SceneNode, "x" | "y" | "width" | "height">>,
+  yieldLayout: () => Promise<void> = yieldToFigmaLayout,
+  maxAttempts = 5
+) {
+  let previous = ciLayoutSignature(nodes);
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await yieldLayout();
+    const current = ciLayoutSignature(nodes);
+    if (current === previous) return;
+    previous = current;
+  }
+  throw new Error(`CI layout did not stabilize after ${maxAttempts} attempts.`);
+}
+
+function ciLayoutSignature(nodes: Array<Pick<SceneNode, "x" | "y" | "width" | "height">>) {
+  return nodes.map(({ x, y, width, height }) => `${x}:${y}:${width}:${height}`).join("|");
+}
+
+async function yieldToFigmaLayout() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 export function horizontalConnectorGap(labelWidth: number) {

--- a/repo/figma-design-sync/tools/src/figma/figma-connector-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-connector-gateway.ts
@@ -1,13 +1,15 @@
 import { CONNECTOR_TEMPLATE_NAME, METADATA_NAMESPACE } from "../config/figma-config";
 
-export function collectTreeConnectors(section) {
-  const sectionNodeIds = new Set([
-    section.id,
-    ...section.findAll().map((node) => node.id),
-  ]);
-  const sectionConnectors = section.findAllWithCriteria({ types: ["CONNECTOR"] })
-    .filter((connector) => connector.name === CONNECTOR_TEMPLATE_NAME);
-  const pageConnectors = section.parent?.type === "PAGE"
+export function collectTreeConnectors(section, traversalRoots = [section]) {
+  const scopedTraversal = traversalRoots.length !== 1 || traversalRoots[0].id !== section.id;
+  const sectionNodeIds = new Set(traversalRoots.flatMap((root) => [
+    root.id,
+    ...root.findAll().map((node) => node.id),
+  ]));
+  const sectionConnectors = traversalRoots.flatMap((root) =>
+    root.findAllWithCriteria({ types: ["CONNECTOR"] })
+  ).filter((connector) => connector.name === CONNECTOR_TEMPLATE_NAME);
+  const pageConnectors = !scopedTraversal && section.parent?.type === "PAGE"
     ? section.parent.findAllWithCriteria({ types: ["CONNECTOR"] })
       .filter((connector) => connector.name === CONNECTOR_TEMPLATE_NAME)
       .filter((connector) => connectorReferencesAnyNode(connector, sectionNodeIds))

--- a/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts
@@ -265,15 +265,21 @@ export function stackAncestorSectionSiblingsWithGap(section, mutatedNodeIds, gap
   stackConfiguredPageSectionsWithGap(section, mutatedNodeIds);
 }
 
-export function unlockSectionTreeForMutation(section, mutatedNodeIds) {
+export function unlockSectionTreeForMutation(section, mutatedNodeIds, traversalRoots = null) {
   const root = rootSection(section);
   setNodeLocked(root, false, mutatedNodeIds);
-  setDescendantsLocked(root, false, mutatedNodeIds);
+  for (const traversalRoot of traversalRoots || [root]) {
+    setNodeLocked(traversalRoot, false, mutatedNodeIds);
+    setDescendantsLocked(traversalRoot, false, mutatedNodeIds);
+  }
 }
 
-export function lockOnlyRootSection(section, mutatedNodeIds) {
+export function lockOnlyRootSection(section, mutatedNodeIds, traversalRoots = null) {
   const root = rootSection(section);
-  setDescendantsLocked(root, false, mutatedNodeIds);
+  for (const traversalRoot of traversalRoots || [root]) {
+    setNodeLocked(traversalRoot, false, mutatedNodeIds);
+    setDescendantsLocked(traversalRoot, false, mutatedNodeIds);
+  }
   setNodeLocked(root, true, mutatedNodeIds);
 }
 

--- a/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -13,8 +13,10 @@ import {
 import { updateNamedTextNodes } from "./figma-text-gateway";
 import { syncTreeNodeGroup, treeNodeLayoutNode } from "./figma-connector-gateway";
 
-export function collectTreeNodeInstancesByLabel(section, type) {
-  const instances = section.findAllWithCriteria({ types: ["INSTANCE"] })
+export function collectTreeNodeInstancesByLabel(section, type, traversalRoots = [section]) {
+  const instances = traversalRoots.flatMap((root) =>
+    root.findAllWithCriteria({ types: ["INSTANCE"] })
+  )
     .filter((instance) => isTreeNodeInstance(instance, type));
   const instancesByLabel = new Map();
 
@@ -42,7 +44,7 @@ export async function createMissingTreeNode(
   mutatedNodeIds
 ) {
   const container = requireTreeNodeContainer(section, node);
-  const template = findTreeNodeTemplate(section, node);
+  const template = findTreeNodeTemplate(container, node);
   const instance = template
     ? template.clone()
     : (await requireTreeNodeComponent(node.type, TREE_NODE_COMPONENT_IDS, componentCache)).createInstance();
@@ -227,8 +229,8 @@ function nextTopLevelSectionPosition(section) {
   };
 }
 
-function findTreeNodeTemplate(section, node) {
-  const candidates = section.findAllWithCriteria({ types: ["INSTANCE"] })
+function findTreeNodeTemplate(container, node) {
+  const candidates = container.findAllWithCriteria({ types: ["INSTANCE"] })
     .filter((instance) => isTreeNodeInstance(instance, node.type));
 
   if (node.type === "Plugin") {

--- a/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
+++ b/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
@@ -2,13 +2,72 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildPartialCatalogSyncScope,
+  catalogTraversalRoots,
   constrainCatalogLayoutToPadding,
   removeEmptyStaleCatalogRootSections,
   removeStaleCatalogNodes,
 } from "../src/figma/figma-catalog-tree-sync-gateway";
 import { stackChildSectionsFromPadding } from "../src/figma/figma-node-gateway";
+import { collectTreeNodeInstancesByLabel } from "../src/figma/figma-tree-node-gateway";
+import { collectTreeConnectors } from "../src/figma/figma-connector-gateway";
 
 const target = { name: "waterMyPlants.libraries" };
+
+test("partial catalog traversal returns only requested root sections", () => {
+  const section = parentSection([
+    childSection("androidx", ["androidx-node"]),
+    childSection("com", ["com-node"]),
+    childSection("io", ["io-node"]),
+  ]);
+
+  assert.deepEqual(
+    catalogTraversalRoots(section, ["io"]).map((root) => root.name),
+    ["io"]
+  );
+});
+
+test("full catalog traversal keeps the catalog section as its only root", () => {
+  const section = parentSection([childSection("androidx", [])]);
+
+  assert.deepEqual(catalogTraversalRoots(section), [section]);
+});
+
+test("partial instance collection never traverses sibling root sections", () => {
+  const ioInstance = libraryTreeNodeInstance("io");
+  const ioRoot = searchableRoot("io", [ioInstance]);
+  const comRoot = searchableRoot("com", [libraryTreeNodeInstance("com")]);
+  const section = parentSection([comRoot, ioRoot]);
+
+  const instances = collectTreeNodeInstancesByLabel(section, "Library", [ioRoot]);
+
+  assert.deepEqual([...instances.keys()], ["io"]);
+  assert.equal(ioRoot.searchCount, 1);
+  assert.equal(comRoot.searchCount, 0);
+});
+
+test("partial connector collection never traverses the catalog page", () => {
+  const connector = { id: "io-connector", name: "simple-solid_arrow" };
+  const ioRoot = {
+    ...searchableRoot("io", []),
+    findAll() {
+      return [{ id: "io-node" }];
+    },
+    findAllWithCriteria() {
+      this.searchCount += 1;
+      return [connector];
+    },
+  };
+  const page = {
+    type: "PAGE",
+    findAllWithCriteria() {
+      throw new Error("A partial root sync must not traverse the page.");
+    },
+  };
+  const section = { id: "catalog", parent: page };
+
+  assert.deepEqual(collectTreeConnectors(section, [ioRoot]), [connector]);
+  assert.equal(ioRoot.searchCount, 1);
+});
 
 test("partial catalog scope reaches stale descendants through managed connectors", () => {
   const instancesByLabel = new Map([
@@ -277,5 +336,26 @@ function positionedChildSection(name: string, x: number, y: number, width: numbe
     height,
     children: [],
     parent: null,
+  };
+}
+
+function searchableRoot(name: string, instances) {
+  return {
+    ...childSection(name, []),
+    searchCount: 0,
+    findAllWithCriteria() {
+      this.searchCount += 1;
+      return instances;
+    },
+  };
+}
+
+function libraryTreeNodeInstance(label: string) {
+  return {
+    name: ".tree node",
+    componentProperties: {
+      Type: { value: "Library" },
+      "Library group#1345:12": { value: label },
+    },
   };
 }

--- a/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-design-sync/tools/tests/ci-visual-plan.test.ts
@@ -17,6 +17,7 @@ import {
   horizontalFlowPositions,
   horizontalConnectorGap,
   managedCiRemovalPriority,
+  waitForStableCiLayout,
 } from "../src/figma/figma-ci-documentation-sync-gateway";
 
 test("CI visual plan creates the five documented granular sections", () => {
@@ -345,6 +346,40 @@ test("CI horizontal rows align node centers and reserve label width", () => {
   assert.equal(centeredRowY(100, 200, 120), 140);
   assert.equal(horizontalConnectorGap(80), 160);
   assert.equal(horizontalConnectorGap(280), 328);
+});
+
+test("CI layout waits for hidden component blocks to collapse before positioning", async () => {
+  const nodes = [
+    { x: 0, y: 0, width: 577, height: 283 },
+    { x: 0, y: 0, width: 763, height: 283 },
+  ];
+  let yields = 0;
+
+  await waitForStableCiLayout(nodes, async () => {
+    yields += 1;
+    if (yields === 1) nodes[0].height = 225;
+  });
+
+  assert.equal(yields, 2);
+  assert.equal(nodes[0].height, 225);
+  assert.equal(centeredRowY(100, 283, nodes[0].height), 129);
+  assert.equal(centeredRowY(100, 283, nodes[1].height), 100);
+});
+
+test("CI labels use stable connector bounds after endpoint geometry updates", async () => {
+  const connectors = [{ x: 680.5, y: 241.5, width: 182, height: 0 }];
+  let yields = 0;
+
+  await waitForStableCiLayout(connectors, async () => {
+    yields += 1;
+    if (yields === 1) connectors[0].y = 256;
+  });
+
+  assert.equal(yields, 2);
+  assert.deepEqual(
+    connectorBoundsLabelPosition(connectors[0], { x: 0, y: 0 }, 141, 40),
+    { x: 701, y: 236 }
+  );
 });
 
 test("CI connector labels move outside nodes when the direct gap is too narrow", () => {


### PR DESCRIPTION
## Summary
- scope partial catalog traversal to requested root sections and managed descendants
- wait for Figma component dimensions and connector bounds to stabilize before CI layout
- document both execution contracts and add regression coverage

## Verification
- `npm test`
- `npm run build`
- focused official-artifact visual sync for `ci.pullRequestIntegration`
- verified node, connector, and label centers at `y = 256`

The focused visual validation did not write authoritative Figma metadata.