### PR TITLE
fix(figma-design-sync): scope catalog cleanup locking

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -128,7 +128,10 @@ section. Instance, connector, lock, stroke, fill, and descendant-layout scans
 must not visit sibling catalog roots or page-level connectors. The generated
 official runner uses one root-scoped `99-*.mcp.js` unit per declared root and a
 separate cleanup unit for stale nodes or sections that require a whole-catalog
-view. This keeps the runtime memory boundary aligned with the model scope.
+view. Cleanup may inspect every direct root of that catalog, but lock and unlock
+traversal remains scoped to the catalog section; it must not scan sibling
+catalogs under the shared parent documentation section. This keeps the runtime
+memory boundary aligned with the model scope.
 
 Known child sections:
 

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -319,7 +319,7 @@ function cleanupCatalogTreeTarget({
   removeCatalogTreeSectionFills(section, mutatedNodeIds);
   applySectionStrokeContractTree(section, outlineVariable, mutatedNodeIds);
   applyAncestorSectionStrokeContract(section, outlineVariable, mutatedNodeIds);
-  lockOnlyRootSection(section, mutatedNodeIds);
+  lockOnlyRootSection(section, mutatedNodeIds, [section]);
 
   return {
     removedCatalogNodes: [

--- a/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
+++ b/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
@@ -7,7 +7,7 @@ import {
   removeEmptyStaleCatalogRootSections,
   removeStaleCatalogNodes,
 } from "../src/figma/figma-catalog-tree-sync-gateway";
-import { stackChildSectionsFromPadding } from "../src/figma/figma-node-gateway";
+import { lockOnlyRootSection, stackChildSectionsFromPadding } from "../src/figma/figma-node-gateway";
 import { collectTreeNodeInstancesByLabel } from "../src/figma/figma-tree-node-gateway";
 import { collectTreeConnectors } from "../src/figma/figma-connector-gateway";
 
@@ -260,6 +260,21 @@ test("partial root layout shifts a wide subtree inside its section padding", () 
   assert.equal(placements.get("right-leaf").x, 1710);
 });
 
+test("catalog cleanup locks the parent without traversing sibling catalog trees", () => {
+  const sibling = lockableSection("sibling");
+  const catalog = lockableSection("catalog");
+  const parent = lockableSection("parent", [sibling, catalog]);
+  parent.parent = { type: "PAGE" };
+  const mutatedNodeIds = [];
+
+  lockOnlyRootSection(catalog, mutatedNodeIds, [catalog]);
+
+  assert.equal(parent.locked, true);
+  assert.equal(catalog.searchCount, 1);
+  assert.equal(sibling.searchCount, 0);
+  assert.deepEqual(mutatedNodeIds, ["parent-id"]);
+});
+
 function catalogNode(label: string, parentPath: string[] = []) {
   return {
     label,
@@ -348,6 +363,24 @@ function searchableRoot(name: string, instances) {
       return instances;
     },
   };
+}
+
+function lockableSection(name: string, children = []) {
+  const section = {
+    id: `${name}-id`,
+    name,
+    type: "SECTION",
+    locked: false,
+    children,
+    parent: null,
+    searchCount: 0,
+    findAll() {
+      this.searchCount += 1;
+      return this.children;
+    },
+  };
+  for (const child of children) child.parent = section;
+  return section;
 }
 
 function libraryTreeNodeInstance(label: string) {


### PR DESCRIPTION
## Summary
- scope catalog cleanup lock traversal to the target catalog section
- keep whole-catalog stale detection without scanning sibling catalogs
- document the cleanup memory boundary and add regression coverage

## Verification
- `npm test`
- `npm run build`
- focused official-artifact execution of `figmaDesignSync.libraries.cleanup`
- cleanup completed without Figma MCP out-of-memory errors

The focused validation did not write authoritative Figma metadata.