### PR TITLE
fix(figma-design-sync): scope catalog cleanup unlocking

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/target-scopes.md
+++ b/repo/figma-design-sync/docs/runbooks/target-scopes.md
@@ -130,8 +130,10 @@ official runner uses one root-scoped `99-*.mcp.js` unit per declared root and a
 separate cleanup unit for stale nodes or sections that require a whole-catalog
 view. Cleanup may inspect every direct root of that catalog, but lock and unlock
 traversal remains scoped to the catalog section; it must not scan sibling
-catalogs under the shared parent documentation section. This keeps the runtime
-memory boundary aligned with the model scope.
+catalogs under the shared parent documentation section. The shared parent is
+unlocked directly so the catalog can be mutated, while descendant `findAll`
+calls start at the selected catalog section rather than at that parent. This
+keeps the runtime memory boundary aligned with the model scope.
 
 Known child sections:
 

--- a/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-catalog-tree-sync-gateway.ts
@@ -101,7 +101,7 @@ export class FigmaCatalogTreeSyncGateway implements CatalogTreeSyncGateway {
       throw new Error(`Expected '${sectionNodeId}' to be a SECTION.`);
     }
     let traversalRoots = catalogTraversalRoots(section, isPartialRootSync ? scopedRootLabels : undefined);
-    unlockSectionTreeForMutation(section, mutatedNodeIds, isPartialRootSync ? traversalRoots : null);
+    unlockSectionTreeForMutation(section, mutatedNodeIds, traversalRoots);
     applyCatalogSectionContract(
       section,
       traversalRoots,

--- a/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
+++ b/repo/figma-design-sync/tools/tests/catalog-root-filter-scope.test.ts
@@ -7,7 +7,11 @@ import {
   removeEmptyStaleCatalogRootSections,
   removeStaleCatalogNodes,
 } from "../src/figma/figma-catalog-tree-sync-gateway";
-import { lockOnlyRootSection, stackChildSectionsFromPadding } from "../src/figma/figma-node-gateway";
+import {
+  lockOnlyRootSection,
+  stackChildSectionsFromPadding,
+  unlockSectionTreeForMutation,
+} from "../src/figma/figma-node-gateway";
 import { collectTreeNodeInstancesByLabel } from "../src/figma/figma-tree-node-gateway";
 import { collectTreeConnectors } from "../src/figma/figma-connector-gateway";
 
@@ -270,6 +274,22 @@ test("catalog cleanup locks the parent without traversing sibling catalog trees"
   lockOnlyRootSection(catalog, mutatedNodeIds, [catalog]);
 
   assert.equal(parent.locked, true);
+  assert.equal(catalog.searchCount, 1);
+  assert.equal(sibling.searchCount, 0);
+  assert.deepEqual(mutatedNodeIds, ["parent-id"]);
+});
+
+test("catalog cleanup unlocks only its catalog tree and never traverses sibling catalogs", () => {
+  const sibling = lockableSection("sibling");
+  const catalog = lockableSection("catalog");
+  const parent = lockableSection("parent", [sibling, catalog]);
+  parent.locked = true;
+  parent.parent = { type: "PAGE" };
+  const mutatedNodeIds = [];
+
+  unlockSectionTreeForMutation(catalog, mutatedNodeIds, [catalog]);
+
+  assert.equal(parent.locked, false);
   assert.equal(catalog.searchCount, 1);
   assert.equal(sibling.searchCount, 0);
   assert.deepEqual(mutatedNodeIds, ["parent-id"]);


### PR DESCRIPTION
## Summary
- scope cleanup-time descendant unlocking to the selected catalog section
- prevent sibling catalog traversal under the shared tooling parent
- add regression coverage for unlock traversal boundaries

## Verification
- npm test
- npm run build
- focused Figma sync of figmaDesignSync.plugins using official artifact 1452