### PR TITLE
fix(figma-design-sync): bound PNG staging discovery

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -85,9 +85,10 @@ Sending it as the default `application/octet-stream` is rejected. Request a new
 URL after any failed or consumed upload attempt; do not reuse an old URL.
 
 `upload_assets` may place the temporary image on the current Figma page, which
-does not have to be the metadata page. The staging runner searches document
-image fills and does not rely on `loadAllPagesAsync`; this MCP runtime may
-expose that API while rejecting it at execution time.
+does not have to be the metadata page. Uploaded assets are direct page children,
+so the staging runner inspects only direct children of each document page. It
+must not call `figma.root.findAll`, which traverses the complete design and can
+exhaust the plugin runtime, or rely on unsupported `loadAllPagesAsync`.
 
 To run only one top-level catalog root, use its explicit execution scope:
 

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -135,11 +135,12 @@ For chunk transport, stage base64 chunks in temporary shared plugin data:
 
 Do not copy long base64 payloads manually from terminal output.
 
-If PNG staging fails with `loadAllPagesAsync is not a supported API`, treat it
-as a runner bug, not a bad payload. The generated staging code must tolerate
-that API being present but rejected by the MCP runtime. Document-level traversal
-can still find uploaded image fills in this file, even when the upload landed
-on a different page from the metadata page.
+If PNG staging fails with `loadAllPagesAsync is not a supported API` or
+`findAll: Out of memory`, treat it as a runner bug, not a bad payload. The
+generated staging code must inspect only direct children of each document page.
+`upload_assets` creates the temporary image as a direct page child, even when
+the upload lands on a different page from the metadata page, so neither API is
+required.
 
 The tools package can generate PNG-based official runner files and chunked
 visual preview runner files:

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -548,32 +548,26 @@ const expected = {
   scriptLength: ${JSON.stringify(String(script.length))}
 };
 
-if (typeof figma.loadAllPagesAsync === "function") {
-  try {
-    await figma.loadAllPagesAsync();
-  } catch (error) {
-    // Some MCP runtimes expose this method but reject it at execution time.
-    // Document-level traversal still sees uploaded image nodes in this file.
-  }
-}
-
 const candidates = [];
 const imageHashes = new Set();
-const imageNodes = figma.root.findAll((node) => {
-  const fills = "fills" in node ? node.fills : undefined;
-  if (!Array.isArray(fills)) {
-    return false;
-  }
+const imageNodes = [];
+for (const documentPage of figma.root.children) {
+  if (documentPage.type !== "PAGE") continue;
 
-  let hasPayloadCandidate = false;
-  for (const fill of fills) {
-    if (fill?.type === "IMAGE" && fill.imageHash) {
-      hasPayloadCandidate = true;
-      imageHashes.add(fill.imageHash);
+  for (const node of documentPage.children) {
+    const fills = "fills" in node ? node.fills : undefined;
+    if (!Array.isArray(fills)) continue;
+
+    let hasPayloadCandidate = false;
+    for (const fill of fills) {
+      if (fill?.type === "IMAGE" && fill.imageHash) {
+        hasPayloadCandidate = true;
+        imageHashes.add(fill.imageHash);
+      }
     }
+    if (hasPayloadCandidate) imageNodes.push(node);
   }
-  return hasPayloadCandidate;
-});
+}
 
 for (const imageHash of imageHashes) {
   const image = figma.getImageByHash(imageHash);

--- a/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
+++ b/repo/figma-design-sync/tools/tests/write-mcp-runner.test.ts
@@ -164,6 +164,10 @@ test("official runner supports an explicitly partial diagnostic target", async (
     const runTargetSource = readFileSync(join(runDir, "99-run-target.mcp.js"), "utf8");
     assert.match(stageSource, /payload\.payloadSchemaVersion === expected\.payloadSchemaVersion/);
     assert.match(stageSource, /setSharedPluginData\(namespace, "script", payload\.script\)/);
+    assert.match(stageSource, /for \(const documentPage of figma\.root\.children\)/);
+    assert.match(stageSource, /for \(const node of documentPage\.children\)/);
+    assert.doesNotMatch(stageSource, /figma\.root\.findAll/);
+    assert.doesNotMatch(stageSource, /loadAllPagesAsync/);
     assert.doesNotMatch(stageSource, /setSharedPluginData\(namespace, "scriptBase64"/);
     assert.match(runTargetSource, /getSharedPluginData\(namespace, "script"\)/);
     assert.doesNotMatch(runTargetSource, /getSharedPluginData\(namespace, "scriptBase64"\)/);


### PR DESCRIPTION
## Summary
- discover uploaded PNG payloads only among direct page children
- remove document-wide findAll and unsupported loadAllPagesAsync from staging
- document and test the bounded transport contract

## Verification
- npm test
- npm run build
- live staging and finalize with TeamCity artifact 1461; metadata not written