### PR TITLE
docs(project): establish validated documentation standard

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -75,12 +75,16 @@ The GitHub ruleset for `main` is documented in
 The pipeline:
 
 - monitors all branches;
+- validates typed documentation before scope classification: canonical
+  placement, frontmatter, review dates, runbook and ADR sections, canonical
+  sources, and local Markdown links are checked by
+  `.teamcity/scripts/validate-documentation.ps1`;
 - validates documentation coverage before Gradle: changes to TeamCity,
   Figma-sync implementation, dependency-catalog model, or CI topology must
   update their mapped canonical documentation in
   [`.teamcity/documentation-coverage.json`](documentation-coverage.json);
-- uses `Verify change scope` to run `git diff --check` and local Markdown-link
-  validation for documentation-only changes; every other change runs
+- uses `Verify change scope` to run `git diff --check` for documentation-only
+  changes after the repository-wide documentation validator; every other change runs
   `.\gradlew.bat check --stacktrace` so Gradle failures retain their diagnostic
   context in the TeamCity build log;
 - blocks invalid dependency version key names through
@@ -88,6 +92,10 @@ The pipeline:
 - blocks unused dependency catalog entries through `checkFigmaCatalogUsage`,
   which is wired into the Gradle `check` lifecycle;
 - publishes the `TeamCity CI` GitHub status from `Verify`.
+
+TeamCity runs these scripts with Windows PowerShell 5.1 (`powershell.exe`). CI
+validation scripts must not depend on APIs available only in newer .NET or
+PowerShell versions.
 
 `CI` does not run `generateFigmaDesignModel` and does not publish
 `build/reports/figma-sync/design-model.json`. Figma represents the stable
@@ -126,6 +134,11 @@ publishes only a `sync-scope.json` artifact and the final job exits successfully
 without Maven, Gradle, model generation, metadata validation, or an MCP write.
 The previous official Figma metadata remains authoritative because neither the
 model nor the compiled visual writer changed.
+
+The same Figma no-op applies to `model-neutral` revisions such as documentation
+validation scripts and their coverage manifest. Unlike documentation-only
+changes, these revisions still run the normal Gradle CI verification before
+merge.
 
 `prepare-figma-sync.ps1` removes the previous
 `build/reports/figma-sync` directory before preparing any scope. This prevents a

--- a/.teamcity/documentation-coverage.json
+++ b/.teamcity/documentation-coverage.json
@@ -1,8 +1,13 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "documentationOnlyPaths": [
     "README.md",
+    "AGENTS.md",
     "docs/*.md",
+    "*/docs/*.md",
+    "*/*/docs/*.md",
+    "*/AGENTS.md",
+    "*/*/AGENTS.md",
     ".teamcity/README.md",
     "repo/*/README.md",
     "repo/*/docs/*.md"
@@ -13,6 +18,13 @@
     "repo/figma-design-sync/tools/scripts/execute-mcp-runner.ts",
     "repo/figma-design-sync/tools/scripts/write-visual-sync-plan.ts",
     "repo/figma-design-sync/tools/tests/*"
+  ],
+  "figmaModelNeutralPaths": [
+    ".teamcity/documentation-coverage.json",
+    ".teamcity/scripts/get-change-impact.ps1",
+    ".teamcity/scripts/invoke-ci-verification.ps1",
+    ".teamcity/scripts/validate-documentation.ps1",
+    ".teamcity/scripts/tests/*"
   ],
   "figmaModelContentPaths": [
     ".teamcity/settings.kts",
@@ -48,6 +60,35 @@
   ],
   "rules": [
     {
+      "id": "documentation-system",
+      "sourcePaths": [
+        "AGENTS.md",
+        "docs/documentation.md",
+        "docs/templates/*.md",
+        ".teamcity/scripts/validate-documentation.ps1"
+      ],
+      "documentationPaths": [
+        "docs/documentation.md",
+        "docs/README.md",
+        ".teamcity/README.md",
+        "docs/ci/documentation-coverage.md"
+      ]
+    },
+    {
+      "id": "product-module-structure",
+      "sourcePaths": [
+        "settings.gradle.kts",
+        "*/build.gradle.kts",
+        "*/*/build.gradle.kts"
+      ],
+      "documentationPaths": [
+        "docs/reference/project-structure.md",
+        "docs/standards/architecture.md",
+        "*/docs/README.md",
+        "*/*/docs/README.md"
+      ]
+    },
+    {
       "id": "teamcity-pipelines",
       "sourcePaths": [".teamcity/settings.kts", ".teamcity/pom.xml", ".teamcity/scripts/*"],
       "documentationPaths": [".teamcity/README.md", "docs/runbooks/teamcity-cloudflare-access.md"]
@@ -62,7 +103,12 @@
         "repo/figma-design-sync/*/build.gradle.kts",
         "repo/figma-design-sync/settings.gradle.kts"
       ],
-      "documentationPaths": ["repo/figma-design-sync/README.md", "repo/figma-design-sync/docs/runbooks/*.md"]
+      "documentationPaths": [
+        "repo/figma-design-sync/README.md",
+        "repo/figma-design-sync/docs/runbooks/*.md",
+        "repo/figma-design-sync/docs/reference/*.md",
+        "repo/figma-design-sync/docs/standards/*.md"
+      ]
     },
     {
       "id": "dependency-catalog-model",
@@ -82,8 +128,8 @@
         "repo/dependency-catalog/README.md",
         "repo/gradle-plugins/README.md",
         "repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md",
-        "repo/figma-design-sync/docs/runbooks/dependency-version-naming.md",
-        "repo/figma-design-sync/docs/runbooks/visual-sync-contract.md"
+        "repo/figma-design-sync/docs/standards/dependency-version-naming.md",
+        "repo/figma-design-sync/docs/reference/visual-sync-contract.md"
       ]
     },
     {

--- a/.teamcity/scripts/get-change-impact.ps1
+++ b/.teamcity/scripts/get-change-impact.ps1
@@ -84,6 +84,13 @@ $transportOnly = -not $documentationOnly -and $changedPaths.Count -gt 0 -and @(
         -not (Test-PathMatchesAny $_ @($manifest.figmaTransportOnlyPaths))
     }
 ).Count -eq 0
+$modelNeutralOnly = -not $documentationOnly -and -not $transportOnly -and $changedPaths.Count -gt 0 -and @(
+    $changedPaths | Where-Object {
+        -not (Test-PathMatchesAny $_ @($manifest.documentationOnlyPaths)) -and
+        -not (Test-PathMatchesAny $_ @($manifest.figmaTransportOnlyPaths)) -and
+        -not (Test-PathMatchesAny $_ @($manifest.figmaModelNeutralPaths))
+    }
+).Count -eq 0
 
 $modelContentChanged = @(
     $changedPaths | Where-Object { Test-PathMatchesAny $_ @($manifest.figmaModelContentPaths) }
@@ -112,6 +119,8 @@ $figmaImpact = if ($documentationOnly) {
     "documentation-only"
 } elseif ($transportOnly) {
     "transport-only"
+} elseif ($modelNeutralOnly) {
+    "model-neutral"
 } elseif ($modelContentChanged) {
     "model-content"
 } elseif ($visualWriterChanged) {
@@ -125,6 +134,8 @@ $result = [PSCustomObject]@{
         "documentation-only"
     } elseif ($transportOnly) {
         "transport-only"
+    } elseif ($modelNeutralOnly) {
+        "model-neutral"
     } else {
         "full-verification"
     }

--- a/.teamcity/scripts/invoke-ci-verification.ps1
+++ b/.teamcity/scripts/invoke-ci-verification.ps1
@@ -5,6 +5,8 @@ $ErrorActionPreference = "Stop"
 $repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
 Push-Location $repositoryRoot
 try {
+    & (Join-Path $PSScriptRoot "validate-documentation.ps1")
+
     $impact = & (Join-Path $PSScriptRoot "get-change-impact.ps1") -FailOnDocumentationGap -AsJson |
         ConvertFrom-Json
 
@@ -16,32 +18,6 @@ try {
         & git diff --check "$($impact.comparisonBase)..HEAD"
         if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
-        }
-
-        foreach ($path in @($impact.changedPaths | Where-Object { $_ -like "*.md" })) {
-            $file = Join-Path $repositoryRoot $path
-            $sourceDirectory = Split-Path -Parent $file
-            $matches = [regex]::Matches((Get-Content -LiteralPath $file -Raw), '(?<!\!)\[[^\]]*\]\((?<target>[^ )]+)')
-            foreach ($match in $matches) {
-                $target = $match.Groups["target"].Value.Trim("<>")
-                if ($target -match "^(https?:|mailto:|#)") {
-                    continue
-                }
-
-                $targetPath = ($target -split "[#?]", 2)[0]
-                if ([string]::IsNullOrWhiteSpace($targetPath)) {
-                    continue
-                }
-
-                $resolvedTarget = if ($targetPath.StartsWith("/")) {
-                    Join-Path $repositoryRoot $targetPath.TrimStart("/")
-                } else {
-                    Join-Path $sourceDirectory $targetPath
-                }
-                if (-not (Test-Path -LiteralPath $resolvedTarget)) {
-                    throw "Broken local Markdown link in '$path': $target"
-                }
-            }
         }
 
         Write-Host "Documentation-only change verified; Gradle check is not required."

--- a/.teamcity/scripts/tests/documentation-only-pipeline.tests.ps1
+++ b/.teamcity/scripts/tests/documentation-only-pipeline.tests.ps1
@@ -22,7 +22,7 @@ try {
     New-Item -ItemType Directory -Path "$testRoot/repo/figma-design-sync/tools/scripts" -Force | Out-Null
     New-Item -ItemType Directory -Path "$testRoot/repo/figma-design-sync/docs/runbooks" -Force | Out-Null
     Copy-Item -LiteralPath "$sourceRoot/.teamcity/documentation-coverage.json" -Destination "$testRoot/.teamcity/documentation-coverage.json"
-    @("get-change-impact.ps1", "invoke-ci-verification.ps1", "prepare-figma-sync.ps1", "verify-figma-trunk-sync.ps1") |
+    @("get-change-impact.ps1", "invoke-ci-verification.ps1", "prepare-figma-sync.ps1", "verify-figma-trunk-sync.ps1", "validate-documentation.ps1") |
         ForEach-Object {
             Copy-Item -LiteralPath "$sourceRoot/.teamcity/scripts/$_" -Destination "$testRoot/.teamcity/scripts/$_"
         }
@@ -70,6 +70,20 @@ try {
 
         & "$testRoot/.teamcity/scripts/verify-figma-trunk-sync.ps1"
         Assert-Equal $LASTEXITCODE 0 "Transport-only Figma verification must be a successful no-op"
+
+        Add-Content -LiteralPath ".teamcity/scripts/validate-documentation.ps1" -Value "`n# Model-neutral test change."
+        Set-Content -LiteralPath ".teamcity/README.md" -Value "# TeamCity`n`nDocument validation changed."
+        Invoke-Git @("add", ".teamcity/scripts/validate-documentation.ps1", ".teamcity/README.md")
+        Invoke-Git @("commit", "-m", "test: update documentation validation")
+
+        & "$testRoot/.teamcity/scripts/prepare-figma-sync.ps1"
+        Assert-Equal $LASTEXITCODE 0 "Model-neutral Figma preparation must succeed"
+        $scope = Get-Content -LiteralPath "build/reports/figma-sync/sync-scope.json" -Raw | ConvertFrom-Json
+        Assert-Equal $scope.scope "model-neutral" "Figma scope artifact must preserve model-neutral classification"
+        Assert-Equal (Test-Path -LiteralPath "build/reports/figma-sync/design-model.json") $false "Model-neutral Figma preparation must not generate a model"
+
+        & "$testRoot/.teamcity/scripts/verify-figma-trunk-sync.ps1"
+        Assert-Equal $LASTEXITCODE 0 "Model-neutral Figma verification must be a successful no-op"
     } finally {
         Pop-Location
     }
@@ -79,4 +93,4 @@ try {
     }
 }
 
-Write-Host "documentation-only and transport-only pipeline tests passed"
+Write-Host "documentation-only, transport-only, and model-neutral pipeline tests passed"

--- a/.teamcity/scripts/tests/get-change-impact.tests.ps1
+++ b/.teamcity/scripts/tests/get-change-impact.tests.ps1
@@ -17,6 +17,12 @@ Assert-Equal $documentationOnly.scope "documentation-only" "Markdown-only change
 Assert-Equal @($documentationOnly.documentationViolations).Count 0 "Markdown-only changes must not require extra coverage"
 Assert-Equal $documentationOnly.comparisonBase $null "Explicit test paths must not invent a Git comparison base"
 
+$productDocumentationOnly = Invoke-Impact @("core/ui/docs/README.md")
+Assert-Equal $productDocumentationOnly.scope "documentation-only" "Nested product-module documentation must be documentation-only"
+
+$agentInstructionsOnly = Invoke-Impact @("repo/figma-design-sync/AGENTS.md")
+Assert-Equal $agentInstructionsOnly.scope "documentation-only" "Module agent instructions must be documentation-only"
+
 $transportOnly = Invoke-Impact @(
     "repo/figma-design-sync/tools/scripts/execute-mcp-runner.ts",
     "repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md"
@@ -24,9 +30,16 @@ $transportOnly = Invoke-Impact @(
 Assert-Equal $transportOnly.scope "transport-only" "MCP transport changes must not request a visual rewrite"
 Assert-Equal $transportOnly.figmaImpact "transport-only" "MCP transport changes must preserve their impact kind"
 
+$modelNeutral = Invoke-Impact @(
+    ".teamcity/scripts/validate-documentation.ps1",
+    "docs/ci/documentation-coverage.md"
+)
+Assert-Equal $modelNeutral.scope "model-neutral" "CI validation tooling must not regenerate the Figma model"
+Assert-Equal $modelNeutral.figmaImpact "model-neutral" "CI validation tooling must expose model-neutral impact"
+
 $targetedWriter = Invoke-Impact @(
     "repo/figma-design-sync/tools/src/figma/figma-version-sync-gateway.ts",
-    "repo/figma-design-sync/docs/runbooks/visual-sync-contract.md"
+    "repo/figma-design-sync/docs/reference/visual-sync-contract.md"
 )
 Assert-Equal $targetedWriter.scope "full-verification" "Visual writer changes must keep full verification"
 Assert-Equal $targetedWriter.figmaImpact "visual-targets" "Visual writer changes must expose target impact"
@@ -34,7 +47,7 @@ Assert-Equal (@($targetedWriter.affectedVisualTargets) -contains "versions") $tr
 
 $coveredImplementation = Invoke-Impact @(
     "repo/figma-design-sync/tools/src/figma/figma-node-gateway.ts",
-    "repo/figma-design-sync/docs/runbooks/visual-sync-contract.md"
+    "repo/figma-design-sync/docs/reference/visual-sync-contract.md"
 )
 Assert-Equal $coveredImplementation.scope "full-verification" "Implementation changes must retain full verification"
 Assert-Equal @($coveredImplementation.documentationViolations).Count 0 "Mapped implementation documentation must satisfy coverage"
@@ -46,5 +59,19 @@ try {
     $uncoveredTeamCityChangeFailed = $_.Exception.Message -like "*teamcity-pipelines*"
 }
 Assert-Equal $uncoveredTeamCityChangeFailed $true "TeamCity changes must fail without mapped documentation"
+
+$uncoveredModuleChangeFailed = $false
+try {
+    & $scriptPath -ChangedPath @("onboarding/ui/build.gradle.kts") -FailOnDocumentationGap | Out-Null
+} catch {
+    $uncoveredModuleChangeFailed = $_.Exception.Message -like "*product-module-structure*"
+}
+Assert-Equal $uncoveredModuleChangeFailed $true "Product module graph changes must fail without architecture documentation"
+
+$coveredModuleChange = Invoke-Impact @(
+    "onboarding/ui/build.gradle.kts",
+    "onboarding/ui/docs/README.md"
+)
+Assert-Equal @($coveredModuleChange.documentationViolations).Count 0 "Module documentation must cover its build graph change"
 
 Write-Host "get-change-impact tests passed"

--- a/.teamcity/scripts/tests/validate-documentation.tests.ps1
+++ b/.teamcity/scripts/tests/validate-documentation.tests.ps1
@@ -1,0 +1,99 @@
+$ErrorActionPreference = "Stop"
+
+$validator = (Resolve-Path (Join-Path $PSScriptRoot "../validate-documentation.ps1")).Path
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) "water-my-plants-doc-validation-$([Guid]::NewGuid())"
+
+function Write-Fixture([string]$RelativePath, [string]$Content) {
+    $path = Join-Path $fixtureRoot $RelativePath
+    New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+    Set-Content -LiteralPath $path -Value $Content -Encoding utf8
+}
+
+function Assert-Fails([scriptblock]$Action, [string]$ExpectedText) {
+    $failed = $false
+    try {
+        & $Action | Out-Null
+    } catch {
+        $failed = $_.Exception.Message -like "*$ExpectedText*"
+    }
+    if (-not $failed) {
+        throw "Expected validation failure containing '$ExpectedText'."
+    }
+}
+
+$validStandard = @'
+---
+title: Example standard
+type: standard
+scope: repository
+owner: engineering
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - source.txt
+---
+
+# Example Standard
+
+## Rules
+
+Example.
+'@
+
+$validRunbook = @'
+---
+title: Example operation
+type: runbook
+scope: repository
+owner: operations
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - source.txt
+---
+
+# Example Operation
+
+## Purpose
+Example.
+## Prerequisites
+Example.
+## Procedure
+Example.
+## Verification
+Example.
+## Recovery
+Example.
+## Prohibited Actions
+Example.
+## Sources
+Example.
+'@
+
+try {
+    New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $fixtureRoot "source.txt") -Value "source" -Encoding utf8
+    Write-Fixture "docs/standards/example.md" $validStandard
+    Write-Fixture "docs/runbooks/example.md" $validRunbook
+
+    & $validator -RepositoryRoot $fixtureRoot | Out-Null
+
+    Write-Fixture "docs/misplaced.md" ($validStandard -replace 'type: standard', 'type: guide')
+    Assert-Fails { & $validator -RepositoryRoot $fixtureRoot } "outside its canonical directory"
+    Remove-Item -LiteralPath (Join-Path $fixtureRoot "docs/misplaced.md")
+
+    Write-Fixture "docs/runbooks/incomplete.md" ($validRunbook -replace '(?ms)## Recovery\r?\nExample\.\r?\n', '')
+    Assert-Fails { & $validator -RepositoryRoot $fixtureRoot } "Runbook section 'Recovery'"
+    Remove-Item -LiteralPath (Join-Path $fixtureRoot "docs/runbooks/incomplete.md")
+
+    Write-Fixture "docs/standards/broken-link.md" ($validStandard + "`n[Missing](missing.md)`n")
+    Assert-Fails { & $validator -RepositoryRoot $fixtureRoot } "Broken local Markdown link"
+
+    Write-Host "validate-documentation tests passed"
+} finally {
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+    }
+}

--- a/.teamcity/scripts/validate-documentation.ps1
+++ b/.teamcity/scripts/validate-documentation.ps1
@@ -1,0 +1,258 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryRoot,
+    [switch]$AsJson,
+    [switch]$FailOnWarnings
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($RepositoryRoot)) {
+    $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+} else {
+    $RepositoryRoot = (Resolve-Path $RepositoryRoot).Path
+}
+
+$errors = [System.Collections.Generic.List[string]]::new()
+$warnings = [System.Collections.Generic.List[string]]::new()
+$validatedDocuments = [System.Collections.Generic.List[string]]::new()
+
+function Normalize-Path([string]$Path) {
+    return $Path.Replace("\", "/").TrimStart("./")
+}
+
+function Get-RelativePath([string]$Path) {
+    $root = [System.IO.Path]::GetFullPath($RepositoryRoot).TrimEnd('\', '/')
+    $rootWithSeparator = $root + [System.IO.Path]::DirectorySeparatorChar
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if ($fullPath -eq $root) {
+        return ""
+    }
+    if (-not $fullPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Documentation path is outside the repository: $fullPath"
+    }
+    return Normalize-Path $fullPath.Substring($rootWithSeparator.Length)
+}
+
+function Get-ExpectedType([string]$RelativePath) {
+    if ($RelativePath -eq "docs/documentation.md") {
+        return "standard"
+    }
+
+    if ($RelativePath -match '^docs/decisions/adr-[0-9]{4}-[a-z0-9]+(?:-[a-z0-9]+)*\.md$') {
+        return "adr"
+    }
+
+    if ($RelativePath -match '(?:^|/)docs/(?<kind>standards|guides|reference|runbooks)/.+\.md$' -and
+        -not $RelativePath.EndsWith("/README.md")) {
+        $type = switch ($Matches.kind) {
+            "standards" { "standard" }
+            "guides" { "guide" }
+            "reference" { "reference" }
+            "runbooks" { "runbook" }
+        }
+        return $type
+    }
+
+    return $null
+}
+
+function Read-Frontmatter([string]$Content) {
+    $match = [regex]::Match($Content, '\A---\r?\n(?<yaml>.*?)\r?\n---(?:\r?\n|\z)', 'Singleline')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    $metadata = @{}
+    $sources = [System.Collections.Generic.List[string]]::new()
+    $currentKey = $null
+    foreach ($line in ($match.Groups["yaml"].Value -split '\r?\n')) {
+        if ($line -match '^(?<key>[a-z][a-z0-9-]*):(?:\s*(?<value>.*))?$') {
+            $currentKey = $Matches.key
+            $metadata[$currentKey] = $Matches.value.Trim().Trim('"', "'")
+            continue
+        }
+
+        if ($currentKey -eq "sources" -and $line -match '^\s+-\s+(?<value>.+?)\s*$') {
+            $sources.Add($Matches.value.Trim().Trim('"', "'"))
+        }
+    }
+    $metadata["sources"] = @($sources)
+
+    return [PSCustomObject]@{
+        metadata = $metadata
+        body = $Content.Substring($match.Length)
+    }
+}
+
+function Add-Error([string]$Path, [string]$Message) {
+    $errors.Add("[$Path] $Message")
+}
+
+function Test-RequiredMetadata([string]$Path, [hashtable]$Metadata, [string]$ExpectedType) {
+    $requiredFields = @("title", "type", "scope", "owner", "status", "last-reviewed", "review-cycle-days")
+    foreach ($field in $requiredFields) {
+        if (-not $Metadata.ContainsKey($field) -or [string]::IsNullOrWhiteSpace($Metadata[$field])) {
+            Add-Error $Path "Missing frontmatter field '$field'."
+        }
+    }
+
+    if ($Metadata["type"] -ne $ExpectedType) {
+        Add-Error $Path "Frontmatter type '$($Metadata['type'])' does not match path type '$ExpectedType'."
+    }
+
+    if ($Metadata["status"] -notin @("draft", "active", "accepted", "deprecated", "superseded")) {
+        Add-Error $Path "Unsupported status '$($Metadata['status'])'."
+    }
+
+    foreach ($field in @("title", "scope", "owner")) {
+        if ($Metadata[$field] -match '(?i)replace|repository-or|stable-area|placeholder') {
+            Add-Error $Path "Frontmatter field '$field' still contains template text."
+        }
+    }
+
+    $reviewDate = [DateTime]::MinValue
+    $validReviewDate = [DateTime]::TryParseExact(
+        $Metadata["last-reviewed"],
+        "yyyy-MM-dd",
+        [Globalization.CultureInfo]::InvariantCulture,
+        [Globalization.DateTimeStyles]::None,
+        [ref]$reviewDate
+    )
+    if (-not $validReviewDate) {
+        Add-Error $Path "last-reviewed must use YYYY-MM-DD."
+    }
+
+    $reviewCycleDays = 0
+    if (-not [int]::TryParse($Metadata["review-cycle-days"], [ref]$reviewCycleDays) -or $reviewCycleDays -le 0) {
+        Add-Error $Path "review-cycle-days must be a positive integer."
+    } elseif ($validReviewDate -and $reviewDate.AddDays($reviewCycleDays) -lt [DateTime]::Today) {
+        $warnings.Add("[$Path] Documentation review expired on $($reviewDate.AddDays($reviewCycleDays).ToString('yyyy-MM-dd')).")
+    }
+
+    $sources = @($Metadata["sources"])
+    if ($sources.Count -eq 0) {
+        Add-Error $Path "At least one canonical source is required."
+    }
+    foreach ($source in $sources) {
+        if ($source -match '^(https?:|generated:)') {
+            continue
+        }
+        $sourcePath = Join-Path $RepositoryRoot $source
+        $exists = if ($source -match '[*?]') {
+            @(Get-ChildItem -Path $sourcePath -ErrorAction SilentlyContinue).Count -gt 0
+        } else {
+            Test-Path -LiteralPath $sourcePath
+        }
+        if (-not $exists) {
+            Add-Error $Path "Canonical source does not exist: $source"
+        }
+    }
+}
+
+function Test-Headings([string]$Path, [string]$Body, [string]$ExpectedType) {
+    if ($Body -notmatch '(?m)^#\s+\S') {
+        Add-Error $Path "A level-one title is required after frontmatter."
+    }
+
+    $headings = @([regex]::Matches($Body, '(?m)^##\s+(?<name>.+?)\s*$') | ForEach-Object {
+        $_.Groups["name"].Value.Trim().ToLowerInvariant()
+    })
+
+    if ($ExpectedType -eq "runbook") {
+        $requirements = @(
+            @{ name = "Purpose"; aliases = @("purpose") },
+            @{ name = "Prerequisites"; aliases = @("prerequisites") },
+            @{ name = "Verification"; aliases = @("verification", "verify") },
+            @{ name = "Recovery"; aliases = @("recovery", "failure recovery") },
+            @{ name = "Prohibited Actions"; aliases = @("prohibited actions") },
+            @{ name = "Sources"; aliases = @("sources") }
+        )
+        foreach ($requirement in $requirements) {
+            if (@($headings | Where-Object { $_ -in $requirement.aliases }).Count -eq 0) {
+                Add-Error $Path "Runbook section '$($requirement.name)' is required."
+            }
+        }
+    }
+
+    if ($ExpectedType -eq "adr") {
+        foreach ($heading in @("context", "decision", "consequences", "alternatives", "supersession")) {
+            if ($heading -notin $headings) {
+                Add-Error $Path "ADR section '$heading' is required."
+            }
+        }
+    }
+}
+
+$markdownFiles = @(Get-ChildItem -LiteralPath $RepositoryRoot -Filter "*.md" -File -Recurse | Where-Object {
+    $relative = Get-RelativePath $_.FullName
+    $relative -notmatch '(^|/)(\.git|build|node_modules|tmp)/' -and
+    $relative -notmatch '(^|/)docs/templates/'
+})
+
+foreach ($file in $markdownFiles) {
+    $path = Get-RelativePath $file.FullName
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    $expectedType = Get-ExpectedType $path
+    $frontmatter = Read-Frontmatter $content
+
+    if ($null -eq $expectedType) {
+        if ($null -ne $frontmatter -and $frontmatter.metadata["type"] -in @("standard", "guide", "runbook", "reference", "adr")) {
+            Add-Error $path "Typed document is outside its canonical directory."
+        }
+    } else {
+        $validatedDocuments.Add($path)
+        if ($null -eq $frontmatter) {
+            Add-Error $path "Typed document must start with YAML frontmatter."
+        } else {
+            Test-RequiredMetadata $path $frontmatter.metadata $expectedType
+            Test-Headings $path $frontmatter.body $expectedType
+        }
+    }
+
+    $sourceDirectory = Split-Path -Parent $file.FullName
+    $links = [regex]::Matches($content, '(?<!\!)\[[^\]]*\]\((?<target>[^ )]+)')
+    foreach ($link in $links) {
+        $target = $link.Groups["target"].Value.Trim("<>")
+        if ($target -match '^(https?:|mailto:|#)') {
+            continue
+        }
+        $targetPath = ($target -split '[#?]', 2)[0]
+        if ([string]::IsNullOrWhiteSpace($targetPath)) {
+            continue
+        }
+        $resolvedTarget = if ($targetPath.StartsWith("/")) {
+            Join-Path $RepositoryRoot $targetPath.TrimStart("/")
+        } else {
+            Join-Path $sourceDirectory $targetPath
+        }
+        if (-not (Test-Path -LiteralPath $resolvedTarget)) {
+            Add-Error $path "Broken local Markdown link: $target"
+        }
+    }
+}
+
+$result = [PSCustomObject]@{
+    validatedDocuments = @($validatedDocuments)
+    errors = @($errors)
+    warnings = @($warnings)
+}
+
+if ($AsJson) {
+    $result | ConvertTo-Json -Depth 4
+} else {
+    foreach ($warning in $warnings) {
+        Write-Warning $warning
+    }
+}
+
+if ($errors.Count -gt 0) {
+    throw "Documentation validation failed:`n$($errors -join "`n")"
+}
+if ($FailOnWarnings -and $warnings.Count -gt 0) {
+    throw "Documentation validation warnings are configured as failures:`n$($warnings -join "`n")"
+}
+
+if (-not $AsJson) {
+    Write-Host "Documentation validation passed for $($validatedDocuments.Count) typed documents."
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,23 @@ The feature covers the domain generation flow and the Gradle task integration
 because both are part of the contract used by the Figma sync pipeline.
 ```
 
+## Documentation
+
+- Treat `docs/documentation.md` as the canonical documentation standard.
+- Choose the document type before creating prose: standard, guide, runbook,
+  reference, ADR, or README index.
+- Start typed documents from the matching template under `docs/templates/` and
+  place them in the canonical project or module directory.
+- Keep shared production rules under `docs/standards/`. Module documentation
+  links to shared rules and records only module ownership, contracts, and
+  explicit exceptions.
+- Keep README files as orientation and navigation. Move detailed development
+  workflows to guides and operational execution or recovery to runbooks.
+- Keep Figma and rendered UML as derived publication surfaces linked to their
+  versioned repository sources.
+- Run `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1`
+  after adding, moving, or editing documentation.
+
 ## UML Documentation
 
 - Use PlantUML for UML diagrams.

--- a/README.md
+++ b/README.md
@@ -3,59 +3,15 @@
 ## Project documentation
 
 - [Documentation guide](docs/documentation.md)
-- [Project structure](docs/project-structure.md)
+- [Documentation index](docs/README.md)
+- [Project structure](docs/reference/project-structure.md)
+- [Engineering standards](docs/standards/README.md)
+- [Development guides](docs/guides/README.md)
 - [Main branch protection](docs/ci/main-branch-protection.md)
 - [TeamCity HTTPS and webhook operations](docs/runbooks/teamcity-cloudflare-access.md)
 
-## BDD with Cucumber
+## Development
 
-This project uses Cucumber JVM for executable BDD scenarios in local JVM tests.
-
-Run the BDD scenarios with the app unit test task:
-
-```bash
-./gradlew :app:testDebugUnitTest
-```
-
-Run a tagged subset:
-
-```bash
-./gradlew :app:testDebugUnitTest -Dcucumber.filter.tags="@smoke"
-```
-
-Cucumber feature files live under:
-
-```text
-app/src/test/resources/features/
-```
-
-Step definitions live under:
-
-```text
-app/src/test/kotlin/com/marmatsan/water_my_plants/bdd/steps/
-```
-
-The Cucumber JUnit Platform suite is:
-
-```text
-app/src/test/kotlin/com/marmatsan/water_my_plants/bdd/RunCucumberTest.kt
-```
-
-Generated reports:
-
-```text
-app/build/reports/cucumber/cucumber.html
-app/build/reports/cucumber/cucumber.json
-```
-
-CI should execute `:app:testDebugUnitTest` and publish `app/build/reports/cucumber/` as build artifacts.
-
-### BDD conventions
-
-- Use Cucumber for executable business scenarios, not for low-level implementation tests.
-- Keep scenarios focused on observable behavior.
-- Write `Given` steps for context, `When` steps for the action, and `Then` steps for the expected outcome.
-- Prefer domain language in feature files.
-- Keep step definitions under the module BDD package so the suite glue can discover them.
-- Tag scenarios that should run in specific suites, for example `@smoke`, `@regression`, or `@wip`.
-- Do not commit `@wip` scenarios as part of release-ready work.
+- [Run executable BDD scenarios](docs/guides/run-bdd-tests.md)
+- [Add a product feature](docs/guides/add-feature.md)
+- [Add a product module](docs/guides/add-module.md)

--- a/app/docs/README.md
+++ b/app/docs/README.md
@@ -1,0 +1,39 @@
+# App Module
+
+## Purpose
+
+`:app` is the Android application and product composition boundary. It owns the
+manifest, application entry points, top-level dependency assembly, and the app
+BDD suite.
+
+## Boundaries
+
+Reusable feature or UI behavior does not belong in `:app`. New production
+features should live behind feature or core module APIs and be assembled here.
+The current greeting classes are scaffold behavior, not a template for future
+layer dependencies.
+
+## Dependencies
+
+- `:core:ui` supplies the shared design system.
+
+Feature modules may be added as composition dependencies when their product
+flow is integrated.
+
+## Shared Standards
+
+- [Architecture](../../docs/standards/architecture.md)
+- [Android](../../docs/standards/android.md)
+- [Compose](../../docs/standards/compose.md)
+- [Testing](../../docs/standards/testing.md)
+
+## Verification
+
+```powershell
+.\gradlew.bat :app:testDebugUnitTest :app:lintDebug
+```
+
+## Module Documentation
+
+BDD feature files live under `src/test/resources/features/`. Project-wide
+development guides live under `docs/guides/`.

--- a/core/ui/docs/README.md
+++ b/core/ui/docs/README.md
@@ -1,0 +1,33 @@
+# Core UI Module
+
+## Purpose
+
+`:core:ui` owns the shared Water My Plants design system: theme, typography,
+colors, shapes, density, spacing, and elevation used across product UI.
+
+## Boundaries
+
+This module must remain feature-agnostic. Feature screens, navigation flows,
+networking, persistence, and product-specific state do not belong here.
+
+## Dependencies
+
+`:core:ui` uses the shared Android and Compose convention plugins and has no
+project-module dependency.
+
+## Shared Standards
+
+- [Architecture](../../../docs/standards/architecture.md)
+- [Compose](../../../docs/standards/compose.md)
+- [Accessibility](../../../docs/standards/accessibility.md)
+
+## Verification
+
+```powershell
+.\gradlew.bat :core:ui:check
+```
+
+## Module Documentation
+
+Add module-specific references or UML below this single `docs/` directory. Keep
+shared UI policy in the project standards linked above.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Project Documentation
+
+Use [documentation.md](documentation.md) for the canonical documentation
+standard and source-of-truth hierarchy.
+
+| Area | Purpose |
+|------|---------|
+| `standards/` | Mandatory and recommended engineering rules. |
+| `guides/` | Supported development workflows. |
+| `reference/` | Exact project contracts and inventories. |
+| `decisions/` | Architecture Decision Records. |
+| `runbooks/` | Operational execution and recovery procedures. |
+| `ci/` | Versioned CI topology, branch protection, and validation contracts. |
+| `uml/` | Project-wide PlantUML sources and shared includes. |
+| `templates/` | Starting points for typed documentation. |
+
+Module-specific documentation belongs in the module's top-level `docs/`
+directory and links back to shared project standards instead of duplicating
+them.

--- a/docs/ci/documentation-coverage.md
+++ b/docs/ci/documentation-coverage.md
@@ -1,12 +1,30 @@
 # CI Documentation Coverage
 
 `.teamcity/documentation-coverage.json` is the versioned documentation contract
-for changes that can alter the CI or Figma documentation state.
+for changes that can alter CI, Figma, the documentation system, or the product
+module graph.
+
+`validate-documentation.ps1` runs before change-scope classification. It checks
+the typed documentation contract from `docs/documentation.md`: canonical
+placement, frontmatter, review dates, canonical sources, runbook and ADR
+sections, and local Markdown links. Expired review dates warn; structural or
+link errors fail CI.
+
+The validator MUST remain compatible with Windows PowerShell 5.1 because
+TeamCity invokes repository scripts through `powershell.exe`. Local validation
+SHOULD execute both the focused test and the validator with that same runtime;
+using `pwsh` alone is insufficient for CI compatibility.
 
 `get-change-impact.ps1` compares the build revision with `origin/main`. It
 classifies the change as `documentation-only` only when every changed path is an
-explicitly allowed Markdown path. Every other change remains
+explicitly allowed Markdown path, including nested product-module docs. Every other change remains
 `full-verification`.
+
+CI validation scripts and the coverage manifest are `model-neutral`: their
+normal CI build still runs Gradle, but post-merge Figma Sync publishes only the
+scope artifact because those files cannot change the generated design model or
+compiled visual writer. This is distinct from `transport-only`, which is
+reserved for MCP runner transport changes.
 
 For each affected rule, the script requires at least one changed file matching
 that rule's `documentationPaths`. CI fails before Gradle when the source surface
@@ -28,7 +46,7 @@ and a matching test in `.teamcity/scripts/tests/get-change-impact.tests.ps1`.
 ## CI Execution
 
 `WaterMyPlantsCi` executes this contract before Gradle. A documentation-only
-revision validates whitespace and local Markdown links, then publishes the same
+revision validates the complete documentation structure and changed whitespace, then publishes the same
 required `TeamCity CI` status without running Gradle. All other revisions run
 the complete Gradle `check` lifecycle.
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+ADRs explain durable project decisions and their tradeoffs. Use
+[`../templates/adr.md`](../templates/adr.md) and name records
+`adr-NNNN-kebab-case-title.md`.
+
+| ADR | Status | Decision |
+|-----|--------|----------|
+| [ADR-0001](adr-0001-documentation-system.md) | Accepted | Use typed docs-as-code with CI validation. |

--- a/docs/decisions/adr-0001-documentation-system.md
+++ b/docs/decisions/adr-0001-documentation-system.md
@@ -1,0 +1,53 @@
+---
+title: Typed documentation system
+type: adr
+scope: repository
+owner: engineering
+status: accepted
+last-reviewed: 2026-07-18
+review-cycle-days: 365
+sources:
+  - docs/documentation.md
+  - .teamcity/documentation-coverage.json
+---
+
+# ADR-0001: Typed Documentation System
+
+## Context
+
+The repository already contains module indexes, CI references, Figma runbooks,
+and UML publication rules. References and standards had started to live inside
+`runbooks/`, making it unclear whether a reader was learning a contract or
+executing an operation. Product development will add architecture, API, UI,
+testing, and accessibility conventions, which would amplify that ambiguity.
+
+## Decision
+
+The repository will use typed documentation with canonical directories for
+standards, guides, references, runbooks, and ADRs. Typed documents carry common
+frontmatter and are validated by CI. README files remain navigation indexes,
+and Figma remains a derived visual publication surface.
+
+Shared production rules live under `docs/standards/`. Module documentation
+links to shared rules and records only module-specific ownership or exceptions.
+
+## Consequences
+
+- Readers can infer a document's purpose from its path and metadata.
+- CI can reject misplaced or structurally incomplete documentation.
+- Existing links must be updated when documents are reclassified.
+- Documentation changes become part of the same reviewed contract as code.
+
+## Alternatives
+
+- Keep all technical documentation in README files. Rejected because indexes
+  would become large, duplicated, and operationally ambiguous.
+- Keep topic-only directories such as `ci/` and `figma/` without document
+  types. Retained only for specialized executable sources; general prose still
+  follows the typed system.
+- Store the canonical process in Figma. Rejected because visual publication is
+  derived and cannot provide reviewable executable contracts by itself.
+
+## Supersession
+
+None.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,62 +1,165 @@
-# Documentation Guide
+---
+title: Documentation standard
+type: standard
+scope: repository
+owner: engineering
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - AGENTS.md
+  - .teamcity/documentation-coverage.json
+---
 
-This repository uses a small set of documentation types. Keep each document in
-one role so readers know whether they are orienting themselves or executing an
-operation.
+# Documentation Standard
+
+This document is the canonical documentation policy for Water My Plants. It
+defines where knowledge belongs, which documents are normative, and what CI
+must validate. Documentation must describe the current repository or clearly
+label a future decision as proposed.
+
+## Source Of Truth
+
+Use this precedence when two artifacts disagree:
+
+1. executable code, tests, schemas, and versioned build configuration define
+   current behavior;
+2. standards define mandatory engineering policy;
+3. accepted ADRs explain why architectural decisions were made;
+4. references describe exact contracts derived from source;
+5. guides explain supported development workflows;
+6. runbooks execute or recover operational procedures;
+7. Figma and rendered UML are derived publication surfaces.
+
+Correct the lower-precedence document when it diverges. Do not weaken an
+executable contract only to preserve stale prose.
 
 ## Document Types
 
-| Type | Purpose | Typical location |
-|------|---------|------------------|
-| `README.md` | Orient readers: what this area is, what it owns, and where to go next. | Repository root, `docs/`, and module `docs/` directories. |
-| Guide | Explain a stable concept, structure, policy, or decision. | `docs/*.md` or module `docs/*.md`. |
-| Runbook | Execute an operation with prerequisites, steps, verification, and recovery notes. | `docs/runbooks/` or module `docs/runbooks/`. |
-| Reference | Capture detailed API, generated-model, BDD, or tool-specific facts. | Close to the owning module or tool. |
+| Type | Question answered | Canonical location |
+|------|-------------------|--------------------|
+| `README.md` | What does this area own and where should I continue? | Repository, documentation root, or module `docs/` root. |
+| `standard` | What must or should implementation follow? | `docs/standards/` or `<module>/docs/standards/`. |
+| `guide` | How do I implement a supported development change? | `docs/guides/` or `<module>/docs/guides/`. |
+| `runbook` | How do I execute, verify, or recover an operation? | `docs/runbooks/` or `<module>/docs/runbooks/`. |
+| `reference` | What is the exact current contract or inventory? | `docs/reference/` or `<module>/docs/reference/`. |
+| `adr` | Why was a durable architectural decision taken? | `docs/decisions/`. |
 
-## README Rules
+Specialized executable or generated documentation may remain in `docs/ci/`,
+`docs/bdd/`, `docs/dokka/`, or `docs/uml/`. These directories do not replace
+the document types above.
 
-A README should answer:
+## Normative Language
 
-- What is this repository, module, or documentation area?
-- What belongs here?
-- Which contracts or boundaries matter?
-- Where should the reader go for details?
+Standards use these terms deliberately:
 
-Avoid putting long operational procedures in README files. Link to a runbook
-instead.
+- `MUST` or `MUST NOT`: required and review-blocking;
+- `SHOULD` or `SHOULD NOT`: expected unless the exception is documented;
+- `MAY`: optional and context-dependent.
 
-## Runbook Rules
+Rules that can be checked mechanically SHOULD be enforced by tests, lint, or
+CI. Prose remains necessary for design constraints that cannot be automated.
 
-A runbook should answer:
+## Placement And Ownership
 
-- When to use it.
-- Prerequisites and required credentials/tools.
-- Exact commands or manual steps.
-- How to verify success.
-- Common failures and recovery steps.
-- What not to do.
+Project-wide rules and concepts belong under `docs/`. Documentation specific
+to one module belongs under that module's single top-level `docs/` directory.
+Do not create nested documentation roots.
 
-Runbooks should be named by operation, for example `trunk-sync.md` or
-`release.md`.
+A rule used by multiple modules MUST have one canonical project-wide document.
+Module documentation links to that rule and records only ownership, contracts,
+or explicit exceptions. Do not duplicate shared rules between modules.
 
-## Placement
+README files are indexes, not handbooks. They SHOULD state purpose, ownership,
+boundaries, verification entry points, and links to canonical detail.
 
-Project-wide documentation belongs under `docs/`.
+## Required Metadata
 
-Module-specific documentation belongs under that module's top-level `docs/`
-directory. Use `docs/runbooks/` for module operations.
+Typed Markdown documents MUST start with YAML frontmatter containing:
 
-UML publication runbooks are the exception: keep them under the module's
-`docs/uml/` directory because the PlantUML source, import notes, and helper
-scripts should stay together.
+```yaml
+---
+title: Human-readable title
+type: standard | guide | runbook | reference | adr
+scope: repository or module path
+owner: stable area name
+status: draft | active | accepted | deprecated | superseded
+last-reviewed: YYYY-MM-DD
+review-cycle-days: positive integer
+sources:
+  - canonical/source/path
+---
+```
 
-## Current Entry Points
+Use stable ownership areas such as `android`, `repository-tooling`, or
+`figma-design-sync`, not an individual's name. Never put credentials or local
+machine paths in metadata.
 
-- Repository overview: `README.md`
-- Project structure: `docs/project-structure.md`
-- CI policy: `docs/ci/main-branch-protection.md`
-- TeamCity HTTPS and webhook operations:
-  `docs/runbooks/teamcity-cloudflare-access.md`
-- Windows CI runtime inventory validation:
-  `docs/ci/windows-runtime-validation.md`
-- Figma design sync docs: `repo/figma-design-sync/docs/README.md`
+Runbooks and external integration references SHOULD use a 90-day review cycle.
+Standards and guides SHOULD use 180 days. ADRs record review metadata but are
+changed by superseding decisions, not rewritten to hide history.
+
+## Runbook Contract
+
+A runbook MUST make the following information easy to find:
+
+1. when to use it;
+2. prerequisites, permissions, tools, and authorized inputs;
+3. ordered commands or manual actions;
+4. success verification;
+5. recovery or rollback;
+6. prohibited actions and safety boundaries;
+7. canonical sources and related contracts.
+
+Commands MUST be directly executable in the stated shell. Secrets must be
+referenced by storage location or environment variable name, never included as
+literal values.
+
+## Guide And Reference Contract
+
+A guide MUST describe one supported development outcome and link to the
+standards it applies. It SHOULD explain choices and expected verification, but
+must not become an incident-recovery procedure.
+
+A reference MUST describe current names, fields, paths, or contracts precisely.
+It should optimize for lookup rather than teach a workflow. Generated data may
+support a reference but must not replace its canonical source.
+
+## ADR Contract
+
+ADRs use `adr-NNNN-kebab-case-title.md`. An ADR records context, decision,
+consequences, alternatives, and links to superseded decisions. Accepted ADRs
+are immutable except for status and supersession links; a changed decision gets
+a new ADR.
+
+## Production Documentation
+
+Before production behavior is added, the applicable project standards MUST be
+identified. New product work begins with the standards under
+`docs/standards/` and the relevant implementation guide under `docs/guides/`.
+
+Product modules keep `<module>/docs/README.md` as their local entry point. The
+module README MUST link to shared standards and describe only module purpose,
+public boundaries, dependencies, and focused verification.
+
+## Derived Visual Documentation
+
+PlantUML source remains the reviewed UML source of truth. Figma contains the
+published visual result and must link back to canonical repository sources.
+Manual Figma edits cannot override a versioned standard, reference, YAML model,
+test, or runbook.
+
+## CI Enforcement
+
+CI validates typed document placement, frontmatter, review dates, ADR names,
+runbook sections, and local Markdown links. Documentation coverage rules in
+`.teamcity/documentation-coverage.json` map implementation areas to canonical
+documents that must change with them.
+
+Review-expiry findings are warnings. Invalid structure, missing metadata,
+broken links, and uncovered mapped implementation changes are failures.
+
+## Templates
+
+Start new documents from `docs/templates/`. Remove all placeholder text before
+review and add the new document to the closest README index.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,12 @@
+# Development Guides
+
+Guides describe supported implementation workflows and link to the standards
+that govern them.
+
+| Guide | Outcome |
+|-------|---------|
+| [Add a module](add-module.md) | Register and document a product Gradle module. |
+| [Add a feature](add-feature.md) | Introduce a feature without breaking module boundaries. |
+| [Add an API endpoint](add-api-endpoint.md) | Add transport and domain behavior without leaking client types. |
+| [Add a Compose screen](add-compose-screen.md) | Build a state-driven, accessible screen using the design system. |
+| [Run BDD tests](run-bdd-tests.md) | Execute and filter the Cucumber business scenarios. |

--- a/docs/guides/add-api-endpoint.md
+++ b/docs/guides/add-api-endpoint.md
@@ -1,0 +1,51 @@
+---
+title: Add an API endpoint
+type: guide
+scope: product-data
+owner: data
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - docs/standards/api-client.md
+  - docs/standards/architecture.md
+  - repo/dependency-catalog/versions.properties
+---
+
+# Add An API Endpoint
+
+## Outcome
+
+Add one remote capability while keeping HTTP and serialization details inside
+the data adapter.
+
+## Applicable Standards
+
+Read the [API client](../standards/api-client.md),
+[architecture](../standards/architecture.md), [Kotlin](../standards/kotlin.md),
+and [testing](../standards/testing.md) standards.
+
+## Steps
+
+1. If this is the first production endpoint, create an ADR selecting the HTTP
+   and serialization stack before adding dependencies.
+2. Define the domain-facing operation and its typed success and failure model.
+3. Add request and response DTOs inside the transport adapter.
+4. Map DTOs to domain models explicitly.
+5. Configure the endpoint through the shared client; do not create an ad hoc
+   client instance in a repository or UI class.
+6. Translate protocol, connectivity, timeout, and malformed-response failures
+   at the adapter boundary while preserving cancellation.
+7. Add deterministic adapter tests for success and each relevant failure.
+8. Register new dependency versions and aliases through the repository catalog
+   if the selected stack requires them.
+
+## Verification
+
+Run adapter tests, catalog naming and usage checks, and `./gradlew check`.
+Inspect logs to ensure credentials and sensitive payloads are absent.
+
+## Related Documentation
+
+- `docs/templates/adr.md`
+- `repo/figma-design-sync/docs/standards/dependency-version-naming.md`

--- a/docs/guides/add-compose-screen.md
+++ b/docs/guides/add-compose-screen.md
@@ -1,0 +1,51 @@
+---
+title: Add a Compose screen
+type: guide
+scope: product-ui
+owner: android-ui
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - docs/standards/compose.md
+  - docs/standards/accessibility.md
+  - core/ui
+---
+
+# Add A Compose Screen
+
+## Outcome
+
+Create a state-driven, accessible screen that uses the shared Water My Plants
+design system.
+
+## Applicable Standards
+
+Apply the [Compose](../standards/compose.md),
+[accessibility](../standards/accessibility.md),
+[Android](../standards/android.md), and [testing](../standards/testing.md)
+standards.
+
+## Steps
+
+1. Define immutable UI state and user events before composing the full screen.
+2. Keep the route or state owner separate from the stateless screen content.
+3. Build reusable components with state and callbacks supplied by the caller.
+4. Use `:core:ui` theme tokens for typography, color, shape, spacing, density,
+   and elevation.
+5. Add semantics and localized descriptions at the component that owns each
+   interaction.
+6. Add previews for loading, content, empty, and error states that actually
+   exist.
+7. Test important state rendering, events, and accessibility semantics.
+8. Verify large text, supported themes, focus order, and touch targets.
+
+## Verification
+
+Run focused tests and `./gradlew check`. Inspect previews and the running screen
+for clipping, overlapping content, missing semantics, and raw design values.
+
+## Related Documentation
+
+- `core/ui/docs/README.md`
+- `onboarding/ui/docs/README.md`

--- a/docs/guides/add-feature.md
+++ b/docs/guides/add-feature.md
@@ -1,0 +1,51 @@
+---
+title: Add a product feature
+type: guide
+scope: product-features
+owner: architecture
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - docs/standards/architecture.md
+  - docs/standards/testing.md
+  - settings.gradle.kts
+---
+
+# Add A Product Feature
+
+## Outcome
+
+Introduce observable product behavior with clear state ownership and without a
+dependency on another feature.
+
+## Applicable Standards
+
+Apply the [architecture](../standards/architecture.md),
+[Kotlin](../standards/kotlin.md), [testing](../standards/testing.md), and any
+UI or API standards relevant to the feature.
+
+## Steps
+
+1. Describe the user-visible behavior and add a BDD scenario only when it adds
+   executable business value.
+2. Decide whether the feature fits an existing module. Create a module only
+   when it introduces a durable capability or boundary.
+3. Model domain behavior without Android, transport, or persistence types.
+4. Define capability interfaces at the boundary that owns the need.
+5. Implement adapters outside the domain boundary and bind them in a
+   composition root.
+6. Expose immutable UI state and events to the screen.
+7. Add focused unit, adapter, and UI tests according to risk.
+8. Update the feature or module README when its public boundary changes.
+
+## Verification
+
+Run focused tests while iterating and `./gradlew check` before review. Confirm
+the module graph still follows the documented dependency direction.
+
+## Related Documentation
+
+- `docs/guides/add-module.md`
+- `docs/guides/add-api-endpoint.md`
+- `docs/guides/add-compose-screen.md`

--- a/docs/guides/add-module.md
+++ b/docs/guides/add-module.md
@@ -1,0 +1,52 @@
+---
+title: Add a product module
+type: guide
+scope: product-modules
+owner: architecture
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - settings.gradle.kts
+  - docs/standards/architecture.md
+  - repo/gradle-plugins
+---
+
+# Add A Product Module
+
+## Outcome
+
+Create a focused Android module registered in the root build with an explicit
+owner, dependency direction, and verification command.
+
+## Applicable Standards
+
+Read the [architecture](../standards/architecture.md),
+[Android](../standards/android.md), and [testing](../standards/testing.md)
+standards before changing the module graph.
+
+## Steps
+
+1. Choose a capability-based path such as `core/<capability>` or
+   `<feature>/<layer>`. Do not use a generic dumping-ground name.
+2. Add the module to the appropriate group in `settings.gradle.kts`.
+3. Apply the existing Android, Compose, and test convention plugins needed by
+   the module. Do not duplicate their shared configuration.
+4. Declare a namespace and only the dependencies permitted by the architecture
+   standard.
+5. Add `<module>/docs/README.md` from the module README template. Record the
+   module purpose, boundaries, consumers, dependencies, and focused check.
+6. Add production and test source sets only when they contain real behavior.
+7. Update `docs/reference/project-structure.md`.
+
+## Verification
+
+Run the new module's `check` task followed by `./gradlew check`. Confirm the
+generated Figma model reports the intended module dependency only through the
+official post-merge workflow.
+
+## Related Documentation
+
+- `docs/templates/module-readme.md`
+- `docs/reference/project-structure.md`
+- `docs/standards/architecture.md`

--- a/docs/guides/run-bdd-tests.md
+++ b/docs/guides/run-bdd-tests.md
@@ -1,0 +1,63 @@
+---
+title: Run executable BDD scenarios
+type: guide
+scope: app
+owner: quality
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - app/src/test/resources/features
+  - app/src/test/kotlin/com/marmatsan/water_my_plants/bdd
+  - repo/gradle-plugins/bdd-test
+---
+
+# Run Executable BDD Scenarios
+
+## Outcome
+
+Execute all or a tagged subset of Cucumber JVM business scenarios and locate
+their reports.
+
+## Applicable Standards
+
+Follow the [testing standard](../standards/testing.md). Cucumber scenarios
+describe observable business behavior, not low-level implementation tests.
+
+## Steps
+
+Run the app BDD suite through its JVM unit-test task:
+
+```powershell
+.\gradlew.bat :app:testDebugUnitTest
+```
+
+Run a tagged subset:
+
+```powershell
+.\gradlew.bat :app:testDebugUnitTest -Dcucumber.filter.tags="@smoke"
+```
+
+Feature files live under `app/src/test/resources/features/`. Step definitions
+live under `app/src/test/kotlin/com/marmatsan/water_my_plants/bdd/steps/`, and
+`RunCucumberTest.kt` owns the JUnit Platform suite configuration.
+
+Use `Given` for context, `When` for the action, and `Then` for the observable
+result. Prefer domain language and tags such as `@smoke` or `@regression`.
+`@wip` scenarios must not reach release-ready `main`.
+
+## Verification
+
+Inspect:
+
+```text
+app/build/reports/cucumber/cucumber.html
+app/build/reports/cucumber/cucumber.json
+```
+
+The Gradle task must succeed and report all selected scenarios.
+
+## Related Documentation
+
+- `app/docs/README.md`
+- `repo/gradle-plugins/bdd-test/docs/README.md`

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,8 @@
+# Project Reference
+
+References describe exact current contracts and inventories. They optimize for
+lookup and point back to executable or versioned sources.
+
+| Reference | Contract |
+|-----------|----------|
+| [Project structure](project-structure.md) | Product modules, repository included builds, documentation, and generated output. |

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -1,3 +1,18 @@
+---
+title: Project structure
+type: reference
+scope: repository
+owner: architecture
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - settings.gradle.kts
+  - repo/dependency-catalog/settings.gradle.kts
+  - repo/gradle-plugins/settings.gradle.kts
+  - repo/figma-design-sync/settings.gradle.kts
+---
+
 # Project Structure
 
 This repository is split between product modules, repository infrastructure,
@@ -74,10 +89,19 @@ publish a compatibility artifact.
 | Path | Purpose |
 |------|---------|
 | `README.md` | Repository entry point and links to deeper documentation. |
-| `docs/documentation.md` | Rules for README files, guides, references, and runbooks. |
+| `docs/documentation.md` | Canonical documentation taxonomy and validation contract. |
+| `docs/standards/` | Project-wide engineering rules for production and tooling. |
+| `docs/guides/` | Supported development workflows. |
+| `docs/reference/` | Exact project contracts and inventories. |
+| `docs/decisions/` | Architecture Decision Records. |
+| `docs/runbooks/` | Project-wide operational execution and recovery procedures. |
+| `docs/templates/` | Starting points for typed documentation. |
 | `docs/ci/` | CI and branch protection documentation. |
 | `docs/uml/` | Project-wide PlantUML diagrams and shared UML includes. |
 | `<module>/docs/README.md` | Module documentation index and orientation. |
+| `<module>/docs/standards/` | Rules owned only by that module. |
+| `<module>/docs/guides/` | Module-specific development workflows. |
+| `<module>/docs/reference/` | Module-specific contracts and inventories. |
 | `<module>/docs/runbooks/` | Module-owned operational runbooks. |
 | `<module>/docs/uml/` | Module-owned PlantUML diagrams, UML publication notes, and UML helper scripts. |
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,8 @@
+# Project Runbooks
+
+Runbooks execute or recover repository-wide operations. Module-owned operations
+remain under that module's `docs/runbooks/` directory.
+
+| Runbook | Operation |
+|---------|-----------|
+| [TeamCity Cloudflare Access](teamcity-cloudflare-access.md) | Operate TeamCity HTTPS access, service authentication, webhooks, and Windows runtime recovery. |

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -1,3 +1,17 @@
+---
+title: TeamCity Cloudflare Access operations
+type: runbook
+scope: repository-ci
+owner: ci-platform
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - .teamcity/settings.kts
+  - docs/ci/external-topology.yaml
+  - docs/ci/windows-runtime.yaml
+---
+
 # TeamCity Cloudflare Access Runbook
 
 ## Purpose
@@ -299,3 +313,24 @@ After configuration or recovery:
   unchanged.
 - When the GitHub webhook secret rotates, update GitHub and the TeamCity GitHub
   App connection in the same operation, then send a test delivery.
+
+## Recovery
+
+Use the verification commands in this runbook to identify whether the failure
+belongs to Cloudflare Access, the tunnel, TeamCity authentication, the GitHub
+webhook, or the Windows services. Restore one boundary at a time and preserve
+the last known valid service-token and TeamCity-token entries until the
+replacement is verified.
+
+## Prohibited Actions
+
+- Do not expose the TeamCity origin directly to bypass Cloudflare Access.
+- Do not place service-token or TeamCity-token values in source control,
+  command history, screenshots, or documentation.
+- Do not grant the build-agent account write access to TeamCity server data.
+
+## Sources
+
+- `.teamcity/settings.kts`
+- `docs/ci/external-topology.yaml`
+- `docs/ci/windows-runtime.yaml`

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -1,0 +1,14 @@
+# Engineering Standards
+
+These documents define project-wide implementation rules. `MUST` rules are
+review-blocking; `SHOULD` rules require a documented reason when not followed.
+
+| Standard | Scope |
+|----------|-------|
+| [Architecture](architecture.md) | Module boundaries and dependency direction. |
+| [Kotlin](kotlin.md) | Kotlin source design and concurrency. |
+| [Android](android.md) | Android modules, lifecycle, dependency injection, and build conventions. |
+| [Compose](compose.md) | Compose APIs, state, design-system use, and previews. |
+| [API client](api-client.md) | Transport boundaries, DTOs, errors, and security. |
+| [Testing](testing.md) | Unit, BDD, integration, and UI test responsibilities. |
+| [Accessibility](accessibility.md) | Semantics, interaction, text, and visual accessibility. |

--- a/docs/standards/accessibility.md
+++ b/docs/standards/accessibility.md
@@ -1,0 +1,56 @@
+---
+title: Accessibility standard
+type: standard
+scope: product-ui
+owner: android-ui
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - core/ui
+  - onboarding/ui
+  - docs/standards/compose.md
+---
+
+# Accessibility Standard
+
+## Semantics
+
+- Interactive elements MUST expose an accessible role, state, action, and name.
+- Meaningful images MUST have a localized description. Decorative images MUST
+  be excluded from accessibility semantics.
+- A composed control SHOULD expose one coherent semantic node rather than
+  duplicate labels from decorative children.
+- Validation errors and asynchronous state changes MUST be perceivable without
+  relying only on color.
+
+## Interaction
+
+- Touch targets MUST be large enough for reliable interaction and must not
+  overlap neighboring actions.
+- Every action MUST be usable without gesture-only knowledge when an equivalent
+  standard action is possible.
+- Focus order MUST follow reading and task order. Dialogs and temporary surfaces
+  must manage focus predictably.
+
+## Text And Visuals
+
+- Layout MUST tolerate user font scaling without clipping, overlap, or loss of
+  actions.
+- Text and meaningful icons MUST maintain readable contrast against their
+  actual background in supported themes.
+- Information MUST NOT depend on color alone.
+- Motion SHOULD respect reduced-motion expectations and MUST NOT block task
+  completion.
+
+## Verification
+
+Review changed screens with semantics inspection, increased font size, light
+and dark themes, and keyboard or accessibility focus where applicable. Add UI
+tests for critical semantics and state descriptions.
+
+## Sources
+
+- `core/ui/`
+- `onboarding/ui/`
+- `docs/standards/compose.md`

--- a/docs/standards/android.md
+++ b/docs/standards/android.md
@@ -1,0 +1,60 @@
+---
+title: Android standard
+type: standard
+scope: product-modules
+owner: android
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - repo/gradle-plugins/android
+  - repo/gradle-plugins/dependencies
+  - settings.gradle.kts
+---
+
+# Android Standard
+
+## Build Configuration
+
+- Android modules MUST apply the repository convention plugins instead of
+  duplicating SDK, Java, Kotlin, coroutine, or test configuration.
+- Dependency versions MUST come from the generated catalogs. Module build
+  files MUST NOT hardcode dependency versions.
+- Dependencies required by every consumer of a convention plugin belong in
+  that plugin. Feature-only dependencies remain in the feature module.
+- Android library modules MUST declare a namespace matching their stable
+  package boundary.
+
+## Lifecycle And State
+
+- Android framework objects MUST remain at Android boundaries and MUST NOT be
+  stored in domain state.
+- Long-running work MUST be lifecycle-aware or owned by an application-scoped
+  component with an explicit reason.
+- Saved state and process restoration must be considered for user-visible
+  state that cannot be reconstructed cheaply.
+
+## Dependency Injection
+
+Constructor injection is the default. A module composition root may bind
+implementations. Activities, composables, repositories, and use cases MUST NOT
+look up dependencies through global mutable state.
+
+## Resources
+
+- User-visible text MUST use Android resources unless it is server-provided
+  content.
+- Reusable colors, typography, spacing, and shapes belong to the design system.
+- Secrets and environment-specific endpoints MUST NOT be committed as Android
+  resources or build constants.
+
+## Verification
+
+Run the affected module's unit tests and `./gradlew check`. Changes to shared
+Android convention plugins require their focused included-build checks.
+
+## Sources
+
+- `repo/gradle-plugins/android/`
+- `repo/gradle-plugins/dependencies/`
+- `settings.gradle.kts`

--- a/docs/standards/api-client.md
+++ b/docs/standards/api-client.md
@@ -1,0 +1,60 @@
+---
+title: API client standard
+type: standard
+scope: product-data
+owner: data
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - docs/standards/architecture.md
+  - repo/dependency-catalog/versions.properties
+---
+
+# API Client Standard
+
+## Current Boundary
+
+The repository has not selected an HTTP client or serialization stack for
+production APIs. That selection MUST be recorded in an ADR when the first real
+endpoint is implemented. This standard defines the boundary independently of
+that library choice.
+
+## Transport Isolation
+
+- HTTP client, response, request, and serialization types MUST remain inside a
+  data or transport adapter.
+- Domain and UI modules MUST depend on capability interfaces and domain models,
+  not URLs, status codes, headers, or transport DTOs.
+- DTO-to-domain mapping MUST be explicit and tested.
+- Endpoint paths, base URLs, authentication, timeouts, and retry policy MUST be
+  configured centrally for a client instance.
+
+## Errors And Cancellation
+
+- Transport failures MUST be translated into a small typed error contract at
+  the adapter boundary.
+- Cancellation MUST never be converted into a network failure.
+- Retries MUST be bounded, observable, and limited to operations known to be
+  safe to retry. UI code MUST NOT implement retry loops around a client.
+- Empty, partial, or malformed responses MUST have explicit handling.
+
+## Security
+
+- Tokens, authorization headers, cookies, and sensitive bodies MUST NOT be
+  logged.
+- Secrets MUST come from an approved runtime or CI secret source, never source
+  control.
+- Certificate and cleartext exceptions require an ADR and a documented threat
+  assessment.
+
+## Verification
+
+Adapter tests MUST cover successful mapping, protocol failures, malformed
+payloads, cancellation, and retry limits. Contract tests SHOULD use a local
+deterministic server rather than the real service.
+
+## Sources
+
+- `docs/standards/architecture.md`
+- `repo/dependency-catalog/versions.properties`

--- a/docs/standards/architecture.md
+++ b/docs/standards/architecture.md
@@ -1,0 +1,72 @@
+---
+title: Product architecture standard
+type: standard
+scope: product-modules
+owner: architecture
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - settings.gradle.kts
+  - docs/reference/project-structure.md
+  - repo/gradle-plugins
+---
+
+# Product Architecture Standard
+
+## Purpose
+
+Define dependency direction and ownership for production Android code without
+committing the project to infrastructure that has not yet been selected.
+
+## Module Boundaries
+
+- `:app` MUST remain the application and composition boundary. It may assemble
+  feature and core modules but SHOULD NOT own reusable feature behavior.
+- `:core:*` modules MUST contain capabilities shared by multiple features and
+  MUST NOT depend on `:app` or a feature module.
+- Feature modules such as `:onboarding:*` MUST NOT depend on `:app` or another
+  feature. Shared behavior moves to an appropriately scoped `:core:*` module.
+- Product modules MUST NOT depend on included builds under `repo/` as runtime
+  libraries. They consume repository tooling only through Gradle plugins and
+  generated catalogs.
+- Gradle module dependencies MUST use type-safe project accessors.
+
+The existing greeting classes in `:app` are scaffold code, not an architectural
+precedent for future production features.
+
+## Dependency Direction
+
+New domain behavior MUST depend on abstractions it owns, not concrete Android,
+network, database, or Gradle implementations. Infrastructure adapters may
+depend inward on those abstractions. Android UI may depend on domain-facing
+interfaces but domain code MUST remain free of Android framework types.
+
+Cross-layer types MUST be explicit. Transport DTOs, persistence entities, and
+Compose state are not domain models and MUST NOT leak across their boundary.
+
+## Public API
+
+- Declarations SHOULD be `internal` unless another module consumes them.
+- A module's public API MUST represent its capability, not its package layout.
+- Cyclic module dependencies are prohibited.
+- New architectural layers, shared modules, or cross-feature dependencies MUST
+  be justified by an ADR before implementation.
+
+## Composition
+
+Constructor injection is the default. Composition roots may select concrete
+implementations; domain and UI classes MUST NOT use service locators or read a
+global dependency container.
+
+## Verification
+
+Run `./gradlew check` after dependency-boundary changes. Review
+`settings.gradle.kts` and affected `build.gradle.kts` files together with the
+module documentation.
+
+## Sources
+
+- `settings.gradle.kts`
+- `docs/reference/project-structure.md`
+- `repo/gradle-plugins/`

--- a/docs/standards/compose.md
+++ b/docs/standards/compose.md
@@ -1,0 +1,65 @@
+---
+title: Jetpack Compose standard
+type: standard
+scope: product-ui
+owner: android-ui
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - core/ui
+  - onboarding/ui
+  - repo/gradle-plugins/compose
+---
+
+# Jetpack Compose Standard
+
+## Component APIs
+
+- Screen composables SHOULD expose immutable UI state and event callbacks.
+- Reusable visual composables MUST be stateless where practical. State owners
+  pass data down and events up.
+- `Modifier` SHOULD be the first optional parameter and MUST be applied to the
+  component's outermost relevant layout.
+- Composables MUST NOT perform network, database, or dependency-container
+  lookups during composition.
+
+## Design System
+
+- Product UI MUST use tokens and theme values from `:core:ui` for shared color,
+  typography, shape, spacing, density, and elevation decisions.
+- Raw geometry is allowed for generated vector artwork and illustration
+  internals, but not as a substitute for layout or design-system tokens.
+- Feature-specific tokens may remain local until at least two consumers justify
+  promotion to `:core:ui`.
+
+## State And Effects
+
+- State used by composition MUST be stable and have one clear owner.
+- Side effects MUST use the appropriate Compose effect API and stable keys.
+- Derived values SHOULD use `derivedStateOf` only when recomputation has a
+  measurable cost or changes observation behavior.
+- Collections rendered with lazy layouts MUST use stable keys when item identity
+  survives reordering.
+
+## Preview And Inspection
+
+Reusable UI and screens SHOULD include focused previews for meaningful states.
+Preview-only data stays outside production behavior. Figma-generated asset
+bindings may live in dedicated `figma` packages and must not own screen state.
+
+## Accessibility
+
+Every composable MUST follow [the accessibility standard](accessibility.md).
+Semantics belong with the component that owns the interaction.
+
+## Verification
+
+Run focused unit or UI tests, inspect previews for changed states, and run
+`./gradlew check` before merge.
+
+## Sources
+
+- `core/ui/`
+- `onboarding/ui/`
+- `repo/gradle-plugins/compose/`

--- a/docs/standards/kotlin.md
+++ b/docs/standards/kotlin.md
@@ -1,0 +1,57 @@
+---
+title: Kotlin standard
+type: standard
+scope: product-modules
+owner: android
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - gradle.properties
+  - repo/gradle-plugins/android
+  - repo/gradle-plugins/unit-test
+---
+
+# Kotlin Standard
+
+## Source Design
+
+- Code MUST use the formatter and compiler configuration supplied by the
+  repository build. Do not introduce module-local formatting policy.
+- Prefer immutable values and pure transformations. Mutable state MUST have a
+  clear owner and lifecycle.
+- Public names MUST express domain intent. Avoid generic names such as
+  `Manager`, `Helper`, or `Utils` when a capability name is available.
+- Production failures MUST use typed results or domain exceptions at module
+  boundaries. Do not use `null` to hide an operational failure.
+- Do not catch `Throwable`, cancellation exceptions, or broad exceptions
+  without rethrowing cancellation and translating the remaining failure.
+
+## Types And APIs
+
+- Keep one primary public top-level type per file. Private helpers and tightly
+  owned nested types may remain with their owner.
+- Prefer sealed hierarchies for closed state or result sets.
+- Default to `internal`; make an API public only for an identified consumer.
+- Extension functions MUST remain close to the type or capability they extend.
+  Unrelated catch-all extension files are prohibited.
+
+## Coroutines
+
+- Coroutines MUST use structured concurrency and an injected or caller-owned
+  scope. `GlobalScope` is prohibited.
+- Dispatchers MUST be supplied at infrastructure boundaries when deterministic
+  tests require control.
+- Flows exposed as state MUST have a single state owner. Callers should receive
+  read-only `Flow` or `StateFlow` views.
+- Cancellation MUST propagate across suspend boundaries.
+
+## Verification
+
+Run the focused module test task during implementation and `./gradlew check`
+before merge.
+
+## Sources
+
+- `repo/gradle-plugins/android/`
+- `repo/gradle-plugins/unit-test/`

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -1,0 +1,56 @@
+---
+title: Testing standard
+type: standard
+scope: repository
+owner: quality
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - repo/gradle-plugins/unit-test
+  - repo/gradle-plugins/bdd-test
+  - app/src/test/resources/features
+---
+
+# Testing Standard
+
+## Test Ownership
+
+- Domain behavior MUST have deterministic unit tests without Android, network,
+  filesystem, clock, or dispatcher dependencies unless those are the subject
+  of the test.
+- Adapters MUST test translation at their boundary, including failures.
+- UI tests SHOULD cover user-observable state and interaction rather than
+  internal composable structure.
+- A regression fix MUST add the smallest test that fails before the fix and
+  passes after it.
+
+## Tooling
+
+- Kotlin unit and integration tests use Kotest and MockK through the repository
+  convention plugins.
+- Tests use explicit `GIVEN`, `WHEN`, and `THEN` sections.
+- Cucumber is reserved for executable business behavior. Feature files use
+  domain language and must not encode implementation paths or class names.
+- `@wip` scenarios MUST NOT reach release-ready `main`.
+
+## Reliability
+
+- Tests MUST control clocks, randomness, dispatchers, and external IO when they
+  affect the assertion.
+- Arbitrary sleeps are prohibited. Await an observable condition with a bounded
+  timeout.
+- Mocks SHOULD represent external collaborators, not every class in the unit.
+- Tests MUST be independent of execution order and developer-machine state.
+
+## Verification
+
+Run the smallest affected test task while iterating and `./gradlew check` before
+merge. BDD changes additionally run `:app:testDebugUnitTest` or the owning
+module's equivalent task.
+
+## Sources
+
+- `repo/gradle-plugins/unit-test/`
+- `repo/gradle-plugins/bdd-test/`
+- `app/src/test/resources/features/`

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,17 @@
+# Documentation Templates
+
+Copy the template matching the document type into its canonical directory,
+replace all placeholder metadata, and add the result to the closest README
+index.
+
+| Template | Destination |
+|----------|-------------|
+| `standard.md` | `docs/standards/` or `<module>/docs/standards/` |
+| `guide.md` | `docs/guides/` or `<module>/docs/guides/` |
+| `runbook.md` | `docs/runbooks/` or `<module>/docs/runbooks/` |
+| `reference.md` | `docs/reference/` or `<module>/docs/reference/` |
+| `adr.md` | `docs/decisions/adr-NNNN-*.md` |
+| `module-readme.md` | `<module>/docs/README.md` |
+
+Templates are excluded from metadata validation because they intentionally
+contain placeholders. Every document created from them is validated by CI.

--- a/docs/templates/adr.md
+++ b/docs/templates/adr.md
@@ -1,0 +1,33 @@
+---
+title: Replace with decision title
+type: adr
+scope: repository
+owner: stable-area-name
+status: draft
+last-reviewed: YYYY-MM-DD
+review-cycle-days: 365
+sources:
+  - canonical/source/path
+---
+
+# ADR-NNNN: Decision Title
+
+## Context
+
+Describe the problem and constraints.
+
+## Decision
+
+State the selected decision.
+
+## Consequences
+
+List benefits, costs, and operational impact.
+
+## Alternatives
+
+List considered alternatives and why they were rejected.
+
+## Supersession
+
+Link to decisions superseded by or superseding this record, or state `None`.

--- a/docs/templates/guide.md
+++ b/docs/templates/guide.md
@@ -1,0 +1,34 @@
+---
+title: Replace with guide title
+type: guide
+scope: repository-or-module-path
+owner: stable-area-name
+status: draft
+last-reviewed: YYYY-MM-DD
+review-cycle-days: 180
+sources:
+  - canonical/source/path
+---
+
+# Guide Title
+
+## Outcome
+
+Describe the supported development result.
+
+## Applicable Standards
+
+Name the standards that govern this change.
+
+## Steps
+
+1. Add the first implementation step.
+2. Add the next implementation step.
+
+## Verification
+
+List focused tests and review checks.
+
+## Related Documentation
+
+List canonical references and runbooks.

--- a/docs/templates/module-readme.md
+++ b/docs/templates/module-readme.md
@@ -1,0 +1,25 @@
+# Module Name
+
+## Purpose
+
+Describe the module's product or infrastructure responsibility.
+
+## Boundaries
+
+State what belongs in the module and what must remain outside it.
+
+## Dependencies
+
+List direct project-module dependencies and why they exist.
+
+## Shared Standards
+
+Link to canonical project standards. Do not duplicate their rules here.
+
+## Verification
+
+List the smallest command that validates this module.
+
+## Module Documentation
+
+Link to module-specific guides, references, runbooks, and UML diagrams.

--- a/docs/templates/reference.md
+++ b/docs/templates/reference.md
@@ -1,0 +1,29 @@
+---
+title: Replace with reference title
+type: reference
+scope: repository-or-module-path
+owner: stable-area-name
+status: draft
+last-reviewed: YYYY-MM-DD
+review-cycle-days: 180
+sources:
+  - canonical/source/path
+---
+
+# Reference Title
+
+## Purpose
+
+State which exact contract this document describes.
+
+## Contract
+
+List stable names, fields, paths, or relationships.
+
+## Invariants
+
+List conditions that must remain true.
+
+## Sources
+
+List canonical source files and generated evidence.

--- a/docs/templates/runbook.md
+++ b/docs/templates/runbook.md
@@ -1,0 +1,42 @@
+---
+title: Replace with runbook title
+type: runbook
+scope: repository-or-module-path
+owner: stable-area-name
+status: draft
+last-reviewed: YYYY-MM-DD
+review-cycle-days: 90
+sources:
+  - canonical/source/path
+---
+
+# Runbook Title
+
+## Purpose
+
+State when this operation is required.
+
+## Prerequisites
+
+List tools, permissions, authorized inputs, and expected starting state.
+
+## Procedure
+
+1. Execute the first operation.
+2. Execute the next operation.
+
+## Verification
+
+Define observable success criteria.
+
+## Recovery
+
+Describe rollback or failure recovery.
+
+## Prohibited Actions
+
+List unsafe shortcuts and invalid inputs.
+
+## Sources
+
+List canonical configuration, code, and related contracts.

--- a/docs/templates/standard.md
+++ b/docs/templates/standard.md
@@ -1,0 +1,35 @@
+---
+title: Replace with standard title
+type: standard
+scope: repository-or-module-path
+owner: stable-area-name
+status: draft
+last-reviewed: YYYY-MM-DD
+review-cycle-days: 180
+sources:
+  - canonical/source/path
+---
+
+# Standard Title
+
+## Purpose
+
+State which implementation this standard governs.
+
+## Rules
+
+- `MUST`: add required behavior.
+- `SHOULD`: add the default behavior and acceptable exception.
+- `MAY`: add optional behavior.
+
+## Exceptions
+
+Explain how exceptions are documented and reviewed.
+
+## Verification
+
+List automated checks and review evidence.
+
+## Sources
+
+List canonical code, configuration, schemas, or accepted ADRs.

--- a/onboarding/ui/docs/README.md
+++ b/onboarding/ui/docs/README.md
@@ -1,0 +1,33 @@
+# Onboarding UI Module
+
+## Purpose
+
+`:onboarding:ui` owns onboarding screen composition, illustration components,
+and Figma-linked onboarding assets.
+
+## Boundaries
+
+The module must not depend on `:app` or another feature. Reusable design-system
+behavior moves to `:core:ui`; onboarding-specific UI remains here.
+
+## Dependencies
+
+- `:core:ui` supplies shared theme and design tokens.
+
+## Shared Standards
+
+- [Architecture](../../../docs/standards/architecture.md)
+- [Compose](../../../docs/standards/compose.md)
+- [Accessibility](../../../docs/standards/accessibility.md)
+- [Testing](../../../docs/standards/testing.md)
+
+## Verification
+
+```powershell
+.\gradlew.bat :onboarding:ui:check
+```
+
+## Module Documentation
+
+Figma binding sources live under `src/main/kotlin/com/marmatsan/onboarding/ui/figma/`.
+Document future onboarding-specific guides or references under this directory.

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -104,9 +104,9 @@ used by CI.
     `design-model.json` may be used for an official or branch-local visual sync.
   - `docs/runbooks/mcp-chunk-transport.md` when staging TeamCity artifacts and
     generated MCP scripts through Figma shared plugin data.
-  - `docs/runbooks/target-scopes.md` when choosing the smallest sync target for
+  - `docs/reference/target-scopes.md` when choosing the smallest sync target for
     a Figma section.
-  - `docs/runbooks/visual-sync-contract.md` when changing or validating Figma
+  - `docs/reference/visual-sync-contract.md` when changing or validating Figma
     visual sync behavior, especially catalog tree nodes, connectors, layout, and
     locking.
   - `docs/runbooks/troubleshooting.md` when diagnosing failed or visually

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -192,10 +192,10 @@ High-signal entry points:
 
 | Document | Use When |
 |----------|----------|
-| `docs/runbooks/dependency-version-naming.md` | Adding or renaming dependency version keys. |
-| `docs/runbooks/visual-sync-contract.md` | Changing component bindings, catalog trees, connectors, layout, or locking. |
+| `docs/standards/dependency-version-naming.md` | Adding or renaming dependency version keys. |
+| `docs/reference/visual-sync-contract.md` | Changing component bindings, catalog trees, connectors, layout, or locking. |
 | `docs/runbooks/trunk-sync.md` | Running the official trunk sync workflow. |
 | `docs/runbooks/official-artifact-visual-sync.md` | Deciding whether a `design-model.json` is official enough for sync. |
 | `docs/runbooks/visual-sync-efficiency.md` | Executing the smallest safe target set and resuming from checkpoints. |
-| `docs/runbooks/target-scopes.md` | Updating the smallest possible Figma section. |
+| `docs/reference/target-scopes.md` | Updating the smallest possible Figma section. |
 | `docs/runbooks/troubleshooting.md` | Diagnosing broken sync output or metadata mismatches. |

--- a/repo/figma-design-sync/docs/README.md
+++ b/repo/figma-design-sync/docs/README.md
@@ -11,10 +11,10 @@ Use this directory as the module documentation index:
 | `runbooks/official-artifact-visual-sync.md` | Runbook | Validate the TeamCity `main` artifact and decide when branch-local visual iteration may reuse it. |
 | `runbooks/mcp-chunk-transport.md` | Runbook | Build the MCP bundle, stage official payloads through PNG or chunk fallback, run targets, and write metadata. |
 | `runbooks/visual-sync-efficiency.md` | Runbook | Use visual plans, capability gates, checkpoints, and staging reuse to minimize safe MCP work. |
-| `runbooks/target-scopes.md` | Reference | Choose the smallest visual target and Figma section for a sync operation. |
-| `runbooks/dependency-version-naming.md` | Reference | Define the repository version key format enforced by CI and rendered in Figma. |
+| `reference/target-scopes.md` | Reference | Choose the smallest visual target and Figma section for a sync operation. |
+| `standards/dependency-version-naming.md` | Standard | Define the repository version key format enforced by CI and rendered in Figma. |
 | `runbooks/visual-preview.md` | Runbook | Iterate on Figma visual sync behavior with fixtures and sandbox sections without writing official metadata. |
-| `runbooks/visual-sync-contract.md` | Reference | Define the Figma visual contract used by the MCP sync, including catalog trees, connectors, layout, and locking. |
+| `reference/visual-sync-contract.md` | Reference | Define the Figma visual contract used by the MCP sync, including catalog trees, connectors, layout, and locking. |
 | `runbooks/troubleshooting.md` | Runbook | Diagnose failed or visually incorrect Figma sync runs without weakening the metadata contract. |
 | `bdd/README.md` | Reference | Explain executable BDD scenarios and their technical resource map. |
 | `uml/figma-import.md` | Runbook | Render PlantUML SVGs and import them into Figma. Kept under `uml/` so it stays next to diagrams and helper scripts. |

--- a/repo/figma-design-sync/docs/reference/target-scopes.md
+++ b/repo/figma-design-sync/docs/reference/target-scopes.md
@@ -1,8 +1,21 @@
+---
+title: Figma sync target scopes
+type: reference
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/tools/src/config/figma-config.ts
+  - repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+---
+
 # Figma Sync Target Scopes
 
 ## Purpose
 
-Use this runbook to understand the ordered visual targets in the Figma model.
+Use this reference to understand the ordered visual targets in the Figma model.
 TeamCity always generates the complete runner. The official visual plan then
 requires either all targets (`full`), only changed fingerprints plus preflight
 (`partial`), or no write (`none`). Ad hoc granular targets remain reserved for

--- a/repo/figma-design-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/reference/visual-sync-contract.md
@@ -1,9 +1,22 @@
+---
+title: Figma visual sync contract
+type: reference
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/tools/src
+  - repo/figma-design-sync/tools/tests
+---
+
 # Figma Visual Sync Contract
 
 ## Purpose
 
 This document captures the stable visual contract used by the MCP sync tooling.
-The execution flow lives in [trunk-sync.md](trunk-sync.md); this file describes
+The execution flow lives in [trunk-sync.md](../runbooks/trunk-sync.md); this file describes
 what the generated Figma state must look like after the sync.
 
 ## Tooling Boundary
@@ -189,7 +202,7 @@ For each repository version:
 - Name plugin-owned version keys with the `PluginVersion` suffix.
 - `checkFigmaVersionNaming` enforces this naming contract in CI through the
   root Gradle `check` lifecycle. See
-  [dependency-version-naming.md](dependency-version-naming.md).
+  [dependency-version-naming.md](../standards/dependency-version-naming.md).
 - Ensure `Version alias` mode equals the version key.
 - Set `Version number` mode to the repository value.
 - Create a missing Figma variable under the matching section folder.

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -1,3 +1,16 @@
+---
+title: MCP payload transport
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+  - repo/figma-design-sync/tools/scripts/execute-mcp-runner.ts
+---
+
 # MCP Payload Transport Runbook
 
 ## Purpose
@@ -247,10 +260,41 @@ return {
 };
 ```
 
+## Prerequisites
+
+- Use the official `main` artifact and generated runner manifest.
+- Build the TypeScript tools with the repository lockfile.
+- Confirm the local MCP endpoint capabilities before attempting a write.
+
+## Verification
+
+Confirm every planned runner unit is recorded as successful, the visual state
+matches the selected plan, and metadata is written only after all authorized
+visual scopes complete.
+
+## Recovery
+
+Resume from `execution-state.json` when execution identity still matches.
+Regenerate runners when model, writer, transport, or manifest hashes differ.
+Use chunk staging only when PNG upload is unavailable and the endpoint supports
+the required write tools.
+
+## Prohibited Actions
+
+- Do not paste the complete model or compiled writer into chat.
+- Do not write metadata after an ad hoc partial repair.
+- Do not treat an MCP handshake as proof of write capability.
+
+## Sources
+
+- `tools/scripts/write-mcp-runner.ts`
+- `tools/scripts/execute-mcp-runner.ts`
+- `tools/scripts/payload-png.ts`
+
 ## Run The Planned Visual Sync
 
 The official runner contains bounded calls for `preflight` and every visual
-target from [target-scopes.md](target-scopes.md). Apply
+target from [target-scopes.md](../reference/target-scopes.md). Apply
 `visual-sync-plan.json`, then execute every selected `99-*.mcp.js` file in
 lexical order without editing its target or root. Catalog calls are split by
 roots from the official model and finish with stale-node cleanup. All calls use

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -1,3 +1,16 @@
+---
+title: Official artifact visual sync
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - .teamcity/settings.kts
+  - repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+---
+
 # Official Artifact Visual Sync Runbook
 
 ## Purpose
@@ -165,3 +178,33 @@ Important generation details:
   either `generateFigmaDesignModel` or `checkFigmaTrunkSync`.
 - Module dependency graphs are no longer rendered into the deleted Figma
   `dependency of modules` section. They belong in PlantUML architecture docs.
+
+## Prerequisites
+
+- The source revision is merged into `main`.
+- TeamCity generated and published the Figma report for that exact revision.
+- The artifact hashes and visual plan are available together.
+
+## Verification
+
+Verify the artifact revision, model hash, writer hash, transport hash, and
+manifest hash before mutation. After visual execution, rerun the complete Figma
+Sync pipeline and require the aggregate run to succeed.
+
+## Recovery
+
+Discard an artifact whose revision or hashes cannot be proven. If visual
+execution fails, resume only compatible checkpoint units or regenerate the
+official artifact from the authoritative `main` run.
+
+## Prohibited Actions
+
+- Do not publish a locally generated or feature-branch design model.
+- Do not repair metadata to make an incompatible artifact appear current.
+- Do not reuse an artifact after its writer or manifest identity changes.
+
+## Sources
+
+- `.teamcity/settings.kts`
+- `.teamcity/scripts/prepare-figma-sync.ps1`
+- `tools/scripts/write-mcp-runner.ts`

--- a/repo/figma-design-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-design-sync/docs/runbooks/troubleshooting.md
@@ -1,3 +1,16 @@
+---
+title: Figma sync troubleshooting
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/tools/src
+  - repo/figma-design-sync/tools/tests
+---
+
 # Figma Sync Troubleshooting
 
 ## Purpose
@@ -5,7 +18,7 @@
 Use this document when a Figma trunk sync fails or produces visually incorrect
 catalog trees. The normal execution flow lives in
 [trunk-sync.md](trunk-sync.md), and the expected visual state lives in
-[visual-sync-contract.md](visual-sync-contract.md).
+[visual-sync-contract.md](../reference/visual-sync-contract.md).
 
 ## Metadata Safety
 
@@ -437,3 +450,33 @@ successful or failed generated unit in `execution-state.json` as described in
 [visual-sync-efficiency.md](visual-sync-efficiency.md). Re-test the endpoint
 with `mcp:probe` before enabling direct execution; do not infer write support
 from a successful MCP handshake.
+
+## Prerequisites
+
+Capture the failing target, runner file, execution identity, Figma section, and
+the smallest relevant tool response. Do not begin with a new full write when a
+compatible checkpoint exists.
+
+## Verification
+
+Re-run the failed atomic unit, inspect its target section, and confirm the
+result is recorded in `execution-state.json`. Complete the authoritative visual
+plan before metadata verification.
+
+## Recovery
+
+Use the symptom-specific sections above. When completion is unknown, inspect
+the target before retrying. When capability or identity is incompatible,
+regenerate rather than overriding the guard.
+
+## Prohibited Actions
+
+- Do not infer success from a timeout.
+- Do not move connectors or managed nodes to the page as a permanent repair.
+- Do not bypass preflight, capability, hash, or metadata completion checks.
+
+## Sources
+
+- `tools/src/`
+- `tools/tests/`
+- `execution-state.json` generated beside the official runners

--- a/repo/figma-design-sync/docs/runbooks/trunk-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/trunk-sync.md
@@ -1,3 +1,16 @@
+---
+title: Figma trunk sync
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - .teamcity/settings.kts
+  - repo/figma-design-sync/tools/src/app/sync-trunk-design-model.mcp.ts
+---
+
 # Figma Trunk Sync Runbook
 
 ## Purpose
@@ -14,8 +27,8 @@ fine-grained runbooks:
 | [official-artifact-visual-sync.md](official-artifact-visual-sync.md) | Choosing and validating the TeamCity `design-model.json` artifact, and deciding whether branch-local visual iteration is allowed. |
 | [mcp-chunk-transport.md](mcp-chunk-transport.md) | Building the MCP bundle, staging official payloads through PNG or chunk fallback, running targets, and writing metadata. |
 | [visual-sync-efficiency.md](visual-sync-efficiency.md) | Reading the visual plan, probing MCP capabilities, and resuming checkpointed execution without repeating completed work. |
-| [target-scopes.md](target-scopes.md) | Understanding the complete target order and choosing partial diagnostic scopes. |
-| [visual-sync-contract.md](visual-sync-contract.md) | Validating the expected Figma component, connector, layout, and locking behavior. |
+| [target-scopes.md](../reference/target-scopes.md) | Understanding the complete target order and choosing partial diagnostic scopes. |
+| [visual-sync-contract.md](../reference/visual-sync-contract.md) | Validating the expected Figma component, connector, layout, and locking behavior. |
 | [troubleshooting.md](troubleshooting.md) | Diagnosing failed or visually incorrect sync runs. |
 
 ## Ownership
@@ -83,7 +96,7 @@ intentionally non-authoritative and must not write official metadata.
    root and finish with cleanup-only calls. Every visual call uses
    `writeMetadata=false`.
 7. Check every managed Figma section against
-   [visual-sync-contract.md](visual-sync-contract.md).
+   [visual-sync-contract.md](../reference/visual-sync-contract.md).
 8. After all visual targets are correct, run only the `metadata` target with
    `writeMetadata=true`.
 9. Optionally rerun only TeamCity `Check Figma trunk sync`, or run
@@ -210,3 +223,15 @@ After merging changes that affect generated model content, regenerate the model
 from `main` and sync Figma again. Commits that only change traceability
 metadata, CI settings, or unrelated files do not require a Figma sync if
 `modelHash` stays unchanged.
+
+## Prerequisites
+
+- Use a TeamCity Figma Sync run for the exact merged `main` revision.
+- Confirm the CI pipeline succeeded before accepting its generated model.
+- Use a write-capable MCP endpoint and the TeamCity-generated visual plan.
+
+## Prohibited Actions
+
+- Do not generate or publish the official model from a feature branch.
+- Do not write official metadata after an incomplete plan.
+- Do not replace the aggregate post-merge verification with a standalone check.

--- a/repo/figma-design-sync/docs/runbooks/visual-preview.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-preview.md
@@ -1,3 +1,16 @@
+---
+title: Figma visual preview
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/tools/src/app/sync-catalog-tree-preview.mcp.ts
+  - repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+---
+
 # Figma Visual Preview Runbook
 
 ## Purpose
@@ -183,3 +196,27 @@ node dist\write-mcp-runner.mjs --mode=preview --fixture=catalog-tree --target=wa
 
 For repository contract changes that affect the generated model, also run the
 Gradle checks described in [trunk-sync.md](trunk-sync.md).
+
+## Prerequisites
+
+- Use a sandbox Figma section or an explicit preview fixture.
+- Build the TypeScript writer from the current branch.
+- Keep official metadata writes disabled.
+
+## Recovery
+
+Delete temporary preview sections and regenerate the preview runner when its
+fixture or writer changes. A failed preview must not be resumed against an
+official section.
+
+## Prohibited Actions
+
+- Do not point a preview runner at an official section.
+- Do not write `water_my_plants_sync` metadata from preview mode.
+- Do not treat a preview result as authorization for trunk publication.
+
+## Sources
+
+- `tools/src/app/sync-catalog-tree-preview.mcp.ts`
+- `tools/scripts/write-mcp-runner.ts`
+- `tools/tests/`

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-efficiency.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-efficiency.md
@@ -1,3 +1,16 @@
+---
+title: Efficient visual sync
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/tools/scripts/execute-mcp-runner.ts
+  - repo/figma-design-sync/tools/scripts/write-visual-sync-plan.ts
+---
+
 # Efficient Visual Sync Runbook
 
 ## Purpose
@@ -125,3 +138,35 @@ evidence, batching makes retries more expensive and less diagnosable.
 
 These rules reduce repeated context while keeping the official full/partial
 decision and every successful execution unit auditable.
+
+## Prerequisites
+
+- Use the complete TeamCity-generated runner and visual plan.
+- Probe the MCP endpoint and require the capabilities selected by the transport.
+- Keep the matching model, writer, transport, manifest, and checkpoint files
+  together.
+
+## Verification
+
+Confirm the plan decision matches changed fingerprints, each selected runner
+unit has a successful checkpoint, and metadata staging reuses only a complete
+compatible visual state.
+
+## Recovery
+
+Retry only the failed atomic unit when execution identity matches. Regenerate
+the plan and checkpoints after any identity change. Fall back from PNG to
+chunks only for a verified transport limitation.
+
+## Prohibited Actions
+
+- Do not choose `none` or `partial` manually for an official integration.
+- Do not skip hash validation to reuse staging.
+- Do not resend successful runner units merely to rebuild conversational
+  context.
+
+## Sources
+
+- `tools/scripts/execute-mcp-runner.ts`
+- `tools/scripts/write-visual-sync-plan.ts`
+- `tools/scripts/write-mcp-runner.ts`

--- a/repo/figma-design-sync/docs/standards/dependency-version-naming.md
+++ b/repo/figma-design-sync/docs/standards/dependency-version-naming.md
@@ -1,8 +1,21 @@
+---
+title: Dependency version naming
+type: standard
+scope: repository-dependencies
+owner: dependency-catalog
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - repo/dependency-catalog/versions.properties
+  - repo/dependency-catalog/water-my-plants-catalog/src/main/kotlin/com/marmatsan/dependencies/Versions.kt
+---
+
 # Dependency Version Naming
 
 ## Purpose
 
-Use this reference when adding or renaming entries in
+Use this standard when adding or renaming entries in
 `repo/dependency-catalog/versions.properties`.
 
 The names are rendered in the Figma `versions` section, so the file must keep a


### PR DESCRIPTION
## Summary

- define a canonical docs-as-code taxonomy for standards, guides, references, runbooks, ADRs, and README indexes
- add reusable templates, initial Android production standards, development guides, and module documentation entry points
- reclassify Figma sync references and standards out of the runbook directory
- validate document placement, frontmatter, review dates, canonical sources, runbook and ADR sections, and local links in TeamCity
- classify documentation validation tooling as model-neutral so post-merge Figma Sync remains a verified no-op

## Why

Repository tooling documentation was already mixing operational procedures with stable references. Product development will add architecture, API, UI, testing, and accessibility rules, so the project needs one scalable structure before those conventions spread across README files and module-local documents.

## Verification

- pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1
- PowerShell validator, change-impact, and no-op pipeline tests
- .\gradlew.bat check --stacktrace
- documentation coverage for the complete diff
- git diff --check