### PR TITLE
docs(figma-design-sync): use portable MCP executor commands

### DIFF
--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -332,7 +332,7 @@ completed visual checkpoint:
 
 ```powershell
 node dist\write-mcp-runner.mjs --mode=official --model=PATH\TO\design-model.json --target=metadata
-npm run mcp:execute -- --manifest=PATH\TO\metadata\manifest.json --reuse-staging --visual-state=PATH\TO\visual\execution-state.json --dry-run
+node dist/execute-mcp-runner.mjs --manifest=PATH\TO\metadata\manifest.json --reuse-staging --visual-state=PATH\TO\visual\execution-state.json --dry-run
 ```
 
 Do not edit `SYNC_OPTIONS` or manifest identity fields by hand.

--- a/repo/figma-design-sync/docs/runbooks/visual-sync-efficiency.md
+++ b/repo/figma-design-sync/docs/runbooks/visual-sync-efficiency.md
@@ -90,16 +90,16 @@ TeamCity path. Do not bypass either failure with direct REST mutations.
 Inspect a runner without executing it:
 
 ```powershell
-npm run mcp:execute -- --manifest=PATH\TO\manifest.json --dry-run
-npm run mcp:execute -- --manifest=PATH\TO\manifest.json --next
+node dist/execute-mcp-runner.mjs --manifest=PATH\TO\manifest.json --dry-run
+node dist/execute-mcp-runner.mjs --manifest=PATH\TO\manifest.json --next
 ```
 
 When Codex executes a generated file through the supported Figma MCP writer,
 record the result in the same checkpoint used by the deterministic executor:
 
 ```powershell
-npm run mcp:execute -- --manifest=PATH\TO\manifest.json --record-success=99-00-preflight.mcp.js --summary="Preflight passed"
-npm run mcp:execute -- --manifest=PATH\TO\manifest.json --record-failure=99-01-versions.mcp.js --summary="Figma component contract failed"
+node dist/execute-mcp-runner.mjs --manifest=PATH\TO\manifest.json --record-success=99-00-preflight.mcp.js --summary="Preflight passed"
+node dist/execute-mcp-runner.mjs --manifest=PATH\TO\manifest.json --record-failure=99-01-versions.mcp.js --summary="Figma component contract failed"
 ```
 
 Continue from the checkpoint with `--resume`; use `--retry-failed` to select
@@ -110,7 +110,7 @@ For metadata, reuse staging only after the completed visual checkpoint matches
 the metadata runner identity:
 
 ```powershell
-npm run mcp:execute -- --manifest=PATH\TO\metadata\manifest.json --reuse-staging --visual-state=PATH\TO\visual\execution-state.json --dry-run
+node dist/execute-mcp-runner.mjs --manifest=PATH\TO\metadata\manifest.json --reuse-staging --visual-state=PATH\TO\visual\execution-state.json --dry-run
 ```
 
 Never record metadata success before every execution scope selected by the


### PR DESCRIPTION
## Summary

- replace `npm run mcp:execute -- ...` examples with direct `node dist/execute-mcp-runner.mjs ...` invocations
- keep dry-run, checkpoint, resume, and metadata validation arguments unchanged

## Why

The npm wrapper dropped the executor arguments in the verified Windows/npm environment during the official Figma sync. Calling the generated Node executable directly is portable and was used successfully for the complete run 1494 visual checkpoint and metadata write.

## Verification

- documentation validation passed for 26 typed documents
- `git diff --check`
- direct executor commands completed the official Figma sync for `main` artifact 1494

This is documentation-only and must not require another visual Figma write.