### PR TITLE
ci(teamcity): harden continuous integration infrastructure

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -8,6 +8,8 @@ is documented in
 Public HTTPS access, Cloudflare policies, CLI service authentication, webhook
 validation, and CSRF recovery are documented in
 [`docs/runbooks/teamcity-cloudflare-access.md`](../docs/runbooks/teamcity-cloudflare-access.md).
+Backup, off-host artifact retention, and isolated restore drills are documented
+in [`docs/runbooks/teamcity-backup-recovery.md`](../docs/runbooks/teamcity-backup-recovery.md).
 The Windows services that host this configuration are versioned in
 [`docs/ci/windows-runtime.yaml`](../docs/ci/windows-runtime.yaml).
 
@@ -75,6 +77,9 @@ The GitHub ruleset for `main` is documented in
 The pipeline:
 
 - monitors all branches;
+- discovers and validates the Windows agent toolchain and Android SDK before
+  running repository verification, then exports the discovered SDK path only
+  to later steps in the same TeamCity build;
 - validates typed documentation and change coverage before scope classification: canonical
   placement, frontmatter, review dates, runbook and ADR sections, canonical
   sources, and local Markdown links are checked by
@@ -112,6 +117,8 @@ requests.
 The pipeline:
 
 - triggers after `CI` finishes successfully on `<default>`;
+- validates Git, Java, Node, npm, and the discovered Android SDK before model
+  preparation, with metadata verification using the same fail-fast preflight;
 - classifies the merged `main` revision before doing expensive work;
 - for a model-affecting revision, generates `.teamcity/target/generated-configs`
   once and shares it with the verification job;
@@ -185,6 +192,20 @@ allowReuse = false
 This prevents TeamCity from satisfying a branch or pull request pipeline with a
 previously successful job from another branch. The generated design model must
 belong to the same branch revision as the pipeline chain being validated.
+
+### Infrastructure Health
+
+`Infrastructure Health` is a daily, non-gating pipeline scheduled at 06:00 in
+the TeamCity server time zone. It validates the Windows agent toolchain, SDK,
+free disk space, the private TeamCity readiness endpoint, the public HTTPS
+route, and the GitHub App webhook boundary. It publishes machine-readable JSON
+under `build/reports/ci-health` and deliberately does not publish a GitHub
+commit status.
+
+This pipeline cannot report that the TeamCity server, its scheduler, or its
+only agent is completely unavailable because none of its steps would start.
+Use an external availability monitor for the public hostname and Cloudflare
+Tunnel when an independent outage signal is required.
 
 ### Queue And Cache Behaviour
 
@@ -347,6 +368,7 @@ Validate TeamCity settings before pushing:
 
 ```powershell
 .\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate
+pwsh -File .teamcity\scripts\tests\ci-infrastructure-health.tests.ps1
 ```
 
 Generated files are written to:
@@ -369,7 +391,11 @@ For this project, the generated pipeline should:
 - keep `Figma Sync` as a separate default-branch pipeline;
 - set the official Figma design model environment guard only on `Figma Sync`;
 - emit `buildDependencyTrigger` for `Figma Sync`, pointing at `CI`, with
-  `afterSuccessfulBuildOnly=true`.
+  `afterSuccessfulBuildOnly=true`;
+- emit a daily trigger and Windows-agent requirement for
+  `Infrastructure Health`;
+- run the agent-capability preflight before every Gradle or infrastructure
+  health operation.
 
 ## TeamCity CLI
 
@@ -404,6 +430,19 @@ require CSRF:
 ```powershell
 pwsh -File tools/teamcity/invoke-figma-sync-rerun.ps1 -Wait
 ```
+
+Prepare the MCP-operated handoff from the successful `Generate main design
+model` child run before opening any runner file:
+
+```powershell
+pwsh -File tools/teamcity/prepare-figma-sync-handoff.ps1 -BuildId <job-run-id>
+```
+
+The wrapper validates TeamCity job identity, `main`, source-revision
+consistency across the artifact set, model hash, sync decision, and both runner
+manifests. It writes an ignored
+`figma-sync-handoff.json` with `dry-run`, `next`, checkpoint, and rerun commands;
+it does not mutate Figma.
 
 Bind the current checkout to the TeamCity project and default pipeline if the
 local `teamcity.toml` is missing:
@@ -483,6 +522,15 @@ directory when the installed patch version changes:
 env.JAVA_HOME=C\:\\Program Files\\Eclipse Adoptium\\jdk-21.0.11.10-hotspot
 env.GRADLE_USER_HOME=C\:\\TeamCity\\buildAgent\\.gradle
 ```
+
+Do not store a developer-specific Android SDK path in Kotlin DSL. The first
+step of every pipeline calls `test-agent-capabilities.ps1`, which checks
+`ANDROID_HOME`, `ANDROID_SDK_ROOT`, normal profile locations, and installed
+user SDK locations. After validating `build-tools` and `platforms`, it emits
+TeamCity `setParameter` messages for `env.ANDROID_HOME` and
+`env.ANDROID_SDK_ROOT`; subsequent steps therefore use the SDK discovered on
+the selected host. A newly provisioned Windows agent must still install the
+required toolchain before it can pass the preflight.
 
 `NT SERVICE\TCBuildAgent` needs `Modify` on its mutable directories. It also
 needs non-inherited `ReadAndExecute` on `C:\TeamCity` so Java
@@ -572,6 +620,12 @@ cleanup {
     }
 }
 ```
+
+An additional keep rule retains successful default-branch Figma Sync reports
+and generated TeamCity configuration artifacts for 30 days. This preserves the
+official model/runner evidence needed for assisted Figma publication without
+keeping all artifacts longer than the base seven-day policy. Off-host TeamCity
+backup remains a separate operation; cleanup retention is not a backup.
 
 The project also sets:
 

--- a/.teamcity/scripts/test-agent-capabilities.ps1
+++ b/.teamcity/scripts/test-agent-capabilities.ps1
@@ -1,0 +1,155 @@
+[CmdletBinding()]
+param(
+    [string] $AndroidSdkPath,
+    [string[]] $RequiredCommands = @("git", "java", "powershell.exe"),
+    [switch] $RequireNode,
+    [switch] $ExportTeamCityParameters,
+    [string] $ReportPath
+)
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+    $ReportPath = Join-Path $repositoryRoot "build/reports/ci-health/agent-capabilities.json"
+}
+
+$checks = [System.Collections.Generic.List[object]]::new()
+
+function Resolve-AndroidSdkPath {
+    param([string] $ExplicitPath)
+
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    foreach ($candidate in @($ExplicitPath, $env:ANDROID_HOME, $env:ANDROID_SDK_ROOT)) {
+        if (-not [string]::IsNullOrWhiteSpace($candidate) -and -not $candidates.Contains($candidate)) {
+            $candidates.Add($candidate)
+        }
+    }
+
+    foreach ($profileRoot in @($env:LOCALAPPDATA, $env:USERPROFILE)) {
+        if (-not [string]::IsNullOrWhiteSpace($profileRoot)) {
+            $candidate = if ($profileRoot -eq $env:LOCALAPPDATA) {
+                Join-Path $profileRoot "Android/Sdk"
+            }
+            else {
+                Join-Path $profileRoot "AppData/Local/Android/Sdk"
+            }
+            if (-not $candidates.Contains($candidate)) {
+                $candidates.Add($candidate)
+            }
+        }
+    }
+
+    # A Windows service normally uses a service profile rather than the profile
+    # that owns Android Studio. Discover installed user SDKs without encoding a
+    # workstation-specific username in versioned TeamCity settings.
+    if ($runningOnWindows -and (Test-Path -LiteralPath "C:/Users" -PathType Container)) {
+        foreach ($userDirectory in Get-ChildItem -LiteralPath "C:/Users" -Directory -ErrorAction SilentlyContinue) {
+            $candidate = Join-Path $userDirectory.FullName "AppData/Local/Android/Sdk"
+            if (-not $candidates.Contains($candidate)) {
+                $candidates.Add($candidate)
+            }
+        }
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Container) {
+            return [System.IO.Path]::GetFullPath($candidate)
+        }
+    }
+
+    return $null
+}
+
+function ConvertTo-TeamCityServiceMessageValue {
+    param([Parameter(Mandatory)][string] $Value)
+
+    return $Value.Replace("|", "||").Replace("'", "|'").Replace("`n", "|n").Replace("`r", "|r").Replace("[", "|[").Replace("]", "|]")
+}
+
+function Add-CapabilityCheck {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [bool] $Passed,
+
+        [Parameter(Mandatory)]
+        [string] $Detail
+    )
+
+    $checks.Add([pscustomobject]@{
+        name = $Name
+        passed = $Passed
+        detail = $Detail
+    })
+}
+
+$runningOnWindows = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+Add-CapabilityCheck -Name "windows" -Passed $runningOnWindows -Detail ([System.Environment]::OSVersion.VersionString)
+
+$AndroidSdkPath = Resolve-AndroidSdkPath -ExplicitPath $AndroidSdkPath
+
+$commands = [System.Collections.Generic.List[string]]::new()
+foreach ($command in $RequiredCommands) {
+    if (-not [string]::IsNullOrWhiteSpace($command) -and -not $commands.Contains($command)) {
+        $commands.Add($command)
+    }
+}
+if ($RequireNode) {
+    foreach ($command in @("node", "npm")) {
+        if (-not $commands.Contains($command)) {
+            $commands.Add($command)
+        }
+    }
+}
+
+foreach ($command in $commands) {
+    $resolvedCommand = Get-Command $command -ErrorAction SilentlyContinue | Select-Object -First 1
+    Add-CapabilityCheck `
+        -Name "command:$command" `
+        -Passed ($null -ne $resolvedCommand) `
+        -Detail $(if ($null -eq $resolvedCommand) { "Command not found on PATH." } else { $resolvedCommand.Source })
+}
+
+$sdkExists = -not [string]::IsNullOrWhiteSpace($AndroidSdkPath) -and (Test-Path -LiteralPath $AndroidSdkPath -PathType Container)
+Add-CapabilityCheck `
+    -Name "android-sdk" `
+    -Passed $sdkExists `
+    -Detail $(if ($sdkExists) { [System.IO.Path]::GetFullPath($AndroidSdkPath) } else { "ANDROID_HOME does not reference an existing directory." })
+
+if ($sdkExists) {
+    foreach ($directoryName in @("build-tools", "platforms")) {
+        $directory = Join-Path $AndroidSdkPath $directoryName
+        Add-CapabilityCheck `
+            -Name "android-sdk:$directoryName" `
+            -Passed (Test-Path -LiteralPath $directory -PathType Container) `
+            -Detail $directory
+    }
+}
+
+$reportDirectory = Split-Path -Parent $ReportPath
+New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+$report = [pscustomobject]@{
+    schemaVersion = 1
+    generatedAt = [DateTime]::UtcNow.ToString("o")
+    machine = [System.Environment]::MachineName
+    requireNode = [bool] $RequireNode
+    androidSdkPath = $AndroidSdkPath
+    checks = @($checks)
+}
+$report | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $ReportPath -Encoding utf8
+
+$failures = @($checks | Where-Object { -not $_.passed })
+if ($failures.Count -gt 0) {
+    $failureSummary = $failures | ForEach-Object { "$($_.name): $($_.detail)" }
+    throw "Agent capability validation failed:`n$($failureSummary -join "`n")"
+}
+
+if ($ExportTeamCityParameters) {
+    $escapedSdkPath = ConvertTo-TeamCityServiceMessageValue -Value $AndroidSdkPath
+    Write-Host "##teamcity[setParameter name='env.ANDROID_HOME' value='$escapedSdkPath']"
+    Write-Host "##teamcity[setParameter name='env.ANDROID_SDK_ROOT' value='$escapedSdkPath']"
+}
+
+Write-Host "Agent capability validation passed. Report: $ReportPath"

--- a/.teamcity/scripts/test-ci-infrastructure-health.ps1
+++ b/.teamcity/scripts/test-ci-infrastructure-health.ps1
@@ -1,0 +1,138 @@
+[CmdletBinding()]
+param(
+    [string] $TeamCityServerUrl = $env:TEAMCITY_SERVER_URL,
+    [string] $PublicTeamCityUrl = "https://teamcity.marmatsan.dev",
+    [ValidateRange(1, 1024)]
+    [int] $MinimumFreeDiskGb = 10,
+    [string] $ReportPath,
+    [switch] $SkipNetworkProbes
+)
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+if ([string]::IsNullOrWhiteSpace($ReportPath)) {
+    $ReportPath = Join-Path $repositoryRoot "build/reports/ci-health/infrastructure-health.json"
+}
+
+$checks = [System.Collections.Generic.List[object]]::new()
+
+function Add-HealthCheck {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [string] $Status,
+
+        [Parameter(Mandatory)]
+        [string] $Detail
+    )
+
+    $checks.Add([pscustomobject]@{
+        name = $Name
+        status = $Status
+        detail = $Detail
+    })
+}
+
+function Test-HttpBoundary {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [string] $Url,
+
+        [Parameter(Mandatory)]
+        [int[]] $ExpectedStatusCodes
+    )
+
+    $curl = Get-Command "curl.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -eq $curl) {
+        Add-HealthCheck -Name $Name -Status "failed" -Detail "curl.exe is not available on PATH."
+        return
+    }
+
+    try {
+        $statusCodeText = & $curl.Source `
+            --silent `
+            --show-error `
+            --output NUL `
+            --write-out "%{http_code}" `
+            --max-time 20 `
+            $Url
+        if ($LASTEXITCODE -ne 0) {
+            Add-HealthCheck -Name $Name -Status "failed" -Detail "curl.exe exited with code $LASTEXITCODE for $Url."
+            return
+        }
+
+        $statusCode = 0
+        if (-not [int]::TryParse(([string] $statusCodeText).Trim(), [ref] $statusCode)) {
+            Add-HealthCheck -Name $Name -Status "failed" -Detail "Unexpected HTTP status '$statusCodeText' for $Url."
+            return
+        }
+
+        $passed = $ExpectedStatusCodes -contains $statusCode
+        Add-HealthCheck `
+            -Name $Name `
+            -Status $(if ($passed) { "passed" } else { "failed" }) `
+            -Detail "HTTP $statusCode from $Url; expected $($ExpectedStatusCodes -join ', ')."
+    }
+    catch {
+        Add-HealthCheck -Name $Name -Status "failed" -Detail $_.Exception.Message
+    }
+}
+
+$repositoryDriveName = ([System.IO.Path]::GetPathRoot($repositoryRoot)).TrimEnd('\').TrimEnd(':')
+$repositoryDrive = Get-PSDrive -Name $repositoryDriveName -ErrorAction Stop
+$freeDiskGb = [Math]::Round($repositoryDrive.Free / 1GB, 2)
+Add-HealthCheck `
+    -Name "agent-disk-space" `
+    -Status $(if ($freeDiskGb -ge $MinimumFreeDiskGb) { "passed" } else { "failed" }) `
+    -Detail "$freeDiskGb GiB free on $repositoryDriveName`:; minimum is $MinimumFreeDiskGb GiB."
+
+if ($SkipNetworkProbes) {
+    Add-HealthCheck -Name "teamcity-ready" -Status "skipped" -Detail "Network probes were explicitly skipped."
+    Add-HealthCheck -Name "cloudflare-access" -Status "skipped" -Detail "Network probes were explicitly skipped."
+    Add-HealthCheck -Name "github-webhook-route" -Status "skipped" -Detail "Network probes were explicitly skipped."
+}
+else {
+    if ([string]::IsNullOrWhiteSpace($TeamCityServerUrl)) {
+        Add-HealthCheck -Name "teamcity-ready" -Status "failed" -Detail "TEAMCITY_SERVER_URL is not configured."
+    }
+    else {
+        Test-HttpBoundary `
+            -Name "teamcity-ready" `
+            -Url "$($TeamCityServerUrl.TrimEnd('/'))/healthCheck/ready" `
+            -ExpectedStatusCodes @(200)
+    }
+
+    Test-HttpBoundary `
+        -Name "cloudflare-access" `
+        -Url $PublicTeamCityUrl `
+        -ExpectedStatusCodes @(301, 302, 303, 307, 308, 401, 403)
+    Test-HttpBoundary `
+        -Name "github-webhook-route" `
+        -Url "$($PublicTeamCityUrl.TrimEnd('/'))/app/webhooks/githubapp" `
+        -ExpectedStatusCodes @(400)
+}
+
+$reportDirectory = Split-Path -Parent $ReportPath
+New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+$report = [pscustomobject]@{
+    schemaVersion = 1
+    generatedAt = [DateTime]::UtcNow.ToString("o")
+    machine = [System.Environment]::MachineName
+    teamCityServerUrl = $TeamCityServerUrl
+    publicTeamCityUrl = $PublicTeamCityUrl
+    checks = @($checks)
+}
+$report | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $ReportPath -Encoding utf8
+
+$failures = @($checks | Where-Object { $_.status -eq "failed" })
+if ($failures.Count -gt 0) {
+    $failureSummary = $failures | ForEach-Object { "$($_.name): $($_.detail)" }
+    throw "CI infrastructure health validation failed:`n$($failureSummary -join "`n")"
+}
+
+Write-Host "CI infrastructure health validation passed. Report: $ReportPath"

--- a/.teamcity/scripts/tests/ci-infrastructure-health.tests.ps1
+++ b/.teamcity/scripts/tests/ci-infrastructure-health.tests.ps1
@@ -1,0 +1,64 @@
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+$capabilityScript = Join-Path $repositoryRoot ".teamcity/scripts/test-agent-capabilities.ps1"
+$healthScript = Join-Path $repositoryRoot ".teamcity/scripts/test-ci-infrastructure-health.ps1"
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) "water-my-plants-ci-health-tests"
+$sdkRoot = Join-Path $fixtureRoot "android-sdk"
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)]
+        [bool] $Condition,
+
+        [Parameter(Mandatory)]
+        [string] $Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+if (Test-Path -LiteralPath $fixtureRoot) {
+    Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path (Join-Path $sdkRoot "build-tools") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $sdkRoot "platforms") -Force | Out-Null
+
+try {
+    $capabilityReport = Join-Path $fixtureRoot "agent-capabilities.json"
+    & $capabilityScript `
+        -AndroidSdkPath $sdkRoot `
+        -RequiredCommands @("pwsh") `
+        -ReportPath $capabilityReport
+    $capabilities = Get-Content -LiteralPath $capabilityReport -Raw | ConvertFrom-Json
+    Assert-True -Condition (@($capabilities.checks | Where-Object { -not $_.passed }).Count -eq 0) -Message "Expected all fixture agent capabilities to pass."
+
+    $missingCommandFailed = $false
+    try {
+        & $capabilityScript `
+            -AndroidSdkPath $sdkRoot `
+            -RequiredCommands @("water-my-plants-command-that-does-not-exist") `
+            -ReportPath (Join-Path $fixtureRoot "missing-command.json")
+    }
+    catch {
+        $missingCommandFailed = $_.Exception.Message -like "*command:water-my-plants-command-that-does-not-exist*"
+    }
+    Assert-True -Condition $missingCommandFailed -Message "A missing agent command must fail closed."
+
+    $healthReport = Join-Path $fixtureRoot "infrastructure-health.json"
+    & $healthScript `
+        -MinimumFreeDiskGb 1 `
+        -ReportPath $healthReport `
+        -SkipNetworkProbes
+    $health = Get-Content -LiteralPath $healthReport -Raw | ConvertFrom-Json
+    Assert-True -Condition (@($health.checks | Where-Object { $_.status -eq "failed" }).Count -eq 0) -Message "Offline infrastructure health fixture must not fail."
+    Assert-True -Condition (@($health.checks | Where-Object { $_.status -eq "skipped" }).Count -eq 3) -Message "Offline infrastructure health fixture must record three skipped network checks."
+
+    Write-Host "CI infrastructure health tests passed."
+}
+finally {
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+    }
+}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -8,7 +8,6 @@ project {
     vcsRoot(GitHub)
 
     params {
-        param("android.sdk.path", "C:\\Users\\mmate\\AppData\\Local\\Android\\Sdk")
         param("teamcity.activeBuildBranch.age.hours", "0")
         password("figma.file.content.access.token", "credentialsJSON:56b32d27-92ba-4f95-8a34-f4e24067105a")
     }
@@ -20,10 +19,29 @@ project {
             all(days = 30)
             preventDependencyCleanup = false
         }
+        keepRule {
+            id = "KeepOfficialFigmaArtifacts"
+            keepAtLeast = days(30) {
+                since = today()
+            }
+            dataToKeep = artifacts(
+                "+:build/reports/figma-sync/**",
+                "+:.teamcity/target/generated-configs/**"
+            )
+            applyToBuilds {
+                inPersonalBuilds = nonPersonal()
+                inBranches {
+                    branchFilter = patterns("+:<default>")
+                }
+                withStatus = successful()
+            }
+            preserveArtifactsDependencies = true
+        }
     }
 
     pipeline(WaterMyPlantsCi)
     pipeline(WaterMyPlantsFigmaSync)
+    pipeline(WaterMyPlantsInfrastructureHealth)
 }
 
 /**
@@ -52,11 +70,6 @@ object WaterMyPlantsCi : Pipeline({
         })
     }
 
-    params {
-        param("env.ANDROID_HOME", "%android.sdk.path%")
-        param("env.ANDROID_SDK_ROOT", "%android.sdk.path%")
-    }
-
     job {
         id("verify")
         name = "Verify"
@@ -68,9 +81,17 @@ object WaterMyPlantsCi : Pipeline({
 
         steps {
             step(PipelineScriptStep {
+                name = "Validate agent capabilities"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-agent-capabilities.ps1 -ExportTeamCityParameters"""
+            })
+            step(PipelineScriptStep {
                 name = "Verify change scope"
                 scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\invoke-ci-verification.ps1"""
             })
+        }
+
+        requirements {
+            contains("teamcity.agent.jvm.os.name", "Windows")
         }
 
         features {
@@ -109,8 +130,6 @@ object WaterMyPlantsFigmaSync : Pipeline({
     }
 
     params {
-        param("env.ANDROID_HOME", "%android.sdk.path%")
-        param("env.ANDROID_SDK_ROOT", "%android.sdk.path%")
         param("env.FIGMA_FILE_CONTENT_ACCESS_TOKEN", "%figma.file.content.access.token%")
         param("env.FIGMA_DESIGN_SYNC_OFFICIAL", "true")
         param("env.FIGMA_DESIGN_SYNC_BRANCH", "%teamcity.build.branch%")
@@ -127,9 +146,17 @@ object WaterMyPlantsFigmaSync : Pipeline({
 
         steps {
             step(PipelineScriptStep {
+                name = "Validate agent capabilities"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-agent-capabilities.ps1 -RequireNode -ExportTeamCityParameters"""
+            })
+            step(PipelineScriptStep {
                 name = "Prepare Figma Sync"
                 scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\prepare-figma-sync.ps1"""
             })
+        }
+
+        requirements {
+            contains("teamcity.agent.jvm.os.name", "Windows")
         }
 
         outputFiles {
@@ -152,9 +179,17 @@ object WaterMyPlantsFigmaSync : Pipeline({
 
         steps {
             step(PipelineScriptStep {
+                name = "Validate agent capabilities"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-agent-capabilities.ps1 -ExportTeamCityParameters"""
+            })
+            step(PipelineScriptStep {
                 name = "Verify Figma sync metadata"
                 scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\verify-figma-trunk-sync.ps1"""
             })
+        }
+
+        requirements {
+            contains("teamcity.agent.jvm.os.name", "Windows")
         }
 
         features {
@@ -165,6 +200,64 @@ object WaterMyPlantsFigmaSync : Pipeline({
             "figma_sync_generate_design_model",
             listOf("build/reports/figma-sync", ".teamcity/target/generated-configs")
         )
+    }
+})
+
+/**
+ * Scheduled infrastructure health pipeline.
+ *
+ * This pipeline checks the build-agent toolchain and the observable TeamCity
+ * HTTPS boundaries. It is intentionally independent from pull request status
+ * publishing so an infrastructure incident is visible without blocking an
+ * unrelated source change.
+ */
+object WaterMyPlantsInfrastructureHealth : Pipeline({
+    id("WaterMyPlantsInfrastructureHealth")
+    name = "Infrastructure Health"
+
+    repositories {
+        repository(GitHub, enabledByDefault = true)
+    }
+
+    triggers {
+        trigger(PipelineDailyScheduleTrigger {
+            hour = 6
+            minute = 0
+            branchFilter = "+:<default>"
+        })
+    }
+
+    params {
+        param("env.TEAMCITY_SERVER_URL", "%teamcity.serverUrl%")
+    }
+
+    job {
+        id("infrastructure_health")
+        name = "Check infrastructure health"
+        allowReuse = false
+
+        repositories {
+            repository(GitHub)
+        }
+
+        steps {
+            step(PipelineScriptStep {
+                name = "Validate agent capabilities"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-agent-capabilities.ps1 -RequireNode -ExportTeamCityParameters"""
+            })
+            step(PipelineScriptStep {
+                name = "Probe TeamCity boundaries"
+                scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-ci-infrastructure-health.ps1"""
+            })
+        }
+
+        requirements {
+            contains("teamcity.agent.jvm.os.name", "Windows")
+        }
+
+        outputFiles {
+            pipelineArtifacts("build/reports/ci-health")
+        }
     }
 })
 
@@ -314,6 +407,49 @@ open class PipelineFinishBuildTrigger(
     private companion object {
         const val BUILD_TYPE_PARAM = "dependsOn"
         const val SUCCESSFUL_ONLY_PARAM = "afterSuccessfulBuildOnly"
+        const val BRANCH_FILTER_PARAM = "branchFilter"
+    }
+}
+
+/**
+ * Pipeline-compatible daily schedule trigger.
+ *
+ * The current Pipeline DSL exposes only the generic trigger boundary. These
+ * parameters are the versioned TeamCity scheduling trigger contract for a
+ * daily run in the server time zone.
+ */
+open class PipelineDailyScheduleTrigger(
+    init: PipelineDailyScheduleTrigger.() -> Unit = {}
+) : Trigger(), PipelineCompatible {
+    var hour: Int = 0
+        set(value) {
+            require(value in 0..23) { "Schedule hour must be between 0 and 23." }
+            field = value
+            param("hour", value.toString())
+        }
+
+    var minute: Int = 0
+        set(value) {
+            require(value in 0..59) { "Schedule minute must be between 0 and 59." }
+            field = value
+            param("minute", value.toString())
+        }
+
+    var branchFilter: String
+        get() = params.find { it.name == BRANCH_FILTER_PARAM }?.value.orEmpty()
+        set(value) {
+            param(BRANCH_FILTER_PARAM, value)
+        }
+
+    init {
+        type = "schedulingTrigger"
+        param("schedulingPolicy", "daily")
+        param("timezone", "SERVER")
+        param("triggerBuildWithPendingChangesOnly", "false")
+        init()
+    }
+
+    private companion object {
         const val BRANCH_FILTER_PARAM = "branchFilter"
     }
 }

--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -60,13 +60,16 @@ service command line because it can contain the tunnel credential.
 
 ### Overview
 
-The overview contains two distinct journeys:
+The overview contains three distinct journeys:
 
 - Pull request integration: branch push, pull request, CI verification, GitHub
   check, merge gate, and merge to `main`.
 - Post-merge design documentation: successful CI on `main`, Figma Sync model
   generation and verification, the external operator and Codex/MCP write, and
   the verification rerun.
+- Infrastructure health: the daily TeamCity schedule, agent capability and
+  disk checks, HTTPS boundary probes, and the published `ci-health` report.
+  This is an internal scheduled signal, not an independent uptime monitor.
 
 Cloudflare appears as a simplified boundary in the overview. Its policies and
 authentication paths belong in `Infrastructure and Access`.
@@ -171,9 +174,9 @@ in a read session, then queues the complete `Figma Sync` pipeline with a fresh
 cookie-free session, Cloudflare's raw `cf-access-token`, and TeamCity Bearer
 authentication. This avoids forwarding Cloudflare's session cookie into
 TeamCity's CSRF check. The TeamCity UI remains the recovery interface. The
-current temporary transport mechanism used to stage the official artifact for
-MCP is represented as a technical annotation on the handoff connection, not as
-another domain artifact.
+repository-owned handoff downloads and validates the official artifact, then
+selects the next checkpoint unit without writing Figma. It is represented as a
+technical annotation on the handoff connection, not as another domain artifact.
 
 `TeamCity CI` participates in the pull request merge gate. `TeamCity Figma
 Sync` is a post-merge documentation status and must not be represented as a pull

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -6,3 +6,4 @@ remain under that module's `docs/runbooks/` directory.
 | Runbook | Operation |
 |---------|-----------|
 | [TeamCity Cloudflare Access](teamcity-cloudflare-access.md) | Operate TeamCity HTTPS access, service authentication, webhooks, and Windows runtime recovery. |
+| [TeamCity Backup And Recovery](teamcity-backup-recovery.md) | Back up TeamCity server state and artifacts, verify off-host copies, and run isolated restore drills. |

--- a/docs/runbooks/teamcity-backup-recovery.md
+++ b/docs/runbooks/teamcity-backup-recovery.md
@@ -1,0 +1,129 @@
+---
+title: TeamCity backup and recovery
+type: runbook
+scope: repository-ci
+owner: ci-platform
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - .teamcity/settings.kts
+  - docs/ci/windows-runtime.yaml
+  - docs/runbooks/teamcity-cloudflare-access.md
+---
+
+# TeamCity Backup And Recovery Runbook
+
+## Purpose
+
+Use this runbook to create a recoverable TeamCity backup, verify that it has
+left the TeamCity host, or restore the service in an isolated environment. Run
+it before a TeamCity upgrade and at least monthly as an explicit recovery
+exercise.
+
+The target service levels are:
+
+- recovery point objective (RPO): at most 24 hours for TeamCity configuration
+  and database state;
+- recovery time objective (RTO): four hours to restore an isolated server and
+  prove that projects, users, build history, and retained artifacts are usable.
+
+## Prerequisites
+
+- TeamCity system-administrator permission.
+- An encrypted backup destination outside the TeamCity host with enough free
+  space for the backup ZIP and `system/artifacts`.
+- The active TeamCity Data Directory from `Administration > Global Settings`.
+- The TeamCity installation directory containing `bin\maintainDB.cmd`.
+- An isolated Windows host or VM for the quarterly restore drill.
+- A recorded checksum and timestamp for each backup set. Do not store secrets
+  or backup archives in this repository.
+
+## Procedure
+
+1. Confirm `TeamCity`, `TCBuildAgent`, and `Cloudflared` are healthy and record
+   the active TeamCity version and Data Directory.
+2. Daily, from `Administration > Backup`, start a custom online backup containing
+   configuration, database, supplementary data, and personal changes. Build
+   logs are optional because the artifact tree is copied separately.
+3. Wait until `GET /app/rest/server/backup` reports `idle` and confirm a new ZIP
+   exists under `<TeamCity Data Directory>\backup`.
+4. Copy the ZIP and the complete
+   `<TeamCity Data Directory>\system\artifacts` tree to the encrypted off-host
+   destination. TeamCity backup ZIPs do not contain build artifacts.
+5. Copy installation-specific configuration needed to rebuild the origin,
+   including `<TeamCity Home>\conf\server.xml`. Store it beside the backup,
+   never in Git.
+6. Generate SHA-256 checksums at the destination and record the backup time,
+   TeamCity version, database type, Data Directory, artifact-copy completion,
+   and storage retention expiry.
+7. Retain at least seven daily backup sets and three monthly recovery points.
+   Delete an old set only after a newer set has passed checksum verification.
+
+For an upgrade or an exact point-in-time maintenance backup, stop the server
+after draining the queue and use `maintainDB.cmd` so running and queued state is
+not changing during capture:
+
+```powershell
+Stop-Service -Name TeamCity
+& '<TeamCity Home>\bin\maintainDB.cmd' backup -A '<TeamCity Data Directory>'
+Start-Service -Name TeamCity
+```
+
+Replace the angle-bracket placeholders with paths verified from the active
+server. Execute service operations only from an elevated PowerShell session.
+
+## Verification
+
+For every backup set:
+
+1. Recalculate the ZIP and artifact-copy checksums from the off-host location.
+2. Open the ZIP and confirm it contains TeamCity configuration and database
+   content; a file existing with non-zero size is not sufficient proof.
+3. Confirm the artifact copy includes a recently retained
+   `build/reports/figma-sync` artifact.
+
+Once per quarter, restore into a clean isolated Data Directory with the same or
+a newer TeamCity version:
+
+```powershell
+& '<TeamCity Home>\bin\maintainDB.cmd' restore `
+    -A '<New TeamCity Data Directory>' `
+    -F '<Off-host backup ZIP>' `
+    -T '<Target database.properties>'
+```
+
+Copy `system\artifacts` into the new Data Directory before the restored server
+starts. Keep Cloudflare Tunnel disabled on the drill host. Start the isolated
+server and verify login, project configuration, recent build history, one Figma
+artifact download, and one non-mutating DSL generation. Record actual RPO and
+RTO; the drill passes only when both targets are met.
+
+## Recovery
+
+If backup creation fails, preserve the last verified set, correct free-space or
+permission failures, and start a new backup. Never overwrite the only known
+good set.
+
+If restore fails, leave the production server untouched. Create another clean
+Data Directory, correct the database or filesystem issue, and retry. Use
+`maintainDB.cmd restore --continue` only after removing the partially restored
+database object named by TeamCity. If artifacts were copied after first start,
+run TeamCity artifact-metadata reindexing before declaring recovery complete.
+
+## Prohibited Actions
+
+- Do not treat `.teamcity/settings.kts` as a backup of users, credentials,
+  history, database state, plugins, or artifacts.
+- Do not keep the only backup on the TeamCity server disk.
+- Do not restore over the active production Data Directory as a drill.
+- Do not start a restored server before its artifact tree is in place.
+- Do not expose the isolated recovery host through the production tunnel.
+
+## Sources
+
+- [TeamCity data backup](https://www.jetbrains.com/help/teamcity/teamcity-data-backup.html)
+- [Restoring TeamCity data](https://www.jetbrains.com/help/teamcity/restoring-teamcity-data-from-backup.html)
+- `.teamcity/settings.kts`
+- `docs/ci/windows-runtime.yaml`
+- `docs/runbooks/teamcity-cloudflare-access.md`

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -300,6 +300,14 @@ After configuration or recovery:
    pipeline and publish its repository check.
 6. Run the manual validation in
    [`../ci/external-topology-validation.md`](../ci/external-topology-validation.md).
+7. Run `Infrastructure Health` once and inspect
+   `build/reports/ci-health/infrastructure-health.json`. Its scheduled runs
+   validate the observable boundaries daily, but an external monitor is still
+   required to detect that TeamCity itself could not schedule the check.
+
+Server-state and artifact recovery are separate from access recovery. Follow
+[`teamcity-backup-recovery.md`](teamcity-backup-recovery.md) for backup capture
+and isolated restore drills.
 
 ## Secret Rotation
 
@@ -334,3 +342,4 @@ replacement is verified.
 - `.teamcity/settings.kts`
 - `docs/ci/external-topology.yaml`
 - `docs/ci/windows-runtime.yaml`
+- `docs/runbooks/teamcity-backup-recovery.md`

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -9,6 +9,7 @@ review-cycle-days: 90
 sources:
   - .teamcity/settings.kts
   - repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+  - tools/teamcity/prepare-figma-sync-handoff.ps1
 ---
 
 # Official Artifact Visual Sync Runbook
@@ -187,6 +188,40 @@ Important generation details:
 - TeamCity generated and published the Figma report for that exact revision.
 - The artifact hashes and visual plan are available together.
 
+## Assisted Handoff
+
+Use the child run id for `Figma Sync > Generate main design model`. The
+repository wrapper queries that build, requires a successful `main` revision,
+downloads its shared artifact package, selects the Figma report within it, and
+validates the model, scope, visual plan, and both runner manifests before
+showing any MCP work:
+
+```powershell
+pwsh -File tools/teamcity/prepare-figma-sync-handoff.ps1 -BuildId <job-run-id>
+```
+
+Run this command from the normal PowerShell profile used by the TeamCity CLI
+wrapper. That profile injects Cloudflare Service Auth headers without exposing
+their values; `pwsh -NoProfile` cannot reach the protected artifact endpoint.
+
+The result is written below `tmp/teamcity/` as
+`figma-sync-handoff.json`. Use its `nextUnit` and commands to execute one
+Codex-operated Figma MCP unit at a time, then record success or failure through
+the existing checkpoint executor. The wrapper never writes to Figma and never
+records a unit automatically.
+
+When artifacts were downloaded through another authorized route, validate them
+without a second download:
+
+```powershell
+pwsh -File tools/teamcity/prepare-figma-sync-handoff.ps1 `
+    -ArtifactDirectory <downloaded-figma-sync-directory>
+```
+
+After all selected visual units and metadata complete, use the handoff's
+`rerun` command. A successful rerun is the final proof; the local handoff JSON
+is only operator state and must not be committed.
+
 ## Verification
 
 Verify the artifact revision, model hash, writer hash, transport hash, and
@@ -210,3 +245,4 @@ official artifact from the authoritative `main` run.
 - `.teamcity/settings.kts`
 - `.teamcity/scripts/prepare-figma-sync.ps1`
 - `tools/scripts/write-mcp-runner.ts`
+- `tools/teamcity/prepare-figma-sync-handoff.ps1`

--- a/tools/teamcity/FigmaArtifactHandoff.psm1
+++ b/tools/teamcity/FigmaArtifactHandoff.psm1
@@ -1,0 +1,142 @@
+Set-StrictMode -Version Latest
+
+function Get-RequiredJsonProperty {
+    param(
+        [Parameter(Mandatory)][object] $Object,
+        [Parameter(Mandatory)][string] $Name,
+        [Parameter(Mandatory)][string] $Context
+    )
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) {
+        throw "$Context is missing required property '$Name'."
+    }
+    return $property.Value
+}
+
+function Get-SingleArtifactFile {
+    param(
+        [Parameter(Mandatory)][string] $Root,
+        [Parameter(Mandatory)][string] $Filter,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    $files = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Filter $Filter)
+    if ($files.Count -ne 1) {
+        throw "Expected exactly one $Description under '$Root'; found $($files.Count)."
+    }
+    return $files[0]
+}
+
+function Read-ArtifactJson {
+    param([Parameter(Mandatory)][System.IO.FileInfo] $File)
+
+    try {
+        return Get-Content -LiteralPath $File.FullName -Raw | ConvertFrom-Json
+    }
+    catch {
+        throw "Artifact '$($File.FullName)' is not valid JSON: $($_.Exception.Message)"
+    }
+}
+
+function Assert-ArtifactValue {
+    param(
+        [AllowNull()][object] $Actual,
+        [AllowNull()][object] $Expected,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if ([string] $Actual -cne [string] $Expected) {
+        throw "$Description mismatch: expected '$Expected', found '$Actual'."
+    }
+}
+
+function Test-OfficialFigmaArtifactSet {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $ArtifactDirectory,
+        [string] $ExpectedGitSha
+    )
+
+    $root = (Resolve-Path -LiteralPath $ArtifactDirectory).Path
+    $modelFile = Get-SingleArtifactFile -Root $root -Filter "design-model.json" -Description "design model"
+    $scopeFile = Get-SingleArtifactFile -Root $root -Filter "sync-scope.json" -Description "sync scope"
+    $planFile = Get-SingleArtifactFile -Root $root -Filter "visual-sync-plan.json" -Description "visual sync plan"
+
+    $model = Read-ArtifactJson -File $modelFile
+    $scope = Read-ArtifactJson -File $scopeFile
+    $plan = Read-ArtifactJson -File $planFile
+
+    $branch = Get-RequiredJsonProperty -Object $model -Name "branch" -Context "design-model.json"
+    if ($branch -ne "main") {
+        throw "Official Figma artifacts require model branch 'main'; found '$branch'."
+    }
+    $gitSha = Get-RequiredJsonProperty -Object $model -Name "gitSha" -Context "design-model.json"
+    $modelHash = Get-RequiredJsonProperty -Object $model -Name "modelHash" -Context "design-model.json"
+    if ([string]::IsNullOrWhiteSpace([string] $gitSha) -or [string]::IsNullOrWhiteSpace([string] $modelHash)) {
+        throw "design-model.json requires non-empty gitSha and modelHash values."
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ExpectedGitSha)) {
+        Assert-ArtifactValue -Actual $gitSha -Expected $ExpectedGitSha -Description "TeamCity revision"
+    }
+
+    Assert-ArtifactValue `
+        -Actual (Get-RequiredJsonProperty -Object $scope -Name "scope" -Context "sync-scope.json") `
+        -Expected "full-verification" `
+        -Description "Figma change scope"
+    Assert-ArtifactValue -Actual $scope.gitSha -Expected $gitSha -Description "Scope gitSha"
+    Assert-ArtifactValue -Actual $scope.modelHash -Expected $modelHash -Description "Scope modelHash"
+
+    $manifestFiles = @(Get-ChildItem -LiteralPath $root -Recurse -File -Filter "manifest.json")
+    $manifestEntries = @($manifestFiles | ForEach-Object {
+        [pscustomobject]@{ File = $_; Data = (Read-ArtifactJson -File $_) }
+    })
+    $visualEntries = @($manifestEntries | Where-Object { $_.Data.fullVisualSync -eq $true })
+    $metadataEntries = @($manifestEntries | Where-Object { $_.Data.writeMetadata -eq $true })
+    if ($visualEntries.Count -ne 1 -or $metadataEntries.Count -ne 1) {
+        throw "Expected one full visual and one metadata manifest; found $($visualEntries.Count) visual and $($metadataEntries.Count) metadata."
+    }
+
+    $visual = $visualEntries[0].Data
+    $metadata = $metadataEntries[0].Data
+    foreach ($entry in @(
+        @{ Name = "visual"; Data = $visual },
+        @{ Name = "metadata"; Data = $metadata }
+    )) {
+        Assert-ArtifactValue -Actual $entry.Data.mode -Expected "official" -Description "$($entry.Name) manifest mode"
+        Assert-ArtifactValue -Actual $entry.Data.gitSha -Expected $gitSha -Description "$($entry.Name) manifest gitSha"
+        Assert-ArtifactValue -Actual $entry.Data.modelHash -Expected $modelHash -Description "$($entry.Name) manifest modelHash"
+        [void] (Get-RequiredJsonProperty -Object $entry.Data -Name "manifestHash" -Context "$($entry.Name) manifest")
+    }
+    Assert-ArtifactValue -Actual $visual.writeMetadata -Expected $false -Description "Visual manifest metadata flag"
+    Assert-ArtifactValue -Actual $metadata.writeMetadata -Expected $true -Description "Metadata manifest metadata flag"
+    foreach ($identityName in @("writerHash", "transportHash")) {
+        $visualIdentity = Get-RequiredJsonProperty -Object $visual -Name $identityName -Context "visual manifest"
+        Assert-ArtifactValue -Actual $metadata.$identityName -Expected $visualIdentity -Description "Metadata manifest $identityName"
+        Assert-ArtifactValue -Actual $scope.$identityName -Expected $visualIdentity -Description "Scope $identityName"
+        Assert-ArtifactValue -Actual $plan.identity.$identityName -Expected $visualIdentity -Description "Visual plan $identityName"
+    }
+    Assert-ArtifactValue -Actual $plan.identity.modelHash -Expected $modelHash -Description "Visual plan modelHash"
+    Assert-ArtifactValue -Actual $plan.manifestHash -Expected $visual.manifestHash -Description "Visual plan manifestHash"
+    Assert-ArtifactValue -Actual $scope.visualRunnerManifestHash -Expected $visual.manifestHash -Description "Scope visual manifestHash"
+    Assert-ArtifactValue -Actual $scope.metadataRunnerManifestHash -Expected $metadata.manifestHash -Description "Scope metadata manifestHash"
+    Assert-ArtifactValue -Actual $scope.visualSyncDecision -Expected $plan.decision -Description "Scope visual decision"
+    if ($plan.decision -notin @("none", "partial", "full")) {
+        throw "Unsupported visual sync decision '$($plan.decision)'."
+    }
+
+    return [pscustomobject]@{
+        ArtifactDirectory = $root
+        GitSha = [string] $gitSha
+        ModelHash = [string] $modelHash
+        Decision = [string] $plan.decision
+        ModelPath = $modelFile.FullName
+        ScopePath = $scopeFile.FullName
+        PlanPath = $planFile.FullName
+        VisualManifestPath = $visualEntries[0].File.FullName
+        MetadataManifestPath = $metadataEntries[0].File.FullName
+        VisualStatePath = Join-Path $visualEntries[0].File.DirectoryName "execution-state.json"
+    }
+}
+
+Export-ModuleMember -Function Test-OfficialFigmaArtifactSet

--- a/tools/teamcity/prepare-figma-sync-handoff.ps1
+++ b/tools/teamcity/prepare-figma-sync-handoff.ps1
@@ -1,0 +1,122 @@
+[CmdletBinding(DefaultParameterSetName = "Download")]
+param(
+    [Parameter(Mandatory, ParameterSetName = "Download")]
+    [ValidateRange(1, [long]::MaxValue)]
+    [long] $BuildId,
+
+    [Parameter(Mandatory, ParameterSetName = "Existing")]
+    [string] $ArtifactDirectory,
+
+    [string] $DestinationRoot,
+    [switch] $SkipExecutorBuild
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+Import-Module (Join-Path $PSScriptRoot "FigmaArtifactHandoff.psm1") -Force
+$expectedGitSha = $null
+
+if ($PSCmdlet.ParameterSetName -eq "Download") {
+    if ($null -eq (Get-Command teamcity -ErrorAction SilentlyContinue)) {
+        throw "TeamCity CLI is required to download an official artifact."
+    }
+
+    $buildJson = (& teamcity --no-color --no-input run view $BuildId --json) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not read TeamCity build $BuildId. Verify CLI authentication and Cloudflare access."
+    }
+    $build = $buildJson | ConvertFrom-Json
+    if ($build.state -ne "finished" -or $build.status -ne "SUCCESS") {
+        throw "Build $BuildId must be finished and successful; found state '$($build.state)' and status '$($build.status)'."
+    }
+    if ($build.branchName -notin @("main", "<default>", "refs/heads/main")) {
+        throw "Build $BuildId is not from main; found branch '$($build.branchName)'."
+    }
+    if ([string] $build.buildType.name -notlike "*Generate main design model*") {
+        throw "Build $BuildId is '$($build.buildType.name)', not the Generate main design model job."
+    }
+    if ([string]::IsNullOrWhiteSpace($DestinationRoot)) {
+        $DestinationRoot = Join-Path $repositoryRoot "tmp/teamcity"
+    }
+    $downloadDirectory = Join-Path $DestinationRoot "figma-sync-$BuildId-$([DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss'))"
+    New-Item -ItemType Directory -Path $downloadDirectory -Force | Out-Null
+    & teamcity --no-color --no-input run download $BuildId --output $downloadDirectory
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not download Figma Sync artifacts from TeamCity build $BuildId."
+    }
+    $sharedArchives = @(Get-ChildItem -LiteralPath $downloadDirectory -Recurse -File -Filter ".shared_files.zip")
+    $downloadedModels = @(Get-ChildItem -LiteralPath $downloadDirectory -Recurse -File -Filter "design-model.json")
+    if ($downloadedModels.Count -eq 0 -and $sharedArchives.Count -eq 1) {
+        $expandedDirectory = Join-Path $downloadDirectory "shared-files"
+        Expand-Archive -LiteralPath $sharedArchives[0].FullName -DestinationPath $expandedDirectory
+    }
+    elseif ($sharedArchives.Count -gt 1) {
+        throw "Build $BuildId returned more than one .shared_files.zip artifact."
+    }
+    $ArtifactDirectory = $downloadDirectory
+}
+
+$handoff = Test-OfficialFigmaArtifactSet `
+    -ArtifactDirectory $ArtifactDirectory `
+    -ExpectedGitSha $expectedGitSha
+
+$toolsDirectory = Join-Path $repositoryRoot "repo/figma-design-sync/tools"
+$executor = Join-Path $toolsDirectory "dist/execute-mcp-runner.mjs"
+if (-not $SkipExecutorBuild) {
+    Push-Location $toolsDirectory
+    try {
+        & npm.cmd ci
+        if ($LASTEXITCODE -ne 0) { throw "npm ci failed while preparing the Figma handoff." }
+        & npm.cmd run build
+        if ($LASTEXITCODE -ne 0) { throw "Figma sync tool build failed while preparing the handoff." }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$dryRun = $null
+$nextUnit = $null
+if (Test-Path -LiteralPath $executor -PathType Leaf) {
+    $dryRun = (& node $executor `
+        "--manifest=$($handoff.VisualManifestPath)" `
+        "--plan=$($handoff.PlanPath)" `
+        --dry-run) -join "`n"
+    if ($LASTEXITCODE -ne 0) { throw "The official visual manifest failed executor dry-run validation." }
+    $nextUnit = (& node $executor `
+        "--manifest=$($handoff.VisualManifestPath)" `
+        "--plan=$($handoff.PlanPath)" `
+        --next) -join "`n"
+    if ($LASTEXITCODE -ne 0) { throw "The official visual manifest failed next-unit selection." }
+}
+elseif (-not $SkipExecutorBuild) {
+    throw "Missing built Figma executor: $executor"
+}
+
+$commandPrefix = "node `"$executor`" --manifest=`"$($handoff.VisualManifestPath)`" --plan=`"$($handoff.PlanPath)`""
+$summary = [pscustomobject]@{
+    schemaVersion = 1
+    preparedAt = [DateTime]::UtcNow.ToString("o")
+    teamCityBuildId = $(if ($PSCmdlet.ParameterSetName -eq "Download") { $BuildId } else { $null })
+    gitSha = $handoff.GitSha
+    modelHash = $handoff.ModelHash
+    decision = $handoff.Decision
+    nextUnit = $nextUnit
+    artifactDirectory = $handoff.ArtifactDirectory
+    visualManifest = $handoff.VisualManifestPath
+    metadataManifest = $handoff.MetadataManifestPath
+    plan = $handoff.PlanPath
+    dryRun = $dryRun
+    commands = [pscustomobject]@{
+        inspect = "$commandPrefix --dry-run"
+        next = "$commandPrefix --next"
+        recordSuccess = "$commandPrefix --record-success=`"RUNNER_FILE.mcp.js`" --summary=`"SHORT_RESULT`""
+        recordFailure = "$commandPrefix --record-failure=`"RUNNER_FILE.mcp.js`" --summary=`"SHORT_ERROR`""
+        rerun = "pwsh -File tools/teamcity/invoke-figma-sync-rerun.ps1 -Wait"
+    }
+}
+$summaryPath = Join-Path $handoff.ArtifactDirectory "figma-sync-handoff.json"
+$summary | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+$summary
+Write-Host "Figma Sync handoff prepared: $summaryPath"

--- a/tools/teamcity/tests/test-figma-artifact-handoff.ps1
+++ b/tools/teamcity/tests/test-figma-artifact-handoff.ps1
@@ -1,0 +1,66 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Import-Module (Join-Path $PSScriptRoot "../FigmaArtifactHandoff.psm1") -Force
+
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) "water-my-plants-figma-handoff-tests-$([Guid]::NewGuid())"
+$visualDirectory = Join-Path $fixtureRoot "mcp-runners/visual"
+$metadataDirectory = Join-Path $fixtureRoot "mcp-runners/metadata"
+New-Item -ItemType Directory -Path $visualDirectory -Force | Out-Null
+New-Item -ItemType Directory -Path $metadataDirectory -Force | Out-Null
+
+function Write-TestJson {
+    param([Parameter(Mandatory)][string] $Path, [Parameter(Mandatory)][object] $Value)
+    $Value | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+try {
+    Write-TestJson (Join-Path $fixtureRoot "design-model.json") ([pscustomobject]@{
+        branch = "main"; gitSha = "abc123"; modelHash = "model-hash"; content = [pscustomobject]@{}
+    })
+    Write-TestJson (Join-Path $fixtureRoot "sync-scope.json") ([pscustomobject]@{
+        scope = "full-verification"; gitSha = "abc123"; modelHash = "model-hash"
+        writerHash = "writer-hash"; transportHash = "transport-hash"
+        visualRunnerManifestHash = "visual-hash"; metadataRunnerManifestHash = "metadata-hash"
+        visualSyncDecision = "partial"
+    })
+    Write-TestJson (Join-Path $fixtureRoot "visual-sync-plan.json") ([pscustomobject]@{
+        decision = "partial"; manifestHash = "visual-hash"; executionScopes = @("preflight")
+        identity = [pscustomobject]@{ modelHash = "model-hash"; writerHash = "writer-hash"; transportHash = "transport-hash" }
+    })
+    Write-TestJson (Join-Path $visualDirectory "manifest.json") ([pscustomobject]@{
+        mode = "official"; gitSha = "abc123"; modelHash = "model-hash"; manifestHash = "visual-hash"
+        writerHash = "writer-hash"; transportHash = "transport-hash"
+        fullVisualSync = $true; writeMetadata = $false
+    })
+    Write-TestJson (Join-Path $metadataDirectory "manifest.json") ([pscustomobject]@{
+        mode = "official"; gitSha = "abc123"; modelHash = "model-hash"; manifestHash = "metadata-hash"
+        writerHash = "writer-hash"; transportHash = "transport-hash"
+        fullVisualSync = $false; writeMetadata = $true
+    })
+
+    $result = Test-OfficialFigmaArtifactSet -ArtifactDirectory $fixtureRoot -ExpectedGitSha "abc123"
+    if ($result.Decision -ne "partial" -or $result.ModelHash -ne "model-hash") {
+        throw "Valid official artifact fixture did not produce the expected handoff."
+    }
+
+    $invalidModel = Get-Content -LiteralPath (Join-Path $fixtureRoot "design-model.json") -Raw | ConvertFrom-Json
+    $invalidModel.branch = "feature/not-main"
+    Write-TestJson (Join-Path $fixtureRoot "design-model.json") $invalidModel
+    $rejected = $false
+    try {
+        Test-OfficialFigmaArtifactSet -ArtifactDirectory $fixtureRoot | Out-Null
+    }
+    catch {
+        $rejected = $_.Exception.Message -like "*require model branch 'main'*"
+    }
+    if (-not $rejected) {
+        throw "A branch-local design model must be rejected."
+    }
+
+    Write-Host "Figma artifact handoff tests passed."
+}
+finally {
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary

- replace the workstation-specific Android SDK parameter with a fail-fast agent capability preflight that discovers and exports the validated SDK for later TeamCity steps
- add a daily non-gating Infrastructure Health pipeline, live boundary probes, selective 30-day retention for official Figma evidence, and a backup/isolated-recovery runbook
- add a validated TeamCity artifact handoff that checks the official Figma model, scope, plan, and runner identities before exposing checkpoint commands to the supported MCP operator
- update the canonical TeamCity, CI visual-model, Cloudflare, recovery, and Figma operation documentation

## Why

The current CI infrastructure depended on a developer-specific SDK path, had no scheduled in-pipeline health signal, retained official Figma evidence only through the generic cleanup window, and required manual artifact selection for MCP-operated Figma publication.

This change makes those boundaries explicit and executable while preserving the supported contract: TeamCity prepares and verifies official artifacts, and Figma mutation remains outside TeamCity under the MCP operator.

## Impact

- Pull request branch protection still requires only `TeamCity CI`.
- `Infrastructure Health` runs daily at 06:00 server time and does not publish a GitHub commit status.
- Existing CI and Figma jobs fail early when their Windows/Java/Node/Android toolchain is incomplete.
- Successful default-branch Figma reports and generated TeamCity settings are retained for 30 days.
- After merge, TeamCity must reload versioned settings before the new schedule and retention policy are active.

External operations remain intentionally separate: provisioning a second agent, selecting an encrypted off-host backup destination, and configuring an uptime monitor that remains available when TeamCity itself is down.

## Validation

- `.\gradlew.bat check --stacktrace`
- `npm test` in `repo/figma-design-sync/tools` — 103 tests passed
- `.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate`
- `teamcity project settings validate .teamcity --verbose`
- `pwsh -NoProfile -File .teamcity/scripts/tests/validate-documentation.tests.ps1`
- `pwsh -NoProfile -File .teamcity/scripts/tests/figma-change-impact-task.tests.ps1`
- `pwsh -NoProfile -File .teamcity/scripts/tests/ci-infrastructure-health.tests.ps1`
- `pwsh -NoProfile -File tools/teamcity/tests/test-teamcity-https-client.ps1`
- `pwsh -NoProfile -File tools/teamcity/tests/test-figma-artifact-handoff.ps1`
- documentation validation with `-FailOnCoverageGap` — 27 typed documents passed
- live health probes: TeamCity readiness 200, Cloudflare Access 302, webhook boundary 400
- official Figma build 1514 handoff: revision `b59e2b3`, plan `none`, next unit `COMPLETE`
