### PR TITLE
fix(figma-design-sync): support scheduled TeamCity triggers

### DIFF
--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -61,7 +61,7 @@ The model is generated from repository source files, not from Figma:
 | Gradle build files | Module dependency edges and applied plugin usage. |
 | `docs/ci/external-topology.yaml` | Versioned external systems, access boundaries, and directed connections. |
 | `docs/ci/windows-runtime.yaml` | Versioned Windows services, startup modes, and service identities for the local CI runtime. |
-| `.teamcity/target/generated-configs` | Effective pipelines, jobs, triggers, artifacts, checks, and VCS roots generated from `.teamcity/settings.kts`. |
+| `.teamcity/target/generated-configs` | Effective pipelines, jobs, VCS, pipeline-finish and scheduled triggers, artifacts, checks, and VCS roots generated from `.teamcity/settings.kts`. |
 | `repo/figma-design-sync/change-impact-policy.json` | Path policy used to classify whether a change can affect the model or visual writer. |
 
 The default included-build sources are configured by the `figmaDesignSync`

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReader.kt
@@ -95,6 +95,13 @@ class TeamCityGeneratedConfigurationReader {
                     afterSuccessfulBuildOnly = parameters[AFTER_SUCCESS_PARAMETER]?.toBooleanStrict()
                 )
 
+                SCHEDULING_TRIGGER_TYPE -> TeamCityTrigger(
+                    type = TeamCityTrigger.Type.Schedule,
+                    branchFilter = parameters[BRANCH_FILTER_PARAMETER],
+                    dependencyPipelineId = null,
+                    afterSuccessfulBuildOnly = null
+                )
+
                 else -> error("Unsupported TeamCity trigger type '$type'")
             }
         }
@@ -244,6 +251,7 @@ class TeamCityGeneratedConfigurationReader {
         const val TYPE_ATTRIBUTE = "type"
         const val VCS_TRIGGER_TYPE = "vcsTrigger"
         const val BUILD_DEPENDENCY_TRIGGER_TYPE = "buildDependencyTrigger"
+        const val SCHEDULING_TRIGGER_TYPE = "schedulingTrigger"
         const val BRANCH_FILTER_PARAMETER = "branchFilter"
         const val DEPENDS_ON_PARAMETER = "dependsOn"
         const val AFTER_SUCCESS_PARAMETER = "afterSuccessfulBuildOnly"

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/teamcity/configuration/TeamCityGeneratedConfigurationReaderTest.kt
@@ -58,6 +58,14 @@ internal class TeamCityGeneratedConfigurationReaderTest : FunSpec({
                       <param name="branchFilter" value="+:*" />
                     </parameters>
                   </build-trigger>
+                  <build-trigger id="TRIGGER_2" type="schedulingTrigger">
+                    <parameters>
+                      <param name="branchFilter" value="+:&lt;default&gt;" />
+                      <param name="hour" value="6" />
+                      <param name="minute" value="0" />
+                      <param name="schedulingPolicy" value="daily" />
+                    </parameters>
+                  </build-trigger>
                 </build-triggers>
               </settings>
             </build-type>
@@ -72,9 +80,15 @@ internal class TeamCityGeneratedConfigurationReaderTest : FunSpec({
         val actualPipeline = configuration.pipelines.single()
         actualPipeline.id shouldBe "Root_Ci"
         actualPipeline.name shouldBe "CI"
-        actualPipeline.triggers.single() shouldBe TeamCityTrigger(
+        actualPipeline.triggers[0] shouldBe TeamCityTrigger(
             type = TeamCityTrigger.Type.Vcs,
             branchFilter = "+:*",
+            dependencyPipelineId = null,
+            afterSuccessfulBuildOnly = null
+        )
+        actualPipeline.triggers[1] shouldBe TeamCityTrigger(
+            type = TeamCityTrigger.Type.Schedule,
+            branchFilter = "+:<default>",
             dependencyPipelineId = null,
             afterSuccessfulBuildOnly = null
         )

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityTrigger.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/ci/TeamCityTrigger.kt
@@ -11,6 +11,7 @@ data class TeamCityTrigger(
 ) {
     enum class Type(val serializedName: String) {
         Vcs("vcs"),
-        PipelineFinish("pipeline finish")
+        PipelineFinish("pipeline finish"),
+        Schedule("schedule")
     }
 }


### PR DESCRIPTION
## Summary

- add `schedule` to the typed TeamCity trigger model
- parse generated `schedulingTrigger` entries without rejecting the effective configuration
- cover the daily scheduled-trigger XML shape introduced by Infrastructure Health

## Root cause

PR #64 added the scheduled `Infrastructure Health` pipeline. The effective TeamCity XML therefore contains `type="schedulingTrigger"`, but `TeamCityGeneratedConfigurationReader` only accepted VCS and pipeline-finish triggers. Official `generateFigmaDesignModel` failed closed on `main` with `Unsupported TeamCity trigger type 'schedulingTrigger'`.

## Impact

Figma Sync can consume the effective TeamCity configuration again. Existing VCS and pipeline-finish trigger behavior is unchanged.

## Validation

- `.\gradlew.bat :figma-design-sync:data:test :figma-design-sync:plugin:test --stacktrace`
- `.\gradlew.bat check --stacktrace` with the local Android SDK configured
- reproduced the original failure in TeamCity Figma Sync run 1530 / child run 1532