### PR TITLE
fix(ci): restore Figma portability documentation coverage

### DIFF
--- a/repo/figma-design-sync/project-config/README.md
+++ b/repo/figma-design-sync/project-config/README.md
@@ -50,6 +50,13 @@ files, or materialization command; its generated model simply omits
 `content.ci`. Water My Plants enables the flag and supplies those inputs from
 its Kotlin adapter.
 
+This portability boundary is executable. The Gradle integration suite applies
+the reusable plugin with its default CI setting, removes both `docs/ci` and
+`.teamcity` from the fixture, generates the design model, and verifies that the
+portable content is present while `content.ci` is absent. Production source and
+KDoc outside `project-config` describe the host repository through adapter
+contracts rather than Water My Plants paths or identities.
+
 The TypeScript selection boundary is the
 `@figma-design-sync/project-config` path in `tools/tsconfig.json`. Point that
 alias at the new repository's config module. TypeScript remains necessary only


### PR DESCRIPTION
## Summary

- document the executable CI-free generation contract in `project-config/README.md`
- restore the documentation coverage required for the final portability-review commit

## Root cause

PR #69 was merged by rebase. The post-merge validator evaluates `HEAD^..HEAD` on `main`, so it saw the final implementation/test commit without the documentation changed by earlier commits in the same PR. TeamCity build `1563` therefore failed the `figma-sync-implementation` coverage rule.

This PR is intentionally one documentation commit and will be squash-merged so the post-merge scope remains atomic.

## Impact

No production behavior changes. The README now records the TestKit guarantee that the portable plugin works without TeamCity, `docs/ci`, `.teamcity`, or `content.ci`.

## Verification

- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1 -FailOnCoverageGap`
- `git diff --check origin/main...HEAD`
