### PR TITLE
feat(figma-design-sync): prepare portable publication

### DIFF
--- a/.teamcity/documentation-coverage.json
+++ b/.teamcity/documentation-coverage.json
@@ -39,12 +39,15 @@
       "id": "figma-sync-implementation",
       "sourcePaths": [
         "repo/figma-design-sync/tools/*",
+        "repo/figma-design-sync/tools/bin/*",
         "repo/figma-design-sync/data/src/*",
         "repo/figma-design-sync/domain/src/*",
         "repo/figma-design-sync/plugin/src/*",
         "repo/figma-design-sync/teamcity-adapter/src/*",
         "repo/figma-design-sync/project-config/src/*",
         "repo/figma-design-sync/project-config/water-my-plants/*",
+        "repo/figma-design-sync/samples/*",
+        "repo/figma-design-sync/gradle.properties",
         "repo/figma-design-sync/*/build.gradle.kts",
         "repo/figma-design-sync/settings.gradle.kts"
       ],
@@ -52,6 +55,7 @@
         "repo/figma-design-sync/README.md",
         "repo/figma-design-sync/project-config/README.md",
         "repo/figma-design-sync/teamcity-adapter/README.md",
+        "repo/figma-design-sync/docs/guides/*.md",
         "repo/figma-design-sync/docs/runbooks/*.md",
         "repo/figma-design-sync/docs/reference/*.md",
         "repo/figma-design-sync/docs/standards/*.md"

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -7,3 +7,4 @@ ADRs explain durable project decisions and their tradeoffs. Use
 | ADR | Status | Decision |
 |-----|--------|----------|
 | [ADR-0001](adr-0001-documentation-system.md) | Accepted | Use typed docs-as-code with CI validation. |
+| [ADR-0002](adr-0002-distribute-figma-design-sync-as-gradle-plugin.md) | Accepted | Expose one versioned Gradle plugin while retaining internal modules and optional adapters. |

--- a/docs/decisions/adr-0002-distribute-figma-design-sync-as-gradle-plugin.md
+++ b/docs/decisions/adr-0002-distribute-figma-design-sync-as-gradle-plugin.md
@@ -1,0 +1,78 @@
+---
+title: Distribute Figma Design Sync as a Gradle plugin
+type: adr
+scope: repository
+owner: figma-design-sync
+status: accepted
+last-reviewed: 2026-07-18
+review-cycle-days: 365
+sources:
+  - repo/figma-design-sync/build.gradle.kts
+  - repo/figma-design-sync/plugin/build.gradle.kts
+  - repo/figma-design-sync/tools/package.json
+  - repo/figma-design-sync/project-config/README.md
+---
+
+# ADR-0002: Distribute Figma Design Sync as a Gradle Plugin
+
+## Context
+
+Figma Design Sync is internally separated into domain, data, Gradle plugin,
+TypeScript writer, optional CI adapter, and Water My Plants project
+configuration. Consuming the source as an included build preserves those
+boundaries but forces every repository to know the implementation layout.
+
+The distribution must keep the Kotlin-first architecture, avoid copying
+PowerShell orchestration, keep repository identities outside the engine, and
+allow CI systems other than TeamCity.
+
+## Decision
+
+Publish `com.marmatsan.figmaDesignSync` as the single public Gradle entry point.
+Keep domain and data as transitive Maven implementation artifacts rather than
+flattening the source modules. Publish `catalog-core` as their reusable
+supporting API and publish `teamcity-adapter` separately as an optional
+artifact.
+
+Publish the portable TypeScript writer as
+`@marmatsan/figma-design-sync-tools`. Its build executable accepts a
+repository-owned `figma-config.ts` and materializes a configured workspace.
+The Water My Plants `project-config` remains source owned by this repository
+and is not part of the portable release.
+
+Use one version for the Maven artifacts, Gradle plugin marker, supporting
+catalog API, and TypeScript package. Prove each staged release from a standalone
+consumer that has no included-build dependency on the source tree.
+
+No external package repository is selected by this ADR. The build supports a
+workspace staging repository and a configurable Maven URL; credentials,
+signing, registry ownership, and the first public version require explicit
+release authorization.
+
+## Consequences
+
+- Consumers see one Gradle plugin instead of the implementation modules.
+- Internal Clean Architecture boundaries and focused tests remain intact.
+- TeamCity remains optional and does not enter the portable plugin classpath.
+- A release contains coordinated Maven and npm artifacts.
+- The release process must publish transitive artifacts in dependency order.
+- Project adapters remain small repository-owned Gradle plugins and TypeScript
+  configuration modules.
+- A separate decision may select Maven Central, the Gradle Plugin Portal,
+  GitHub Packages, or another registry and its signing policy.
+
+## Alternatives
+
+- Publish one shaded JAR. Rejected because it hides dependency boundaries,
+  complicates Gradle plugin metadata, and would bundle the optional TeamCity
+  adapter or require additional shading variants.
+- Merge all Kotlin modules. Rejected because distribution convenience should
+  not remove the dependency rules already enforced by the architecture.
+- Continue requiring `includeBuild`. Retained for repository development but
+  rejected as the public consumption contract.
+- Publish `project-config` as part of the engine. Rejected because it would
+  reintroduce Water My Plants paths, Figma ids, catalogs, and CI assumptions.
+
+## Supersession
+
+None.

--- a/repo/dependency-catalog/README.md
+++ b/repo/dependency-catalog/README.md
@@ -17,7 +17,10 @@ water-my-plants-catalog -> catalog-core
 ```
 
 The included-build root is an organizational parent and does not publish a
-compatibility artifact.
+compatibility artifact. `:catalog-core` does publish the supporting
+`com.marmatsan.repo:catalog-core:<version>` artifact required by a distributed
+Figma Design Sync plugin. The concrete Water My Plants catalog remains source
+owned and is not part of the portable release.
 
 ## Public Contract
 
@@ -50,8 +53,15 @@ Repository-specific consumers declare both stable coordinates only when they
 need the concrete facade:
 
 ```kotlin
-implementation("com.marmatsan.repo:catalog-core")
+implementation("com.marmatsan.repo:catalog-core:<version>")
 implementation("com.marmatsan.repo:water-my-plants-catalog")
+```
+
+Stage and verify `catalog-core` through the owning Figma Design Sync
+distribution task:
+
+```powershell
+.\gradlew.bat :figma-design-sync:verifyStagedPublication
 ```
 
 ## Sources Of Truth

--- a/repo/dependency-catalog/catalog-core/build.gradle.kts
+++ b/repo/dependency-catalog/catalog-core/build.gradle.kts
@@ -1,5 +1,42 @@
+import org.gradle.api.publish.maven.MavenPublication
+
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    `maven-publish`
 }
 
 group = "com.marmatsan.repo"
+version = providers.gradleProperty("figmaDesignSyncVersion").getOrElse("0.1.0-SNAPSHOT")
+
+java {
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "catalog-core"
+
+            pom {
+                name.set("Repository Catalog Core")
+                description.set("Portable dependency catalog model used by Figma Design Sync adapters.")
+                url.set("https://github.com/marmatsan/water-my-plants/tree/main/repo/dependency-catalog")
+                scm {
+                    connection.set("scm:git:https://github.com/marmatsan/water-my-plants.git")
+                    url.set("https://github.com/marmatsan/water-my-plants")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "staging"
+            url = uri(
+                providers.gradleProperty("figmaDesignSyncPublicationRepository").orNull
+                    ?: rootProject.layout.buildDirectory.dir("publication-repository").get().asFile
+            )
+        }
+    }
+}

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -85,6 +85,37 @@ The portable plugin id is `com.marmatsan.figmaDesignSync`. It intentionally has
 no Water My Plants defaults. See [`project-config/README.md`](project-config/README.md)
 for the adapter contract required by another repository.
 
+## Distribution Readiness
+
+Consumers will apply one versioned Gradle plugin rather than addressing the
+internal projects. The staged publication contains the plugin marker,
+`figma-design-sync-gradle-plugin`, transitive domain and data artifacts, the
+supporting `catalog-core` API, and the optional `teamcity-adapter`. Water My
+Plants `project-config` is deliberately excluded.
+
+The TypeScript writer is prepared as
+`@marmatsan/figma-design-sync-tools`. Its build executable injects a
+repository-owned `figma-config.ts`, so the published package does not own Figma
+node ids or repository paths. Maven and npm versions must remain aligned.
+
+Validate the complete staged distribution without publishing externally:
+
+```powershell
+.\gradlew.bat :figma-design-sync:verifyStagedPublication
+
+Push-Location repo\figma-design-sync\tools
+$env:npm_config_cache = "..\..\..\build\npm-cache"
+npm pack --dry-run
+Remove-Item Env:npm_config_cache
+Pop-Location
+```
+
+The standalone fixture resolves the plugin from generated Maven files and does
+not use `includeBuild`. See the
+[adoption guide](docs/guides/adopting-figma-design-sync.md),
+[distribution contract](docs/reference/distribution-contract.md), and
+[publication runbook](docs/runbooks/publishing-release.md).
+
 ## Output Contract
 
 `generateFigmaDesignModel` writes:

--- a/repo/figma-design-sync/build.gradle.kts
+++ b/repo/figma-design-sync/build.gradle.kts
@@ -1,3 +1,97 @@
 plugins {
+    base
     `kotlin-dsl` apply false
+}
+
+@DisableCachingByDefault(because = "The verification task has no reusable output artifact")
+abstract class VerifyPublicationVersionAlignmentTask : DefaultTask() {
+    @get:Input
+    abstract val mavenVersion: Property<String>
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val packageJson: RegularFileProperty
+
+    @TaskAction
+    fun verifyVersions() {
+        val npmVersion = Regex("\\\"version\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"")
+            .find(packageJson.get().asFile.readText())
+            ?.groupValues
+            ?.get(1)
+            ?: error("Missing version in tools/package.json")
+        val expectedVersion = mavenVersion.get()
+        check(npmVersion == expectedVersion) {
+            "Publication version mismatch: Maven=$expectedVersion, npm=$npmVersion"
+        }
+    }
+}
+
+val publicationGroup = providers
+    .gradleProperty("figmaDesignSyncGroup")
+    .getOrElse("com.marmatsan.figma-design-sync")
+val publicationVersion = providers
+    .gradleProperty("figmaDesignSyncVersion")
+    .getOrElse("0.1.0-SNAPSHOT")
+val configuredPublicationRepository = providers
+    .gradleProperty("figmaDesignSyncPublicationRepository")
+    .orNull
+val stagingPublicationRepository = configuredPublicationRepository
+    ?: layout.buildDirectory.dir("publication-repository").get().asFile.absolutePath
+val catalogStagingPublicationRepository = configuredPublicationRepository
+    ?: layout.projectDirectory.dir("../dependency-catalog/build/publication-repository").asFile.absolutePath
+
+allprojects {
+    group = publicationGroup
+    version = publicationVersion
+}
+
+val verifyPublicationVersionAlignment = tasks.register<VerifyPublicationVersionAlignmentTask>(
+    "verifyPublicationVersionAlignment"
+) {
+    group = "verification"
+    description = "Checks that Maven and npm publication versions remain aligned."
+
+    mavenVersion.set(publicationVersion)
+    packageJson.set(layout.projectDirectory.file("tools/package.json"))
+}
+
+tasks.register("publishPortablePublicationToStagingRepository") {
+    group = "publishing"
+    description = "Publishes the portable Figma sync artifacts to the configured staging Maven repository."
+
+    dependsOn(
+        verifyPublicationVersionAlignment,
+        ":domain:publishAllPublicationsToStagingRepository",
+        ":data:publishAllPublicationsToStagingRepository",
+        ":plugin:publishAllPublicationsToStagingRepository",
+        ":teamcity-adapter:publishAllPublicationsToStagingRepository",
+        gradle.includedBuild("dependency-catalog")
+            .task(":catalog-core:publishAllPublicationsToStagingRepository")
+    )
+}
+
+tasks.register<Exec>("verifyStagedPublication") {
+    group = "verification"
+    description = "Applies the staged plugin from a standalone consumer build."
+    dependsOn("publishPortablePublicationToStagingRepository")
+
+    val sampleDirectory = layout.projectDirectory.dir("samples/standalone-consumer")
+    val wrapper = layout.projectDirectory.file(
+        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+            "../../gradlew.bat"
+        } else {
+            "../../gradlew"
+        }
+    )
+
+    workingDir(sampleDirectory)
+    commandLine(
+        wrapper.asFile.absolutePath,
+        "--no-daemon",
+        "verifyPluginApplication",
+        "-PfigmaDesignSyncVersion=$publicationVersion",
+        "-PfigmaDesignSyncPublicationRepository=$stagingPublicationRepository",
+        "-PfigmaDesignSyncCatalogPublicationRepository=$catalogStagingPublicationRepository",
+        "--stacktrace"
+    )
 }

--- a/repo/figma-design-sync/data/build.gradle.kts
+++ b/repo/figma-design-sync/data/build.gradle.kts
@@ -1,11 +1,13 @@
 @file:Suppress("AvoidDuplicateDependencies")
 
 import java.net.URI
+import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
     alias(plugins.plugins.org.jetbrains.kotlin.plugin.serialization)
     alias(plugins.plugins.org.jetbrains.dokka)
+    `maven-publish`
 }
 
 repositories {
@@ -18,9 +20,13 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+java {
+    withSourcesJar()
+}
+
 dependencies {
     implementation(projects.domain)
-    implementation("com.marmatsan.repo:catalog-core")
+    implementation("com.marmatsan.repo:catalog-core:${project.version}")
     testImplementation("com.marmatsan.repo:water-my-plants-catalog")
 
     implementation(libs.me.tatarka.inject.kotlin.inject.runtime)
@@ -38,6 +44,35 @@ dependencies {
     testImplementation(libs.io.kotest.runner.junit5)
     testImplementation(libs.io.kotest.assertions.core)
     testRuntimeOnly(libs.org.junit.jupiter.platform.launcher)
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "figma-design-sync-data"
+
+            pom {
+                name.set("Figma Design Sync Data")
+                description.set("Portable filesystem, Gradle, catalog, and Figma adapters.")
+                url.set("https://github.com/marmatsan/water-my-plants/tree/main/repo/figma-design-sync")
+                scm {
+                    connection.set("scm:git:https://github.com/marmatsan/water-my-plants.git")
+                    url.set("https://github.com/marmatsan/water-my-plants")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "staging"
+            url = uri(
+                providers.gradleProperty("figmaDesignSyncPublicationRepository").orNull
+                    ?: rootProject.layout.buildDirectory.dir("publication-repository").get().asFile
+            )
+        }
+    }
 }
 
 dokka {

--- a/repo/figma-design-sync/docs/README.md
+++ b/repo/figma-design-sync/docs/README.md
@@ -7,6 +7,9 @@ Use this directory as the module documentation index:
 
 | Path | Role | Purpose |
 |------|------|---------|
+| `guides/adopting-figma-design-sync.md` | Guide | Consume the versioned Gradle plugin and configure a repository adapter without copying the source modules. |
+| `reference/distribution-contract.md` | Reference | Define public coordinates, version alignment, artifact boundaries, and the standalone-consumer gate. |
+| `runbooks/publishing-release.md` | Runbook | Stage, inspect, authorize, and publish a coordinated Maven and npm release. |
 | `runbooks/trunk-sync.md` | Runbook | Execute the official Figma trunk sync path and route to the detailed runbooks. |
 | `runbooks/official-artifact-visual-sync.md` | Runbook | Validate the TeamCity `main` artifact and decide when branch-local visual iteration may reuse it. |
 | `runbooks/mcp-chunk-transport.md` | Runbook | Build the MCP bundle, stage official payloads through PNG or chunk fallback, run targets, and write metadata. |

--- a/repo/figma-design-sync/docs/guides/adopting-figma-design-sync.md
+++ b/repo/figma-design-sync/docs/guides/adopting-figma-design-sync.md
@@ -1,0 +1,129 @@
+---
+title: Adopt Figma Design Sync in a Gradle repository
+type: guide
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
+  - repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaCatalogChecksExtension.kt
+  - repo/figma-design-sync/tools/bin/build.mjs
+  - repo/figma-design-sync/samples/standalone-consumer
+---
+
+# Adopt Figma Design Sync in a Gradle Repository
+
+## Outcome
+
+A Gradle repository consumes the versioned `com.marmatsan.figmaDesignSync`
+plugin without including this source build. The repository owns its Figma
+identities and catalog adapters, may select an optional CI adapter, and builds
+the portable TypeScript writer with its own `figma-config.ts`.
+
+Until an external repository is selected, use the staged publication produced
+by `verifyStagedPublication`. Do not copy `domain`, `data`, or `plugin` into a
+consumer repository.
+
+## Applicable Standards
+
+- Follow [ADR-0002](../../../../docs/decisions/adr-0002-distribute-figma-design-sync-as-gradle-plugin.md)
+  for the public artifact boundary.
+- Follow [the documentation standard](../../../../docs/documentation.md) for
+  the consumer repository's project adapter documentation.
+- Keep project identities outside the portable modules as required by
+  [`project-config/README.md`](../../project-config/README.md).
+
+## Steps
+
+1. Add the release Maven repository to `pluginManagement` and select one
+   version for every Figma Design Sync artifact:
+
+   ```kotlin
+   pluginManagement {
+       repositories {
+           maven("https://packages.example.com/figma-design-sync")
+           gradlePluginPortal()
+           mavenCentral()
+       }
+       plugins {
+           id("com.marmatsan.figmaDesignSync") version "<version>"
+       }
+   }
+   ```
+
+2. Create a repository-owned Gradle adapter. It applies the portable plugin,
+   implements `DependencyCatalogProvider`, and configures the
+   `figmaDesignSync` extension. Keep Figma node ids, paths, catalog names, and
+   CI commands in that adapter.
+
+   ```kotlin
+   plugins {
+       id("com.marmatsan.figmaDesignSync")
+   }
+
+   figmaDesignSync {
+       metadataNamespace.set("example_project_sync")
+       designModelMetadataNodeUrl.set(
+           "https://www.figma.com/design/<file-key>/<file>?node-id=<page-node>"
+       )
+       primaryCatalogModelName.set("exampleProject")
+       dependencyCatalogProviderClassName.set(
+           "com.example.figma.ExampleDependencyCatalogProvider"
+       )
+       versionsFile.set(layout.projectDirectory.file("gradle/versions.properties"))
+       toolsDirectory.set(layout.buildDirectory.dir("figma-design-sync-tools"))
+   }
+   ```
+
+3. Add `@marmatsan/figma-design-sync-tools` at the same version and materialize
+   a project-configured writer. The config module supplies repository paths,
+   Figma component identities, visual targets, and the relative repository
+   root used for writer fingerprints.
+
+   ```powershell
+   npm install --save-dev @marmatsan/figma-design-sync-tools@<version>
+   npx figma-design-sync-build `
+       --project-config=repo\figma-design-sync\project-config\figma-config.ts `
+       --output-dir=build\figma-design-sync-tools
+   ```
+
+4. Configure included builds through `figmaDesignSync.includedBuilds` only when
+   they contribute catalogs, modules, or convention plugins to the generated
+   model.
+
+5. For TeamCity, add the optional
+   `com.marmatsan.figma-design-sync:figma-design-sync-teamcity-adapter:<version>`
+   dependency to the repository adapter and select
+   `TeamCityCiConfigurationProvider`. Other repositories may supply a sibling
+   `CiConfigurationProvider` or leave CI documentation disabled.
+
+6. Add the relevant verification tasks to CI. Treat the model generated on the
+   default branch as the only official publication input.
+
+## Verification
+
+Run the standalone staged-consumer test before adopting a release:
+
+```powershell
+.\gradlew.bat :figma-design-sync:verifyStagedPublication
+```
+
+In the consumer repository, verify plugin application and its focused checks:
+
+```powershell
+.\gradlew.bat tasks --group verification
+.\gradlew.bat checkFigmaVersionNaming checkFigmaCatalogUsage
+```
+
+Build the configured writer and run its tests before enabling an official
+Figma write. Do not generate or publish official metadata from a feature
+branch.
+
+## Related Documentation
+
+- [Distribution contract](../reference/distribution-contract.md)
+- [Publication runbook](../runbooks/publishing-release.md)
+- [Project adapter contract](../../project-config/README.md)
+- [Official trunk sync](../runbooks/trunk-sync.md)

--- a/repo/figma-design-sync/docs/reference/distribution-contract.md
+++ b/repo/figma-design-sync/docs/reference/distribution-contract.md
@@ -1,0 +1,96 @@
+---
+title: Figma Design Sync distribution contract
+type: reference
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 180
+sources:
+  - repo/figma-design-sync/gradle.properties
+  - repo/figma-design-sync/build.gradle.kts
+  - repo/figma-design-sync/plugin/build.gradle.kts
+  - repo/figma-design-sync/tools/package.json
+  - repo/figma-design-sync/samples/standalone-consumer
+---
+
+# Figma Design Sync Distribution Contract
+
+## Purpose
+
+This reference defines the artifacts, versions, public entry points, and
+release gates used to consume Figma Design Sync without source modules or an
+included build.
+
+## Contract
+
+The public Gradle entry point is:
+
+```text
+plugin id: com.marmatsan.figmaDesignSync
+```
+
+The Maven publication set is:
+
+| Coordinate | Visibility | Responsibility |
+|------------|------------|----------------|
+| `com.marmatsan.figma-design-sync:figma-design-sync-gradle-plugin` | Public entry point | Gradle plugin implementation and tasks. |
+| `com.marmatsan.figma-design-sync:figma-design-sync-domain` | Transitive implementation | Portable models and ports. |
+| `com.marmatsan.figma-design-sync:figma-design-sync-data` | Transitive implementation | Portable filesystem, Gradle, catalog, and Figma adapters. |
+| `com.marmatsan.repo:catalog-core` | Transitive supporting API | Reusable dependency catalog model used by catalog providers. |
+| `com.marmatsan.figma-design-sync:figma-design-sync-teamcity-adapter` | Optional | TeamCity parser and typed CLI boundary. |
+
+Gradle also publishes the standard plugin marker coordinate generated for
+`com.marmatsan.figmaDesignSync`. Consumers use the plugin id rather than the
+implementation coordinate directly.
+
+The portable writer package is:
+
+```text
+@marmatsan/figma-design-sync-tools
+```
+
+Its `figma-design-sync-build` executable accepts:
+
+| Argument | Required | Meaning |
+|----------|----------|---------|
+| `--project-config=PATH` | Yes | TypeScript module exporting the repository's Figma identities and visual target configuration. |
+| `--output-dir=PATH` | No | Materialized tool workspace; defaults to the current directory. |
+
+The materialized directory contains the compiled writer, checkpoint executor,
+runner generator, portable writer sources used for fingerprints, and visual
+fixtures. `figmaDesignSync.toolsDirectory` points to this directory.
+
+The project config owns both
+`REPOSITORY_ROOT_RELATIVE_TO_TOOLS` and
+`CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY`. This prevents the portable
+package from assuming the Water My Plants directory structure.
+
+`repo/figma-design-sync/gradle.properties` owns the staged Maven version.
+`tools/package.json` must contain the same version. The
+`verifyPublicationVersionAlignment` task rejects drift.
+
+## Invariants
+
+- Consumers apply one Gradle plugin; they do not include or address the
+  internal `domain`, `data`, or `plugin` projects.
+- `project-config` is never part of the portable publication set.
+- The TeamCity adapter is never a transitive dependency of the portable
+  Gradle plugin.
+- Maven artifacts, the plugin marker, `catalog-core`, and the npm package use
+  one release version.
+- The npm package remains `private` until an explicit release authorizes the
+  selected registry and namespace.
+- A release must pass `verifyStagedPublication`, which resolves the plugin from
+  Maven files and applies it from `samples/standalone-consumer` without an
+  included build.
+- Publication credentials and signing material never enter versioned files.
+
+## Sources
+
+- [`../../build.gradle.kts`](../../build.gradle.kts)
+- [`../../plugin/build.gradle.kts`](../../plugin/build.gradle.kts)
+- [`../../tools/package.json`](../../tools/package.json)
+- [`../../tools/bin/build.mjs`](../../tools/bin/build.mjs)
+- [`../../samples/standalone-consumer`](../../samples/standalone-consumer)
+- [`../../project-config/water-my-plants/figma-config.ts`](../../project-config/water-my-plants/figma-config.ts)

--- a/repo/figma-design-sync/docs/runbooks/publishing-release.md
+++ b/repo/figma-design-sync/docs/runbooks/publishing-release.md
@@ -1,0 +1,134 @@
+---
+title: Publish a Figma Design Sync release
+type: runbook
+scope: repo/figma-design-sync
+owner: figma-design-sync
+status: active
+last-reviewed: 2026-07-18
+review-cycle-days: 90
+sources:
+  - repo/figma-design-sync/gradle.properties
+  - repo/figma-design-sync/build.gradle.kts
+  - repo/figma-design-sync/tools/package.json
+  - repo/figma-design-sync/samples/standalone-consumer
+---
+
+# Publish a Figma Design Sync Release
+
+## Purpose
+
+Use this runbook only after the team chooses the Maven and npm registries and
+explicitly authorizes a release. It prepares and verifies the complete artifact
+set without changing the Figma official model.
+
+## Prerequisites
+
+- Start from a clean, tested `main` revision and create a short-lived release
+  preparation branch.
+- Choose one semantic version and the external Maven and npm destinations.
+- Confirm ownership of the Maven group, Gradle plugin id, npm scope, and any
+  required signing identity.
+- Store repository credentials in the CI secret store. Reference them through
+  provider-specific environment variables or Gradle credentials; never write
+  them into build files, `gradle.properties`, `.npmrc`, or documentation.
+- Keep `tools/package.json` private until the release PR explicitly approves
+  npm publication.
+
+## Procedure
+
+1. Replace `0.1.0-SNAPSHOT` in
+   `repo/figma-design-sync/gradle.properties` and `tools/package.json` with the
+   same release version. Update the lockfile with:
+
+   ```powershell
+   Push-Location repo\figma-design-sync\tools
+   npm install --package-lock-only --ignore-scripts
+   Pop-Location
+   ```
+
+2. Build all Maven artifacts into workspace staging and resolve the plugin
+   from the standalone consumer:
+
+   ```powershell
+   .\gradlew.bat :figma-design-sync:verifyStagedPublication --stacktrace
+   ```
+
+3. Run the Kotlin and TypeScript checks:
+
+   ```powershell
+   .\gradlew.bat :figma-design-sync:domain:check `
+       :figma-design-sync:data:check `
+       :figma-design-sync:teamcity-adapter:check `
+       :figma-design-sync:plugin:check `
+       :figma-design-sync:project-config:check
+
+   Push-Location repo\figma-design-sync\tools
+   npm test
+   npm run build
+   $env:npm_config_cache = "..\..\..\build\npm-cache"
+   npm pack --dry-run
+   Remove-Item Env:npm_config_cache
+   Pop-Location
+   ```
+
+4. Inspect the staged POMs, Gradle module metadata, plugin marker, sources
+   JARs, npm file inventory, and checksums. Confirm that `project-config` and
+   Water My Plants credentials are absent.
+
+5. Configure the selected Maven repository URL through
+   `-PfigmaDesignSyncPublicationRepository=<repository-url>`. Add authentication
+   and signing only through the chosen provider's supported secret mechanism.
+
+6. In the release PR, remove the npm `private` guard only after the npm scope
+   and destination have been approved. Publish the npm package with the same
+   version as Maven.
+
+7. Publish in dependency order: `catalog-core`, domain, data, the Gradle plugin
+   implementation and marker, then the optional TeamCity adapter. The Gradle
+   aggregate task preserves this dependency set even when the repository
+   executes independent upload tasks.
+
+8. Verify from a clean external consumer, merge the release PR, create the
+   `v<version>` Git tag, and then restore the next development version in a
+   separate change if continuing development.
+
+## Verification
+
+A release is successful only when:
+
+- the plugin resolves through `plugins { id("com.marmatsan.figmaDesignSync") }`;
+- the consumer does not use `includeBuild("repo/figma-design-sync")`;
+- the Gradle tasks and `figmaDesignSync` extension are registered;
+- the TypeScript package materializes a writer with the consumer's config;
+- all published artifacts report the same version;
+- no Water My Plants `project-config` artifact is present.
+
+## Recovery
+
+- If staging fails, fix the source and rerun the staging task; workspace Maven
+  files are generated build artifacts.
+- If an external immutable version was uploaded partially, do not overwrite
+  it. Mark it unusable according to registry policy and release a new patch
+  version.
+- If npm was published but Maven failed, deprecate the npm version until the
+  matching Maven release exists.
+- If credentials appear in output, revoke them immediately and remove the
+  affected logs or artifacts according to the registry incident process.
+
+## Prohibited Actions
+
+- Do not publish from a feature branch, dirty checkout, or unverified staging
+  repository.
+- Do not publish `project-config` or `water-my-plants-catalog` as portable
+  artifacts.
+- Do not use different Maven and npm versions.
+- Do not bypass `verifyStagedPublication` or make `includeBuild` part of the
+  consumer fixture.
+- Do not write official Figma metadata as part of a software package release.
+
+## Sources
+
+- [Distribution contract](../reference/distribution-contract.md)
+- [Adoption guide](../guides/adopting-figma-design-sync.md)
+- [ADR-0002](../../../../docs/decisions/adr-0002-distribute-figma-design-sync-as-gradle-plugin.md)
+- [`../../samples/standalone-consumer`](../../samples/standalone-consumer)

--- a/repo/figma-design-sync/domain/build.gradle.kts
+++ b/repo/figma-design-sync/domain/build.gradle.kts
@@ -1,10 +1,12 @@
 @file:Suppress("AvoidDuplicateDependencies")
 
 import java.net.URI
+import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
     alias(plugins.plugins.org.jetbrains.dokka)
+    `maven-publish`
 }
 
 repositories {
@@ -17,6 +19,10 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+java {
+    withSourcesJar()
+}
+
 dependencies {
     implementation(libs.me.tatarka.inject.kotlin.inject.runtime)
 
@@ -24,6 +30,35 @@ dependencies {
     testImplementation(libs.io.kotest.runner.junit5)
     testImplementation(libs.io.kotest.assertions.core)
     testRuntimeOnly(libs.org.junit.jupiter.platform.launcher)
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "figma-design-sync-domain"
+
+            pom {
+                name.set("Figma Design Sync Domain")
+                description.set("Portable models and ports for Figma design synchronization.")
+                url.set("https://github.com/marmatsan/water-my-plants/tree/main/repo/figma-design-sync")
+                scm {
+                    connection.set("scm:git:https://github.com/marmatsan/water-my-plants.git")
+                    url.set("https://github.com/marmatsan/water-my-plants")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "staging"
+            url = uri(
+                providers.gradleProperty("figmaDesignSyncPublicationRepository").orNull
+                    ?: rootProject.layout.buildDirectory.dir("publication-repository").get().asFile
+            )
+        }
+    }
 }
 
 dokka {

--- a/repo/figma-design-sync/gradle.properties
+++ b/repo/figma-design-sync/gradle.properties
@@ -1,0 +1,2 @@
+figmaDesignSyncGroup=com.marmatsan.figma-design-sync
+figmaDesignSyncVersion=0.1.0-SNAPSHOT

--- a/repo/figma-design-sync/plugin/build.gradle.kts
+++ b/repo/figma-design-sync/plugin/build.gradle.kts
@@ -1,10 +1,12 @@
 @file:Suppress("AvoidDuplicateDependencies")
 
 import java.net.URI
+import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
+    `maven-publish`
     alias(plugins.plugins.com.google.devtools.ksp)
     alias(plugins.plugins.org.jetbrains.dokka)
 }
@@ -29,6 +31,10 @@ tasks.withType<Test> {
     System.getProperty("cucumber.features")?.let { features ->
         systemProperty("cucumber.features", features)
     }
+}
+
+java {
+    withSourcesJar()
 }
 
 dependencies {
@@ -56,6 +62,36 @@ gradlePlugin {
     plugins.register(pluginName) {
         id = pluginName
         implementationClass = "${pluginName}.plugin.gradle.FigmaDesignSyncGradlePlugin"
+        displayName = "Figma Design Sync"
+        description = "Generates and verifies a portable Gradle repository model for Figma documentation."
+    }
+}
+
+publishing {
+    publications.withType<MavenPublication>().configureEach {
+        if (name == "pluginMaven") {
+            artifactId = "figma-design-sync-gradle-plugin"
+        }
+
+        pom {
+            name.set("Figma Design Sync Gradle Plugin")
+            description.set("Gradle entry point for portable Figma design synchronization.")
+            url.set("https://github.com/marmatsan/water-my-plants/tree/main/repo/figma-design-sync")
+            scm {
+                connection.set("scm:git:https://github.com/marmatsan/water-my-plants.git")
+                url.set("https://github.com/marmatsan/water-my-plants")
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "staging"
+            url = uri(
+                providers.gradleProperty("figmaDesignSyncPublicationRepository").orNull
+                    ?: rootProject.layout.buildDirectory.dir("publication-repository").get().asFile
+            )
+        }
     }
 }
 

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/artifact/ValidateOfficialFigmaArtifactSetTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/artifact/ValidateOfficialFigmaArtifactSetTask.kt
@@ -16,8 +16,10 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /** Validates an official artifact set and writes its typed handoff identity. */
+@DisableCachingByDefault(because = "The output records absolute paths from the staged artifact set")
 abstract class ValidateOfficialFigmaArtifactSetTask : DefaultTask() {
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.NONE)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/catalog/CheckFigmaCatalogUsageTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/catalog/CheckFigmaCatalogUsageTask.kt
@@ -19,11 +19,13 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Gradle verification task that fails when dependency catalogs declare entries
  * not used by any module, convention plugin, or tool configuration.
  */
+@DisableCachingByDefault(because = "The check inspects repository sources outside its declared settings inputs")
 abstract class CheckFigmaCatalogUsageTask : DefaultTask() {
     @get:Input
     abstract val primaryCatalogModelName: Property<String>

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiExternalTopologyFreshnessTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiExternalTopologyFreshnessTask.kt
@@ -11,10 +11,12 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Emits a non-blocking warning when external CI topology validation is stale.
  */
+@DisableCachingByDefault(because = "The warning depends on the current UTC date")
 abstract class CheckCiExternalTopologyFreshnessTask : DefaultTask() {
     @get:InputFile
     @get:Optional

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiWindowsRuntimeFreshnessTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/ci/CheckCiWindowsRuntimeFreshnessTask.kt
@@ -2,6 +2,8 @@ package com.marmatsan.figmaDesignSync.plugin.task.ci
 
 import com.marmatsan.figmaDesignSync.plugin.di.create
 import com.marmatsan.figmaDesignSync.plugin.di.figmaDesignSyncComponent
+import java.time.LocalDate
+import java.time.ZoneOffset
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
@@ -9,12 +11,12 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.time.LocalDate
-import java.time.ZoneOffset
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Emits a non-blocking warning when Windows CI runtime validation is stale.
  */
+@DisableCachingByDefault(because = "The warning depends on the current UTC date")
 abstract class CheckCiWindowsRuntimeFreshnessTask : DefaultTask() {
     @get:InputFile
     @get:Optional

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/generate/GenerateFigmaDesignModelTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/generate/GenerateFigmaDesignModelTask.kt
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Gradle task that writes the official `main` branch `design-model.json` artifact.
@@ -36,6 +37,7 @@ import org.gradle.api.tasks.TaskAction
  * the configured CI Figma Sync adapter on `main` so local or short-lived
  * branch models cannot be mistaken for the official Figma publication input.
  */
+@DisableCachingByDefault(because = "Generation records Git, environment, and current-time runtime state")
 abstract class GenerateFigmaDesignModelTask : DefaultTask() {
     @get:Input
     abstract val primaryCatalogModelName: Property<String>

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/sync/CheckFigmaTrunkSyncTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/sync/CheckFigmaTrunkSyncTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Gradle verification task that fails when Figma does not contain the current
@@ -31,6 +32,7 @@ import org.gradle.api.tasks.TaskAction
  * The task reads `FIGMA_FILE_CONTENT_ACCESS_TOKEN` at execution time and does
  * not model it as a cacheable input because the token is secret runtime state.
  */
+@DisableCachingByDefault(because = "The check reads Figma, Git, a secret token, and current-time runtime state")
 abstract class CheckFigmaTrunkSyncTask : DefaultTask() {
     @get:Input
     abstract val metadataNodeUrl: Property<String>

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/versions/CheckFigmaVersionNamingTask.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/versions/CheckFigmaVersionNamingTask.kt
@@ -10,11 +10,13 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Gradle verification task that fails when version keys do not match the
  * Figma dependency version naming contract.
  */
+@DisableCachingByDefault(because = "The verification task has no reusable output artifact")
 abstract class CheckFigmaVersionNamingTask : DefaultTask() {
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/repo/figma-design-sync/project-config/README.md
+++ b/repo/figma-design-sync/project-config/README.md
@@ -63,11 +63,20 @@ portable content is present while `content.ci` is absent. Production source and
 KDoc outside `project-config` describe the host repository through adapter
 contracts rather than Water My Plants paths or identities.
 
-The TypeScript selection boundary is the
-`@figma-design-sync/project-config` path in `tools/tsconfig.json`. Point that
-alias at the new repository's config module. TypeScript remains necessary only
-for code bundled into the Figma plugin/MCP runtime; repository generation,
-classification, and artifact validation stay in Kotlin.
+The TypeScript selection boundary is the `--project-config` input of
+`figma-design-sync-build`. The package build aliases
+`@figma-design-sync/project-config` to that repository-owned module and bundles
+it into the materialized writer. The config declares its repository root and
+change-impact policy paths explicitly, so a published package does not assume
+the Water My Plants layout. TypeScript remains necessary only for code bundled
+into the Figma plugin/MCP runtime; repository generation, classification, and
+artifact validation stay in Kotlin.
+
+After publication, repositories consume the engine through the versioned
+`com.marmatsan.figmaDesignSync` plugin and keep only their adapter in source.
+See the [adoption guide](../docs/guides/adopting-figma-design-sync.md) for that
+workflow. The current Water My Plants build continues to use `includeBuild`
+while developing the engine itself.
 
 ## Optional Operational Adapters
 

--- a/repo/figma-design-sync/project-config/water-my-plants/figma-config.ts
+++ b/repo/figma-design-sync/project-config/water-my-plants/figma-config.ts
@@ -94,8 +94,9 @@ export const BRANCH_PROTECTION_SOURCE = "docs/ci/main-branch-protection.md";
 export const OFFICIAL_SYNC_SOURCE =
   "repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md";
 export const OFFICIAL_DESIGN_MODEL_PATH = "build/reports/figma-sync/design-model.json";
-export const CHANGE_IMPACT_POLICY_RELATIVE_TO_MODULE =
-  "project-config/water-my-plants/change-impact-policy.json";
+export const REPOSITORY_ROOT_RELATIVE_TO_TOOLS = "../../..";
+export const CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY =
+  "repo/figma-design-sync/project-config/water-my-plants/change-impact-policy.json";
 
 export const HEADER_SECTION_TARGETS = [
   {

--- a/repo/figma-design-sync/samples/standalone-consumer/README.md
+++ b/repo/figma-design-sync/samples/standalone-consumer/README.md
@@ -1,0 +1,10 @@
+# Standalone Consumer Fixture
+
+This fixture resolves `com.marmatsan.figmaDesignSync` only from staged Maven
+artifacts. It must not add `repo/figma-design-sync` as an included build.
+
+Run it through the owning build so the portable artifacts are staged first:
+
+```powershell
+.\gradlew.bat :figma-design-sync:verifyStagedPublication
+```

--- a/repo/figma-design-sync/samples/standalone-consumer/build.gradle.kts
+++ b/repo/figma-design-sync/samples/standalone-consumer/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("com.marmatsan.figmaDesignSync")
+}
+
+tasks.register("verifyPluginApplication") {
+    group = "verification"
+    description = "Verifies the published plugin can be resolved and applied without included builds."
+
+    doLast {
+        check(project.extensions.findByName("figmaDesignSync") != null) {
+            "The published plugin did not register the figmaDesignSync extension."
+        }
+        check(
+            listOf(
+                "generateFigmaDesignModel",
+                "prepareOfficialFigmaSync",
+                "verifyOfficialFigmaSync",
+                "checkFigmaTrunkSync"
+            ).all(tasks.names::contains)
+        ) {
+            "The published plugin did not register its public Gradle tasks."
+        }
+    }
+}

--- a/repo/figma-design-sync/samples/standalone-consumer/settings.gradle.kts
+++ b/repo/figma-design-sync/samples/standalone-consumer/settings.gradle.kts
@@ -1,0 +1,43 @@
+pluginManagement {
+    val pluginRepository = providers
+        .gradleProperty("figmaDesignSyncPublicationRepository")
+        .get()
+    val catalogRepository = providers
+        .gradleProperty("figmaDesignSyncCatalogPublicationRepository")
+        .getOrElse(pluginRepository)
+
+    repositories {
+        maven { url = uri(pluginRepository) }
+        maven { url = uri(catalogRepository) }
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    plugins {
+        id("com.marmatsan.figmaDesignSync") version providers
+            .gradleProperty("figmaDesignSyncVersion")
+            .get()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            url = uri(providers.gradleProperty("figmaDesignSyncPublicationRepository").get())
+        }
+        maven {
+            url = uri(
+                providers
+                    .gradleProperty("figmaDesignSyncCatalogPublicationRepository")
+                    .orElse(providers.gradleProperty("figmaDesignSyncPublicationRepository"))
+                    .get()
+            )
+        }
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "figma-design-sync-standalone-consumer"

--- a/repo/figma-design-sync/teamcity-adapter/build.gradle.kts
+++ b/repo/figma-design-sync/teamcity-adapter/build.gradle.kts
@@ -1,7 +1,10 @@
 @file:Suppress("AvoidDuplicateDependencies")
 
+import org.gradle.api.publish.maven.MavenPublication
+
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    `maven-publish`
 }
 
 repositories {
@@ -14,6 +17,10 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+java {
+    withSourcesJar()
+}
+
 dependencies {
     implementation(projects.domain)
     implementation(projects.data)
@@ -23,4 +30,33 @@ dependencies {
     testImplementation(libs.io.kotest.runner.junit5)
     testImplementation(libs.io.kotest.assertions.core)
     testRuntimeOnly(libs.org.junit.jupiter.platform.launcher)
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "figma-design-sync-teamcity-adapter"
+
+            pom {
+                name.set("Figma Design Sync TeamCity Adapter")
+                description.set("Optional TeamCity adapter for the portable Figma design sync model.")
+                url.set("https://github.com/marmatsan/water-my-plants/tree/main/repo/figma-design-sync")
+                scm {
+                    connection.set("scm:git:https://github.com/marmatsan/water-my-plants.git")
+                    url.set("https://github.com/marmatsan/water-my-plants")
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "staging"
+            url = uri(
+                providers.gradleProperty("figmaDesignSyncPublicationRepository").orNull
+                    ?: rootProject.layout.buildDirectory.dir("publication-repository").get().asFile
+            )
+        }
+    }
 }

--- a/repo/figma-design-sync/tools/README.md
+++ b/repo/figma-design-sync/tools/README.md
@@ -1,0 +1,16 @@
+# Figma Design Sync Tools
+
+This package contains the portable TypeScript writer and the checkpointed MCP
+runner tooling. It is built with a repository-owned `figma-config.ts` so Figma
+node identities and visual targets remain outside the reusable writer.
+
+Prepare a configured tool workspace with:
+
+```powershell
+npx figma-design-sync-build `
+    --project-config=path\to\figma-config.ts `
+    --output-dir=build\figma-design-sync-tools
+```
+
+The package remains `private` until a release is explicitly authorized. The
+publication runbook describes the release gate and version alignment contract.

--- a/repo/figma-design-sync/tools/bin/build.mjs
+++ b/repo/figma-design-sync/tools/bin/build.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { cp, mkdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { build } from "esbuild";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const options = parseOptions(process.argv.slice(2));
+const projectConfig = resolve(process.cwd(), options.projectConfig);
+const outputRoot = resolve(process.cwd(), options.outputDirectory);
+const outputDist = join(outputRoot, "dist");
+
+await mkdir(outputDist, { recursive: true });
+await copyRuntimeSources(outputRoot);
+
+const alias = {
+  "@figma-design-sync/project-config": projectConfig,
+};
+
+await bundleFigmaEntrypoint(
+  "src/app/sync-trunk-design-model.mcp.ts",
+  "sync-trunk-design-model.mcp.js",
+  "FigmaTrunkSync"
+);
+await bundleFigmaEntrypoint(
+  "src/app/sync-catalog-tree-preview.mcp.ts",
+  "sync-catalog-tree-preview.mcp.js",
+  "FigmaCatalogTreePreview"
+);
+
+for (const [entrypoint, output] of [
+  ["scripts/write-mcp-js.ts", "write-mcp-js.mjs"],
+  ["scripts/write-mcp-runner.ts", "write-mcp-runner.mjs"],
+  ["scripts/execute-mcp-runner.ts", "execute-mcp-runner.mjs"],
+  ["scripts/write-visual-sync-plan.ts", "write-visual-sync-plan.mjs"],
+]) {
+  await build({
+    absWorkingDir: packageRoot,
+    alias,
+    bundle: true,
+    entryPoints: [entrypoint],
+    format: "esm",
+    outfile: join(outputDist, output),
+    platform: "node",
+    target: "node18",
+  });
+}
+
+await import(pathToFileURL(join(outputDist, "write-mcp-js.mjs")).href);
+
+console.log(`Prepared Figma Design Sync tools in ${outputRoot}`);
+
+async function bundleFigmaEntrypoint(entrypoint, output, globalName) {
+  await build({
+    absWorkingDir: packageRoot,
+    alias,
+    bundle: true,
+    entryPoints: [entrypoint],
+    format: "iife",
+    globalName,
+    minify: true,
+    outfile: join(outputDist, output),
+    target: "es2022",
+  });
+}
+
+async function copyRuntimeSources(targetRoot) {
+  if (resolve(targetRoot) === packageRoot) {
+    return;
+  }
+
+  await cp(join(packageRoot, "src"), join(targetRoot, "src"), {
+    recursive: true,
+    force: true,
+  });
+  await cp(join(packageRoot, "fixtures"), join(targetRoot, "fixtures"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+function parseOptions(args) {
+  const values = {};
+  for (const argument of args) {
+    const [key, value] = argument.replace(/^--/, "").split("=", 2);
+    if (!argument.startsWith("--") || !key || !value) {
+      throw new Error(`Expected --name=value, received '${argument}'.`);
+    }
+    values[key] = value;
+  }
+
+  if (!values["project-config"]) {
+    throw new Error("Missing --project-config=PATH.");
+  }
+
+  return {
+    projectConfig: values["project-config"],
+    outputDirectory: values["output-dir"] || ".",
+  };
+}

--- a/repo/figma-design-sync/tools/package-lock.json
+++ b/repo/figma-design-sync/tools/package-lock.json
@@ -1,13 +1,21 @@
 {
-  "name": "tools",
+  "name": "@marmatsan/figma-design-sync-tools",
+  "version": "0.1.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "@marmatsan/figma-design-sync-tools",
+      "version": "0.1.0-SNAPSHOT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "esbuild": "^0.25.0"
+      },
+      "bin": {
+        "figma-design-sync-build": "bin/build.mjs"
+      },
       "devDependencies": {
         "@figma/plugin-typings": "^1.117.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "esbuild": "^0.25.0",
         "typescript": "^5.8.3"
       }
     },
@@ -18,7 +26,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -35,7 +42,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -52,7 +58,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -69,7 +74,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -86,7 +90,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -103,7 +106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -120,7 +122,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -137,7 +138,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -154,7 +154,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -171,7 +170,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -188,7 +186,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -205,7 +202,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -222,7 +218,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -239,7 +234,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -256,7 +250,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -273,7 +266,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -290,7 +282,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,7 +298,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -324,7 +314,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -341,7 +330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,7 +346,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,7 +362,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -392,7 +378,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -409,7 +394,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,7 +410,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -443,7 +426,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -464,7 +446,6 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -477,7 +458,6 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -518,7 +498,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -532,7 +511,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -549,7 +527,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -567,7 +544,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -592,7 +568,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -606,7 +581,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -616,7 +590,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -630,7 +603,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -647,7 +619,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -661,7 +632,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -671,7 +641,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -681,7 +650,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -691,7 +659,6 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -709,7 +676,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -724,7 +690,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -742,7 +707,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -752,7 +716,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -767,14 +730,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -784,7 +745,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -794,7 +754,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -804,7 +763,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -817,7 +775,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -859,14 +816,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -876,7 +831,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -889,7 +843,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -899,7 +852,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -943,7 +895,6 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
       "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -963,14 +914,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
       "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -987,7 +936,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1009,7 +957,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1019,7 +966,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1029,7 +975,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1039,7 +984,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1064,7 +1008,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -1078,7 +1021,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1091,7 +1033,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1104,7 +1045,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1117,7 +1057,6 @@
       "version": "4.12.30",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
       "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1127,7 +1066,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -1148,7 +1086,6 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1165,14 +1102,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1182,7 +1117,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -1192,21 +1126,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
       "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1216,21 +1147,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1240,7 +1168,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1250,7 +1177,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1263,7 +1189,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1273,7 +1198,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -1290,14 +1214,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1307,7 +1229,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1317,7 +1238,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1330,7 +1250,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -1343,7 +1262,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1353,7 +1271,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1363,7 +1280,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1373,7 +1289,6 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1384,7 +1299,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -1394,7 +1308,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -1408,7 +1321,6 @@
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -1425,7 +1337,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
       "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1439,7 +1350,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -1455,7 +1365,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1465,7 +1374,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1482,14 +1390,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1516,7 +1422,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -1536,14 +1441,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1556,7 +1459,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1566,7 +1468,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1586,7 +1487,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1603,7 +1503,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -1622,7 +1521,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -1642,7 +1540,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1652,7 +1549,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -1662,7 +1558,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -1681,7 +1576,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1709,7 +1603,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1719,7 +1612,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1729,7 +1621,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1745,14 +1636,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -1762,7 +1651,6 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/repo/figma-design-sync/tools/package.json
+++ b/repo/figma-design-sync/tools/package.json
@@ -1,9 +1,26 @@
 {
+  "name": "@marmatsan/figma-design-sync-tools",
+  "version": "0.1.0-SNAPSHOT",
+  "description": "Portable TypeScript writer and checkpointed MCP runner tooling for Figma Design Sync.",
   "private": true,
   "type": "module",
+  "bin": {
+    "figma-design-sync-build": "bin/build.mjs"
+  },
+  "files": [
+    "bin/",
+    "fixtures/",
+    "scripts/",
+    "src/",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "build": "tsc --project tsconfig.json && esbuild src/app/sync-trunk-design-model.mcp.ts --bundle --format=iife --global-name=FigmaTrunkSync --target=es2022 --minify --outfile=dist/sync-trunk-design-model.mcp.js && esbuild src/app/sync-catalog-tree-preview.mcp.ts --bundle --format=iife --global-name=FigmaCatalogTreePreview --target=es2022 --minify --outfile=dist/sync-catalog-tree-preview.mcp.js && esbuild scripts/write-mcp-js.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-js.mjs && esbuild scripts/write-mcp-runner.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-mcp-runner.mjs && esbuild scripts/execute-mcp-runner.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/execute-mcp-runner.mjs && esbuild scripts/write-visual-sync-plan.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/write-visual-sync-plan.mjs && node dist/write-mcp-js.mjs",
-    "test": "npm run test:payload-png && npm run test:sync-preflight && npm run test:version-sync-plan && npm run test:header-sync-plan && npm run test:metadata-sync && npm run test:writer-scope-fingerprints && npm run test:write-mcp-runner && npm run test:execute-mcp-runner && npm run test:visual-sync-plan && npm run test:catalog-root-filter && npm run test:library-catalog-entries && npm run test:catalog-tree-targets && npm run test:ci-visual-plan",
+    "build": "node bin/build.mjs --project-config=../project-config/water-my-plants/figma-config.ts --output-dir=.",
+    "test": "npm run test:distribution-build && npm run test:payload-png && npm run test:sync-preflight && npm run test:version-sync-plan && npm run test:header-sync-plan && npm run test:metadata-sync && npm run test:writer-scope-fingerprints && npm run test:write-mcp-runner && npm run test:execute-mcp-runner && npm run test:visual-sync-plan && npm run test:catalog-root-filter && npm run test:library-catalog-entries && npm run test:catalog-tree-targets && npm run test:ci-visual-plan",
+    "test:distribution-build": "node --test tests/distribution-build.test.mjs",
     "test:payload-png": "esbuild tests/payload-png.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/payload-png.test.mjs && node --test dist/payload-png.test.mjs",
     "test:sync-preflight": "esbuild tests/sync-preflight-target.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/sync-preflight-target.test.mjs && node --test dist/sync-preflight-target.test.mjs",
     "test:version-sync-plan": "esbuild tests/version-sync-plan.test.ts --bundle --platform=node --format=esm --target=node18 --outfile=dist/version-sync-plan.test.mjs && node --test dist/version-sync-plan.test.mjs",
@@ -24,10 +41,12 @@
     "premcp:preview": "npm run build",
     "mcp:preview": "node dist/write-mcp-runner.mjs --mode=preview"
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "esbuild": "^0.25.0"
+  },
   "devDependencies": {
     "@figma/plugin-typings": "^1.117.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "esbuild": "^0.25.0",
     "typescript": "^5.8.3"
   }
 }

--- a/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
+++ b/repo/figma-design-sync/tools/scripts/write-mcp-runner.ts
@@ -16,11 +16,12 @@ import {
 } from "./writer-scope-fingerprints";
 import {
   CATALOG_TARGET_NAMES,
-  CHANGE_IMPACT_POLICY_RELATIVE_TO_MODULE,
+  CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY,
   DEFAULT_FIXTURE_TARGETS,
   METADATA_PAGE_ID,
   OFFICIAL_STAGING_NAMESPACE,
   PREVIEW_STAGING_NAMESPACE,
+  REPOSITORY_ROOT_RELATIVE_TO_TOOLS,
   WRITER_TARGET_NAMES,
 } from "@figma-design-sync/project-config";
 
@@ -274,8 +275,12 @@ async function writeRunnerFiles(options) {
   const targetFingerprints = createTargetFingerprints(designModel);
   const writerScopeFingerprints = await createWriterScopeFingerprints({
     sourceRoot: resolve(TOOL_ROOT, "src"),
-    repositoryRoot: resolve(TOOL_ROOT, "..", "..", ".."),
-    policyPath: resolve(TOOL_ROOT, "..", CHANGE_IMPACT_POLICY_RELATIVE_TO_MODULE),
+    repositoryRoot: resolve(TOOL_ROOT, REPOSITORY_ROOT_RELATIVE_TO_TOOLS),
+    policyPath: resolve(
+      TOOL_ROOT,
+      REPOSITORY_ROOT_RELATIVE_TO_TOOLS,
+      CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY
+    ),
     scopes: Object.keys(targetFingerprints),
   });
 

--- a/repo/figma-design-sync/tools/tests/distribution-build.test.mjs
+++ b/repo/figma-design-sync/tools/tests/distribution-build.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const toolRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const projectConfig = resolve(
+  toolRoot,
+  "..",
+  "project-config",
+  "water-my-plants",
+  "figma-config.ts"
+);
+
+test("materializes a project-configured writer outside the package", async () => {
+  const outputRoot = await mkdtemp(join(tmpdir(), "figma-design-sync-tools-"));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(toolRoot, "bin", "build.mjs"),
+        `--project-config=${projectConfig}`,
+        `--output-dir=${outputRoot}`,
+      ],
+      { cwd: toolRoot, encoding: "utf8" }
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const generatedWriter = await readFile(
+      join(outputRoot, "sync-trunk-design-model.mcp.js"),
+      "utf8"
+    );
+    assert.match(generatedWriter, /Generated from sync-trunk-design-model\.mcp\.ts/);
+    assert.doesNotMatch(generatedWriter, /@figma-design-sync\/project-config/);
+
+    const runner = await readFile(join(outputRoot, "dist", "write-mcp-runner.mjs"), "utf8");
+    assert.match(runner, /water_my_plants_sync/);
+    assert.doesNotMatch(runner, /@figma-design-sync\/project-config/);
+  } finally {
+    await rm(outputRoot, { recursive: true, force: true });
+  }
+});

--- a/repo/figma-design-sync/tools/tests/writer-scope-fingerprints.test.ts
+++ b/repo/figma-design-sync/tools/tests/writer-scope-fingerprints.test.ts
@@ -3,7 +3,9 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { CHANGE_IMPACT_POLICY_RELATIVE_TO_MODULE } from "@figma-design-sync/project-config";
+import {
+  CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY,
+} from "@figma-design-sync/project-config";
 import {
   createWriterScopeFingerprints,
   WRITER_SCOPE_FINGERPRINT_SCHEMA_VERSION,
@@ -113,7 +115,13 @@ test("repository policy maps catalog writer changes to catalog scopes and prefli
   const options = {
     sourceRoot,
     repositoryRoot: root,
-    policyPath: join(process.cwd(), "..", CHANGE_IMPACT_POLICY_RELATIVE_TO_MODULE),
+    policyPath: join(
+      process.cwd(),
+      "..",
+      "..",
+      "..",
+      CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY
+    ),
     scopes: REQUESTED_SCOPES,
   };
 


### PR DESCRIPTION
## Summary

- stage the Kotlin Gradle plugin, its transitive Maven artifacts, `catalog-core`, and the optional TeamCity adapter under one aligned snapshot version
- package the TypeScript writer behind a project-configurable build executable while keeping npm publication blocked by `private: true`
- prove both distribution paths with a standalone Gradle consumer and an external TypeScript workspace
- document the distribution decision, adoption contract, artifact coordinates, and future release procedure

## Release safety

- no external Maven or npm destination is selected
- no credentials, signing material, or publication automation are added
- the version remains `0.1.0-SNAPSHOT`
- Water My Plants `project-config` and `water-my-plants-catalog` remain outside the portable publication set

## Validation

- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1`
- focused Kotlin checks plus `:figma-design-sync:verifyStagedPublication`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
- `pwsh -NoProfile -File .teamcity/scripts/invoke-ci-verification.ps1`
