### PR TITLE
feat(figma-design-sync): move CI visual planning to Kotlin

### DIFF
--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -32,12 +32,12 @@ Plugin API boundary:
 
 | Path | Role |
 |------|------|
-| `domain/` | Pure model and port definitions for versions, catalogs, modules, and module dependency edges. |
-| `data/` | File, Gradle, dependency-catalog, and Figma API adapters that implement domain ports. |
+| `domain/` | Pure model, port, and visual-planning definitions for versions, catalogs, modules, CI, and writer execution. |
+| `data/` | File, Gradle, dependency-catalog, JSON, MCP, and Figma API adapters that implement domain ports. |
 | `plugin/` | Gradle plugin, tasks, checkers, dependency injection bindings, and model generation orchestration. |
 | `teamcity-adapter/` | Optional Kotlin adapter that translates generated TeamCity YAML/XML and provides typed TeamCity CLI operations. |
 | `project-config/` | Water My Plants adapter for repository paths, catalog source, Figma identities, visual targets, credentials, and optional CI operations. |
-| `tools/` | TypeScript executed inside the Figma Plugin API runtime plus preview tooling and visual sync tests. |
+| `tools/` | Thin TypeScript Figma Plugin API boundary plus transitional preview tooling and adapter tests. |
 | `docs/` | Runbooks, BDD notes, UML diagrams, and visual contract documentation. |
 
 Dependency direction is intentional:
@@ -54,6 +54,12 @@ composition. `plugin` wires portable Gradle tasks to domain ports through
 `data`; `teamcity-adapter` owns the vendor-specific parser; `project-config`
 applies the plugin and selects one repository's concrete catalog, layout,
 Figma document, and CI adapter.
+
+Pure CI section planning is Kotlin-owned. `CiVisualPlanner` produces a portable
+plan, `CiVisualPlanJson` projects one requested target into the official runner,
+and TypeScript consumes that plan while interacting with Figma nodes. Kotlin
+planner sources participate in target-scoped writer fingerprints, so a CI-only
+planning change does not invalidate catalog or version targets.
 
 ## Inputs
 

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/fingerprint/WriterScopeFingerprintCalculator.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/fingerprint/WriterScopeFingerprintCalculator.kt
@@ -22,15 +22,20 @@ class WriterScopeFingerprintCalculator {
         scopes: List<String>
     ): Map<String, String> {
         validateRuleTargets(policy, writerTargets)
-        val sourceFiles = Files.walk(sourceRoot).use { paths ->
+        require(Files.isDirectory(sourceRoot)) { "Figma writer source root does not exist: $sourceRoot" }
+        val sourceFiles = Files.walk(repositoryRoot).use { paths ->
             paths.filter(Path::isRegularFile)
                 .sorted()
                 .filter { source ->
-                    !matchesAny(repositoryPath(repositoryRoot, source), policy.transportOnlyPaths)
+                    val path = repositoryPath(repositoryRoot, source)
+                    matchesAny(path, policy.visualWriterPaths) &&
+                        !matchesAny(path, policy.transportOnlyPaths)
                 }
                 .toList()
         }
-        require(sourceFiles.isNotEmpty()) { "No Figma writer sources were found under $sourceRoot." }
+        require(sourceFiles.isNotEmpty()) {
+            "No Figma writer sources matched the visual writer policy under $repositoryRoot."
+        }
 
         val sourcesByTarget = writerTargets.associateWith { mutableListOf<SourceFingerprint>() }
         sourceFiles.forEach { source ->

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/visual/CiVisualPlanJson.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/visual/CiVisualPlanJson.kt
@@ -1,0 +1,235 @@
+package com.marmatsan.figmaDesignSync.data.json.visual
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConnection
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiPipeline
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiTrigger
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiVcsRoot
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlan
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
+import com.marmatsan.figmaDesignSync.domain.service.visual.CiVisualPlanner
+import java.time.LocalDate
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/** JSON boundary between the official design model and the Kotlin CI visual planner. */
+object CiVisualPlanJson {
+    fun create(
+        designModel: JsonObject,
+        config: CiVisualPlanConfig,
+        target: String? = null
+    ): JsonObject {
+        val ci = designModel["content"]?.jsonObject?.get("ci")?.jsonObject
+            ?: throw IllegalArgumentException("designModel.content.ci is required for CI visual sync.")
+        val plan = CiVisualPlanner().create(
+            externalTopology = ci.requiredObject("externalTopology").toExternalTopology(),
+            windowsRuntime = ci.requiredObject("windowsRuntime").toWindowsRuntime(),
+            configuration = ci.requiredObject(config.configurationModelName).toCiConfiguration(),
+            config = config
+        )
+        val selected = target?.let { requested ->
+            plan.copy(sections = plan.sections.filter { section -> section.target == requested })
+                .also { filtered ->
+                    require(filtered.sections.size == 1) { "CI visual plan has no section for target '$requested'." }
+                }
+        } ?: plan
+        return selected.toJson()
+    }
+
+    private fun JsonObject.toExternalTopology(): CiExternalTopology = CiExternalTopology(
+        schemaVersion = requiredInt("schemaVersion"),
+        validation = requiredObject("validation").let { validation ->
+            CiExternalTopology.Validation(
+                lastValidatedOn = LocalDate.parse(validation.requiredString("lastValidatedOn")),
+                warnAfterDays = validation.requiredInt("warnAfterDays")
+            )
+        },
+        nodes = requiredArray("nodes").map { element ->
+            val node = element.jsonObject
+            CiNode(
+                id = node.requiredString("id"),
+                type = CiNode.Type.entries.single { type -> type.serializedName == node.requiredString("type") },
+                name = node.requiredString("name"),
+                description = node.requiredString("description")
+            )
+        },
+        connections = requiredArray("connections").map { element ->
+            val connection = element.jsonObject
+            CiConnection(
+                id = connection.requiredString("id"),
+                sourceNodeId = connection.requiredString("source"),
+                targetNodeId = connection.requiredString("target"),
+                label = connection.requiredString("label"),
+                description = connection.requiredString("description"),
+                protocol = connection.optionalString("protocol"),
+                authentication = connection.requiredArray("authentication").map { it.jsonPrimitive.content },
+                policy = connection.optionalString("policy"),
+                path = connection.optionalString("path"),
+                automation = CiConnection.Automation.entries.single { automation ->
+                    automation.serializedName == connection.requiredString("automation")
+                },
+                annotation = connection.optionalString("annotation")
+            )
+        }
+    )
+
+    private fun JsonObject.toWindowsRuntime(): CiWindowsRuntime = CiWindowsRuntime(
+        schemaVersion = requiredInt("schemaVersion"),
+        validation = requiredObject("validation").let { validation ->
+            CiWindowsRuntime.Validation(
+                lastValidatedOn = LocalDate.parse(validation.requiredString("lastValidatedOn")),
+                warnAfterDays = validation.requiredInt("warnAfterDays")
+            )
+        },
+        platform = requiredString("platform"),
+        services = requiredArray("services").map { element ->
+            val service = element.jsonObject
+            CiWindowsRuntime.Service(
+                id = service.requiredString("id"),
+                name = service.requiredString("name"),
+                description = service.requiredString("description"),
+                service = service.requiredString("service"),
+                startup = service.requiredString("startup"),
+                identity = service.requiredString("identity")
+            )
+        }
+    )
+
+    private fun JsonObject.toCiConfiguration(): CiConfiguration = CiConfiguration(
+        pipelines = requiredArray("pipelines").map { element -> element.jsonObject.toCiPipeline() },
+        vcsRoots = requiredArray("vcsRoots").map { element ->
+            val root = element.jsonObject
+            CiVcsRoot(
+                id = root.requiredString("id"),
+                name = root.requiredString("name"),
+                url = root.requiredString("url"),
+                defaultBranchRef = root.requiredString("defaultBranchRef"),
+                branchSpec = root.requiredArray("branchSpec").map { it.jsonPrimitive.content }
+            )
+        }
+    )
+
+    private fun JsonObject.toCiPipeline(): CiPipeline = CiPipeline(
+        id = requiredString("id"),
+        name = requiredString("name"),
+        triggers = requiredArray("triggers").map { element ->
+            val trigger = element.jsonObject
+            CiTrigger(
+                type = CiTrigger.Type.entries.single { type -> type.serializedName == trigger.requiredString("type") },
+                branchFilter = trigger.optionalString("branchFilter"),
+                dependencyPipelineId = trigger.optionalString("dependencyPipelineId"),
+                afterSuccessfulBuildOnly = trigger["afterSuccessfulBuildOnly"]?.jsonPrimitive?.booleanOrNull
+            )
+        },
+        jobs = requiredArray("jobs").map { element -> element.jsonObject.toCiJob() }
+    )
+
+    private fun JsonObject.toCiJob(): CiJob = CiJob(
+        id = requiredString("id"),
+        name = requiredString("name"),
+        steps = requiredArray("steps").map { element ->
+            val step = element.jsonObject
+            CiJob.Step(step.requiredString("id"), step.requiredString("name"), step.requiredString("command"))
+        },
+        repositoryIds = requiredArray("repositoryIds").map { it.jsonPrimitive.content },
+        artifacts = requiredArray("artifacts").map { element ->
+            val artifact = element.jsonObject
+            CiJob.Artifact(
+                artifact.requiredString("path"),
+                artifact.requiredBoolean("publish"),
+                artifact.requiredBoolean("shareWithJobs")
+            )
+        },
+        dependencies = requiredArray("dependencies").map { element ->
+            val dependency = element.jsonObject
+            CiJob.Dependency(
+                dependency.requiredString("jobId"),
+                dependency.requiredArray("artifactPaths").map { it.jsonPrimitive.content }
+            )
+        },
+        publishedChecks = requiredArray("publishedChecks").map { element ->
+            CiJob.PublishedCheck(element.jsonObject.requiredString("name"))
+        }
+    )
+
+    private fun CiVisualPlan.toJson(): JsonObject = buildJsonObject {
+        put("parentName", parentName)
+        put("sections", JsonArray(sections.map { section -> section.toJson() }))
+    }
+
+    private fun CiVisualPlan.Section.toJson(): JsonObject = buildJsonObject {
+        put("target", target)
+        put("name", name)
+        put("description", description)
+        put("orientation", orientation.wireValue)
+        put("headerSources", JsonArray(headerSources.map { source ->
+            buildJsonObject {
+                put("label", source.label)
+                put("url", source.url)
+            }
+        }))
+        put("nodes", JsonArray(nodes.map { node -> node.toJson() }))
+        put("connections", JsonArray(connections.map { connection ->
+            buildJsonObject {
+                put("id", connection.id)
+                put("source", connection.source)
+                put("target", connection.target)
+                put("label", connection.label)
+            }
+        }))
+    }
+
+    private fun CiVisualPlan.Node.toJson(): JsonObject = buildJsonObject {
+        put("id", id)
+        put("type", type.wireValue)
+        put("environment", environment.wireValue)
+        put("name", name)
+        put("description", description)
+        steps?.let { put("steps", it) }
+        runtime?.let { value ->
+            put("runtime", buildJsonObject {
+                put("platform", value.platform)
+                put("service", value.service)
+                put("startup", value.startup)
+                put("identity", value.identity)
+            })
+        }
+        put("source", source)
+        put("sourceUrl", sourceUrl)
+        put("row", row)
+        put("column", column)
+    }
+
+    private fun JsonObject.requiredObject(name: String): JsonObject =
+        this[name]?.jsonObject ?: throw IllegalArgumentException("CI visual model is missing '$name'.")
+
+    private fun JsonObject.requiredArray(name: String): JsonArray =
+        this[name]?.jsonArray ?: throw IllegalArgumentException("CI visual model is missing '$name'.")
+
+    private fun JsonObject.requiredString(name: String): String =
+        this[name]?.jsonPrimitive?.contentOrNull ?: throw IllegalArgumentException("CI visual model is missing '$name'.")
+
+    private fun JsonObject.optionalString(name: String): String? =
+        this[name]?.takeUnless { it is JsonNull }?.jsonPrimitive?.contentOrNull
+
+    private fun JsonObject.requiredInt(name: String): Int =
+        this[name]?.jsonPrimitive?.int ?: throw IllegalArgumentException("CI visual model is missing '$name'.")
+
+    private fun JsonObject.requiredBoolean(name: String): Boolean =
+        this[name]?.jsonPrimitive?.booleanOrNull ?: throw IllegalArgumentException("CI visual model is missing '$name'.")
+}

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/writer/FigmaWriterProjectConfigJson.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/writer/FigmaWriterProjectConfigJson.kt
@@ -60,6 +60,7 @@ object FigmaWriterProjectConfigJson {
             put("HEADER_LINK_PROPERTY_NAME", headerLinkPropertyName)
             put("GITHUB_MAIN_BLOB_URL", githubMainBlobUrl)
             put("GITHUB_MAIN_TREE_URL", githubMainTreeUrl)
+            put("CI_CONFIGURATION_MODEL_NAME", ciConfigurationModelName)
             put("CI_PIPELINE_NAME", ciPipelineName)
             put("FIGMA_PIPELINE_NAME", figmaPipelineName)
             put("TEAMCITY_SOURCE", teamCitySource)

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/writer/FigmaWriterRuntimeConfigJson.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/writer/FigmaWriterRuntimeConfigJson.kt
@@ -1,5 +1,6 @@
 package com.marmatsan.figmaDesignSync.data.json.writer
 
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
 import com.marmatsan.figmaDesignSync.domain.model.writer.FigmaWriterRuntimeConfig
 import java.nio.file.Files
 import java.nio.file.Path
@@ -20,6 +21,7 @@ object FigmaWriterRuntimeConfigJson {
             "Unsupported Figma writer project config schema ${json.requiredInt("schemaVersion")}; " +
                 "expected $SUPPORTED_SCHEMA_VERSION."
         }
+        val ciTargets = json.requiredStringList("CI_VISUAL_TARGET_NAMES")
         return FigmaWriterRuntimeConfig(
             metadataPageId = json.requiredString("METADATA_PAGE_ID"),
             metadataNamespace = json.requiredString("METADATA_NAMESPACE"),
@@ -30,7 +32,21 @@ object FigmaWriterRuntimeConfigJson {
             changeImpactPolicyRelativeToRepository =
                 json.requiredString("CHANGE_IMPACT_POLICY_RELATIVE_TO_REPOSITORY"),
             writerTargetNames = json.requiredStringList("WRITER_TARGET_NAMES"),
-            catalogTargetNames = json.requiredStringList("CATALOG_TARGET_NAMES")
+            catalogTargetNames = json.requiredStringList("CATALOG_TARGET_NAMES"),
+            ciVisualPlanConfig = if (ciTargets.isEmpty()) null else CiVisualPlanConfig(
+                configurationModelName = json.requiredString("CI_CONFIGURATION_MODEL_NAME"),
+                ciPipelineName = json.requiredString("CI_PIPELINE_NAME"),
+                figmaPipelineName = json.requiredString("FIGMA_PIPELINE_NAME"),
+                githubMainBlobUrl = json.requiredString("GITHUB_MAIN_BLOB_URL"),
+                teamCitySource = json.requiredString("TEAMCITY_SOURCE"),
+                topologySource = json.requiredString("TOPOLOGY_SOURCE"),
+                windowsRuntimeSource = json.requiredString("WINDOWS_RUNTIME_SOURCE"),
+                windowsRuntimeRunbookSource = json.requiredString("WINDOWS_RUNTIME_RUNBOOK_SOURCE"),
+                visualContractSource = json.requiredString("VISUAL_CONTRACT_SOURCE"),
+                branchProtectionSource = json.requiredString("BRANCH_PROTECTION_SOURCE"),
+                officialSyncSource = json.requiredString("OFFICIAL_SYNC_SOURCE"),
+                officialDesignModelPath = json.requiredString("OFFICIAL_DESIGN_MODEL_PATH")
+            )
         )
     }
 

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGenerator.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGenerator.kt
@@ -5,6 +5,7 @@ import com.marmatsan.figmaDesignSync.data.fingerprint.FigmaTargetFingerprintCalc
 import com.marmatsan.figmaDesignSync.data.fingerprint.WriterScopeFingerprintCalculator
 import com.marmatsan.figmaDesignSync.data.hash.Sha256Hash
 import com.marmatsan.figmaDesignSync.data.json.CanonicalJson
+import com.marmatsan.figmaDesignSync.data.json.visual.CiVisualPlanJson
 import com.marmatsan.figmaDesignSync.data.json.writer.ExecutableRunnerManifestJson
 import com.marmatsan.figmaDesignSync.data.png.PayloadPngEncoder
 import com.marmatsan.figmaDesignSync.domain.model.writer.ExecutableRunnerManifest
@@ -305,6 +306,13 @@ class OfficialMcpRunnerGenerator(
                 put("catalogRootFilters", buildJsonObject { put(target, JsonArray(roots.map(::JsonPrimitive))) })
             }
             if (cleanupOnly) put("catalogCleanupOnlyTargets", JsonArray(listOf(JsonPrimitive(target))))
+            if (target.startsWith("ci.")) {
+                val ciConfig = context.request.config.ciVisualPlanConfig
+                    ?: throw IllegalArgumentException(
+                        "CI visual target '$target' requires CI visual plan project configuration."
+                    )
+                put("ciVisualPlan", CiVisualPlanJson.create(context.designModel, ciConfig, target))
+            }
             put("executionMetadata", executionMetadata)
         }
         return renderer.runTarget(

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/fingerprint/WriterScopeFingerprintCalculatorTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/fingerprint/WriterScopeFingerprintCalculatorTest.kt
@@ -38,6 +38,27 @@ internal class WriterScopeFingerprintCalculatorTest : FunSpec({
             root.toFile().deleteRecursively()
         }
     }
+
+    test("includes Kotlin visual planners outside the TypeScript source root") {
+        val root = Files.createTempDirectory("kotlin-writer-fingerprints")
+        try {
+            val sourceRoot = root.resolve("repo/tools/src").apply { createDirectories() }
+            sourceRoot.resolve("shared.ts").writeText("export const shared = 1;\n")
+            val kotlinPlanner = root.resolve("repo/visual/CiVisualPlanner.kt").apply {
+                parent.createDirectories()
+                writeText("class CiVisualPlanner\n")
+            }
+
+            val before = fingerprints(root, sourceRoot)
+            kotlinPlanner.writeText("class CiVisualPlannerV2\n")
+            val after = fingerprints(root, sourceRoot)
+
+            after["ci.overview"] shouldNotBe before["ci.overview"]
+            after["versions"] shouldBe before["versions"]
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
 })
 
 private fun fingerprints(repositoryRoot: java.nio.file.Path, sourceRoot: java.nio.file.Path) =
@@ -49,7 +70,7 @@ private fun fingerprints(repositoryRoot: java.nio.file.Path, sourceRoot: java.ni
             transportOnlyPaths = listOf("repo/tools/src/preview.ts"),
             modelNeutralPaths = emptyList(),
             modelContentPaths = emptyList(),
-            visualWriterPaths = listOf("repo/tools/src/*"),
+            visualWriterPaths = listOf("repo/tools/src/*", "repo/visual/*"),
             visualTargetRules = listOf(
                 FigmaVisualTargetRule(
                     paths = listOf("repo/tools/src/figma/figma-ci-*"),
@@ -58,6 +79,10 @@ private fun fingerprints(repositoryRoot: java.nio.file.Path, sourceRoot: java.ni
                 FigmaVisualTargetRule(
                     paths = listOf("repo/tools/src/figma/figma-catalog-*"),
                     targets = listOf("preflight", "waterMyPlants.libraries")
+                ),
+                FigmaVisualTargetRule(
+                    paths = listOf("repo/visual/*"),
+                    targets = listOf("ci.overview")
                 )
             )
         ),

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/json/visual/CiVisualPlanJsonTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/json/visual/CiVisualPlanJsonTest.kt
@@ -1,0 +1,79 @@
+package com.marmatsan.figmaDesignSync.data.json.visual
+
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+internal class CiVisualPlanJsonTest : FunSpec({
+    test("adapts the language-neutral design model to one target-scoped Kotlin plan") {
+        val designModel = Json.parseToJsonElement(
+            """
+            {
+              "content": {
+                "ci": {
+                  "externalTopology": {
+                    "schemaVersion": 1,
+                    "validation": {"lastValidatedOn":"2026-07-18","warnAfterDays":90},
+                    "nodes": [
+                      {"id":"operator","type":"actor","name":"Operator","description":"Starts manual actions."}
+                    ],
+                    "connections": []
+                  },
+                  "windowsRuntime": {
+                    "schemaVersion": 1,
+                    "validation": {"lastValidatedOn":"2026-07-18","warnAfterDays":90},
+                    "platform": "Windows",
+                    "services": [
+                      {
+                        "id":"teamcity-server",
+                        "name":"TeamCity Server",
+                        "description":"Hosts TeamCity.",
+                        "service":"TeamCity",
+                        "startup":"Automatic",
+                        "identity":"NT SERVICE\\\\TeamCity"
+                      }
+                    ]
+                  },
+                  "teamCity": {
+                    "vcsRoots": [],
+                    "pipelines": [
+                      {"id":"Root_Ci","name":"CI","triggers":[],"jobs":[]},
+                      {"id":"Root_FigmaSync","name":"Figma Sync","triggers":[],"jobs":[]}
+                    ]
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+        ).jsonObject
+
+        val plan = CiVisualPlanJson.create(designModel, config, "ci.windowsRuntime")
+
+        plan["parentName"]?.jsonPrimitive?.content shouldBe
+            "Continuous Integration and Design Documentation"
+        val sections = plan["sections"]!!.jsonArray
+        sections.size shouldBe 1
+        sections.single().jsonObject["target"]?.jsonPrimitive?.content shouldBe "ci.windowsRuntime"
+        val node = sections.single().jsonObject["nodes"]!!.jsonArray.single().jsonObject
+        node["environment"]?.jsonPrimitive?.content shouldBe "teamcity"
+    }
+})
+
+private val config = CiVisualPlanConfig(
+    configurationModelName = "teamCity",
+    ciPipelineName = "CI",
+    figmaPipelineName = "Figma Sync",
+    githubMainBlobUrl = "https://example.test/blob/main",
+    teamCitySource = ".teamcity/settings.kts",
+    topologySource = "docs/ci/external-topology.yaml",
+    windowsRuntimeSource = "docs/ci/windows-runtime.yaml",
+    windowsRuntimeRunbookSource = "docs/runbooks/teamcity.md",
+    visualContractSource = "docs/ci/visual-model-contract.md",
+    branchProtectionSource = "docs/ci/main-branch-protection.md",
+    officialSyncSource = "docs/runbooks/official-sync.md",
+    officialDesignModelPath = "build/reports/figma-sync/design-model.json"
+)

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGeneratorTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGeneratorTest.kt
@@ -1,6 +1,7 @@
 package com.marmatsan.figmaDesignSync.data.writer
 
 import com.marmatsan.figmaDesignSync.data.json.writer.ExecutableRunnerManifestJson
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
 import com.marmatsan.figmaDesignSync.domain.model.writer.FigmaWriterRuntimeConfig
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -30,6 +31,34 @@ internal class OfficialMcpRunnerGeneratorTest : FunSpec({
                   "waterMyPlants":{
                     "libraries":[{"group":"androidx"},{"group":"com"}]
                   }
+                },
+                "ci":{
+                  "externalTopology":{
+                    "schemaVersion":1,
+                    "validation":{"lastValidatedOn":"2026-07-18","warnAfterDays":90},
+                    "nodes":[{"id":"operator","type":"actor","name":"Operator","description":"Starts actions."}],
+                    "connections":[]
+                  },
+                  "windowsRuntime":{
+                    "schemaVersion":1,
+                    "validation":{"lastValidatedOn":"2026-07-18","warnAfterDays":90},
+                    "platform":"Windows",
+                    "services":[{
+                      "id":"teamcity-server",
+                      "name":"TeamCity Server",
+                      "description":"Hosts TeamCity.",
+                      "service":"TeamCity",
+                      "startup":"Automatic",
+                      "identity":"LocalSystem"
+                    }]
+                  },
+                  "teamCity":{
+                    "vcsRoots":[],
+                    "pipelines":[
+                      {"id":"Root_Ci","name":"CI","triggers":[],"jobs":[]},
+                      {"id":"Root_FigmaSync","name":"Figma Sync","triggers":[],"jobs":[]}
+                    ]
+                  }
                 }
               }
             }
@@ -51,7 +80,7 @@ internal class OfficialMcpRunnerGeneratorTest : FunSpec({
               "figmaTransportOnlyPaths":[],
               "figmaModelNeutralPaths":[],
               "figmaModelContentPaths":[],
-              "figmaVisualWriterPaths":[],
+              "figmaVisualWriterPaths":["repo/figma-design-sync/tools/src/*"],
               "figmaVisualTargetRules":[]
             }
             """.trimIndent()
@@ -71,14 +100,15 @@ internal class OfficialMcpRunnerGeneratorTest : FunSpec({
         val result = generator.generate(request)
 
         result.visualManifest.targets shouldContainExactly
-            listOf("preflight", "versions", "waterMyPlants.libraries")
+            listOf("preflight", "versions", "waterMyPlants.libraries", "ci.windowsRuntime")
         result.visualManifest.fullVisualSync shouldBe true
         result.visualManifest.executionScopes.values shouldContainExactly listOf(
             "preflight",
             "versions",
             "waterMyPlants.libraries.androidx",
             "waterMyPlants.libraries.com",
-            "waterMyPlants.libraries.cleanup"
+            "waterMyPlants.libraries.cleanup",
+            "ci.windowsRuntime"
         )
         result.visualManifest.payloadImage.shouldNotBeNull()
         result.metadataManifest.targets shouldContainExactly listOf("metadata")
@@ -89,10 +119,15 @@ internal class OfficialMcpRunnerGeneratorTest : FunSpec({
         val androidxSource = Files.readString(
             visualDirectory.resolve("99-02-00-waterMyPlants-libraries-androidx.mcp.js")
         )
+        val ciSource = Files.readString(
+            visualDirectory.resolve("99-03-ci-windowsRuntime.mcp.js")
+        )
         stageSource shouldContain "for (const documentPage of figma.root.children)"
         stageSource shouldContain "page.setSharedPluginData(namespace, \"script\", payload.script)"
         androidxSource shouldContain
             "\"catalogRootFilters\":{\"waterMyPlants.libraries\":[\"androidx\"]}"
+        ciSource shouldContain "\"ciVisualPlan\""
+        ciSource shouldContain "\"target\":\"ci.windowsRuntime\""
         ExecutableRunnerManifestJson().read(visualDirectory.resolve("manifest.json").toString())
             .manifestHash shouldBe result.visualManifest.manifestHash
 
@@ -118,6 +153,26 @@ private val runtimeConfig = FigmaWriterRuntimeConfig(
     mcpClientName = "test-client",
     repositoryRootRelativeToTools = "../../..",
     changeImpactPolicyRelativeToRepository = "change-impact-policy.json",
-    writerTargetNames = listOf("preflight", "versions", "waterMyPlants.libraries", "metadata"),
-    catalogTargetNames = listOf("waterMyPlants.libraries")
+    writerTargetNames = listOf(
+        "preflight",
+        "versions",
+        "waterMyPlants.libraries",
+        "ci.windowsRuntime",
+        "metadata"
+    ),
+    catalogTargetNames = listOf("waterMyPlants.libraries"),
+    ciVisualPlanConfig = CiVisualPlanConfig(
+        configurationModelName = "teamCity",
+        ciPipelineName = "CI",
+        figmaPipelineName = "Figma Sync",
+        githubMainBlobUrl = "https://example.test/blob/main",
+        teamCitySource = ".teamcity/settings.kts",
+        topologySource = "docs/ci/external-topology.yaml",
+        windowsRuntimeSource = "docs/ci/windows-runtime.yaml",
+        windowsRuntimeRunbookSource = "docs/runbooks/teamcity.md",
+        visualContractSource = "docs/ci/visual-model-contract.md",
+        branchProtectionSource = "docs/ci/main-branch-protection.md",
+        officialSyncSource = "docs/runbooks/official-sync.md",
+        officialDesignModelPath = "build/reports/figma-sync/design-model.json"
+    )
 )

--- a/repo/figma-design-sync/docs/reference/change-impact-classification.md
+++ b/repo/figma-design-sync/docs/reference/change-impact-classification.md
@@ -77,12 +77,13 @@ scope.
 
 ## Writer Scope Fingerprints
 
-The same `figmaVisualTargetRules` also classify TypeScript writer sources when
-the MCP manifest is generated. Each mapped source contributes only to the
-listed writer target fingerprints. An unmapped source under `tools/src` is
-treated as shared and contributes to every target, so changing shared node,
-text, configuration, port, or orchestration code still forces a full visual
-sync.
+The same `figmaVisualTargetRules` classify every source selected by
+`figmaVisualWriterPaths` when the MCP manifest is generated. This includes the
+TypeScript Figma boundary and Kotlin visual planners/JSON adapters outside
+`tools/src`. Each mapped source contributes only to the listed writer target
+fingerprints. An unmapped selected source is treated as shared and contributes
+to every target, so changing shared node, text, configuration, port, or
+orchestration code still forces a full visual sync.
 
 Sources explicitly classified as `figmaTransportOnlyPaths`, including the
 sandbox catalog preview entrypoint, do not contribute to official writer
@@ -90,8 +91,11 @@ fingerprints because they cannot alter the trunk writer.
 
 Catalog roots and cleanup execution scopes inherit their catalog target
 fingerprint. The global compiled `writerHash` remains the guard that detects an
-actual runtime change. If that hash changes but the scoped source fingerprints
-cannot explain it, planning fails closed to `full`.
+actual TypeScript runtime change. Scoped fingerprints are compared
+independently so a Kotlin planner or JSON adapter change still selects its
+mapped targets even when the compiled JavaScript hash is unchanged. If the
+compiled hash changes but the scoped source fingerprints cannot explain it,
+planning fails closed to `full`.
 
 Increment `WRITER_SCOPE_FINGERPRINT_SCHEMA_VERSION` whenever classification
 semantics change incompatibly. The resulting full migration sync writes a new

--- a/repo/figma-design-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-design-sync/docs/reference/visual-sync-contract.md
@@ -9,6 +9,8 @@ review-cycle-days: 90
 sources:
   - repo/figma-design-sync/tools/src
   - repo/figma-design-sync/tools/tests
+  - repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual
+  - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/visual
 ---
 
 # Figma Visual Sync Contract
@@ -21,12 +23,18 @@ what the generated Figma state must look like after the sync.
 
 ## Tooling Boundary
 
-The visual sync source of truth is TypeScript under
-`repo/figma-design-sync/tools/src/`.
+Visual planning is split by capability. Pure, deterministic plans live in
+Kotlin under `domain/service/visual`; JSON adaptation lives in
+`data/json/visual`. TypeScript under `tools/src` owns only orchestration that
+runs inside the Figma Plugin API and the concrete node, component, variable,
+text, and connector adapters.
 
 The tool source follows the same dependency direction as the Gradle sync code:
 
-- `domain` contains generated-model types and pure catalog rules.
+- Kotlin `domain` contains portable models and pure visual rules.
+- Kotlin `data` translates language-neutral JSON into those models and emits
+  target-scoped plan JSON.
+- TypeScript `domain` retains boundary types and transitional preview rules.
 - `ports` contains gateway contracts.
 - `usecases` coordinates sync behavior through those contracts.
 - `figma` contains the Figma MCP API adapters.
@@ -79,8 +87,14 @@ runner does not authorize metadata.
 
 ## CI Documentation Visual Sync
 
-The CI writer reads only `content.ci` from the official `main`
-`design-model.json`. It creates or updates one parent section named
+The Kotlin `CiVisualPlanner` reads only `content.ci` from the official `main`
+`design-model.json` through `CiVisualPlanJson`. The official runner generator
+embeds one target-scoped `ciVisualPlan` in `SYNC_OPTIONS`; the TypeScript Figma
+gateway consumes that plan and does not decide CI section structure during an
+official sync. Transitional preview runners may still calculate the same plan
+in TypeScript until preview generation is moved behind the Kotlin contract.
+
+The Figma gateway creates or updates one parent section named
 `Continuous Integration and Design Documentation` on Figma page `63153:2876`
 and exposes five independently runnable targets:
 
@@ -149,7 +163,7 @@ from component set `64361:716`. Its `environment` variant is configured directly
 on the nested instance because Figma does not promote that property to the
 parent `.ci node` component. Supported environments are `github`, `teamcity`,
 `cloudflare`, `figma`, `codex`, `browser`, `terminal`, `operator`, and `json`.
-The visual plan maps every node explicitly; there is no generic fallback. The
+The Kotlin visual plan maps every node explicitly; there is no generic fallback. The
 preflight must fail when the nested instance is absent or duplicated, belongs
 to another component set, lacks the `environment` property, or exposes a
 different set of variant values.

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -29,9 +29,11 @@ payload is too large or asset upload is unavailable.
 
 ## Build The MCP Bundle
 
-The visual sync source lives under `repo/figma-design-sync/tools/src/`.
-TypeScript is the source of truth; JavaScript is only the generated runtime
-artifact executed by Figma MCP.
+The Figma Plugin API boundary lives under
+`repo/figma-design-sync/tools/src/`. Pure CI planning lives in Kotlin and is
+embedded in the runner as `ciVisualPlan`; TypeScript consumes that plan while
+performing node mutations. JavaScript is only the generated runtime artifact
+executed by Figma MCP.
 
 ```powershell
 cd repo\figma-design-sync\tools

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/visual/CiVisualPlan.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/visual/CiVisualPlan.kt
@@ -1,0 +1,78 @@
+package com.marmatsan.figmaDesignSync.domain.model.visual
+
+/** Deterministic, Figma-independent plan for the CI documentation surface. */
+data class CiVisualPlan(
+    val parentName: String,
+    val sections: List<Section>
+) {
+    data class Section(
+        val target: String,
+        val name: String,
+        val description: String,
+        val orientation: Orientation,
+        val headerSources: List<HeaderSource>,
+        val nodes: List<Node>,
+        val connections: List<Connection>
+    )
+
+    data class HeaderSource(
+        val label: String,
+        val url: String
+    )
+
+    data class Node(
+        val id: String,
+        val type: Type,
+        val environment: Environment,
+        val name: String,
+        val description: String,
+        val steps: String?,
+        val runtime: Runtime?,
+        val source: String,
+        val sourceUrl: String,
+        val row: Int,
+        val column: Int
+    )
+
+    data class Runtime(
+        val platform: String,
+        val service: String,
+        val startup: String,
+        val identity: String
+    )
+
+    data class Connection(
+        val id: String,
+        val source: String,
+        val target: String,
+        val label: String
+    )
+
+    enum class Orientation(val wireValue: String) {
+        HORIZONTAL("horizontal"),
+        GRID("grid")
+    }
+
+    enum class Type(val wireValue: String) {
+        ACTOR("actor"),
+        SYSTEM("system"),
+        GIT_REFERENCE("git reference"),
+        PIPELINE("pipeline"),
+        JOB("job"),
+        ARTIFACT("artifact"),
+        CHECK("check"),
+        GATE("gate")
+    }
+
+    enum class Environment(val wireValue: String) {
+        GITHUB("github"),
+        TEAMCITY("teamcity"),
+        CLOUDFLARE("cloudflare"),
+        FIGMA("figma"),
+        CODEX("codex"),
+        BROWSER("browser"),
+        TERMINAL("terminal"),
+        OPERATOR("operator"),
+        JSON("json")
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/visual/CiVisualPlanConfig.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/visual/CiVisualPlanConfig.kt
@@ -1,0 +1,17 @@
+package com.marmatsan.figmaDesignSync.domain.model.visual
+
+/** Project-owned names and source links used by the portable CI visual planner. */
+data class CiVisualPlanConfig(
+    val configurationModelName: String,
+    val ciPipelineName: String,
+    val figmaPipelineName: String,
+    val githubMainBlobUrl: String,
+    val teamCitySource: String,
+    val topologySource: String,
+    val windowsRuntimeSource: String,
+    val windowsRuntimeRunbookSource: String,
+    val visualContractSource: String,
+    val branchProtectionSource: String,
+    val officialSyncSource: String,
+    val officialDesignModelPath: String
+)

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/writer/FigmaWriterProjectConfig.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/writer/FigmaWriterProjectConfig.kt
@@ -36,6 +36,7 @@ data class FigmaWriterProjectConfig(
     val headerLinkPropertyName: String,
     val githubMainBlobUrl: String,
     val githubMainTreeUrl: String,
+    val ciConfigurationModelName: String,
     val ciPipelineName: String,
     val figmaPipelineName: String,
     val teamCitySource: String,

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/writer/FigmaWriterRuntimeConfig.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/writer/FigmaWriterRuntimeConfig.kt
@@ -1,5 +1,7 @@
 package com.marmatsan.figmaDesignSync.domain.model.writer
 
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
+
 /** Small portable configuration required by runner generation and MCP execution. */
 data class FigmaWriterRuntimeConfig(
     val metadataPageId: String,
@@ -10,7 +12,8 @@ data class FigmaWriterRuntimeConfig(
     val repositoryRootRelativeToTools: String,
     val changeImpactPolicyRelativeToRepository: String,
     val writerTargetNames: List<String>,
-    val catalogTargetNames: List<String>
+    val catalogTargetNames: List<String>,
+    val ciVisualPlanConfig: CiVisualPlanConfig? = null
 ) {
     val officialStagingNamespace: String = "${metadataNamespace}_staging"
     val visualTargetNames: List<String> = writerTargetNames.filterNot { target -> target == "metadata" }

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual/CiVisualPlanner.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual/CiVisualPlanner.kt
@@ -1,0 +1,328 @@
+package com.marmatsan.figmaDesignSync.domain.service.visual
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiPipeline
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiTrigger
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlan
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
+
+/** Converts portable CI models into a deterministic visual plan without using the Figma API. */
+class CiVisualPlanner {
+    fun create(
+        externalTopology: CiExternalTopology,
+        windowsRuntime: CiWindowsRuntime,
+        configuration: CiConfiguration,
+        config: CiVisualPlanConfig
+    ): CiVisualPlan {
+        val ciPipeline = requirePipeline(configuration, config.ciPipelineName)
+        val figmaPipeline = requirePipeline(configuration, config.figmaPipelineName)
+        return CiVisualPlan(
+            parentName = "Continuous Integration and Design Documentation",
+            sections = listOf(
+                createOverviewSection(ciPipeline, figmaPipeline, config),
+                createPullRequestSection(ciPipeline, config),
+                createPostMergeSection(externalTopology, figmaPipeline, config),
+                createInfrastructureSection(externalTopology, config),
+                createWindowsRuntimeSection(windowsRuntime, config)
+            )
+        )
+    }
+
+    private fun createOverviewSection(
+        ciPipeline: CiPipeline,
+        figmaPipeline: CiPipeline,
+        config: CiVisualPlanConfig
+    ): CiVisualPlan.Section {
+        val ciCheck = publishedChecks(ciPipeline).firstOrNull() ?: "TeamCity CI"
+        val figmaCheck = publishedChecks(figmaPipeline).firstOrNull() ?: "TeamCity Figma Sync"
+        val nodes = listOf(
+            visualNode("overview-pr", CiVisualPlan.Type.GIT_REFERENCE, CiVisualPlan.Environment.GITHUB, "Pull Request", "Proposes a reviewed change to the repository.", config.branchProtectionSource, 0, 0, config),
+            pipelineNode("overview-ci", ciPipeline, 1, 0, config),
+            visualNode("overview-ci-check", CiVisualPlan.Type.CHECK, CiVisualPlan.Environment.TEAMCITY, ciCheck, "Reports CI verification to GitHub.", config.teamCitySource, 2, 0, config),
+            visualNode("overview-gate", CiVisualPlan.Type.GATE, CiVisualPlan.Environment.GITHUB, "Pull request merge gate", "Requires the CI check before merge.", config.branchProtectionSource, 3, 0, config),
+            visualNode("overview-main", CiVisualPlan.Type.GIT_REFERENCE, CiVisualPlan.Environment.GITHUB, "main", "Stable trunk after the reviewed merge.", config.branchProtectionSource, 4, 0, config),
+            pipelineNode("overview-figma", figmaPipeline, 5, 0, config),
+            visualNode("overview-model", CiVisualPlan.Type.ARTIFACT, CiVisualPlan.Environment.JSON, "design-model.json", "Carries the repository documentation snapshot.", config.teamCitySource, 6, 0, config),
+            visualNode("overview-figma-check", CiVisualPlan.Type.CHECK, CiVisualPlan.Environment.TEAMCITY, figmaCheck, "Reports whether Figma metadata matches main.", config.teamCitySource, 7, 0, config)
+        )
+        return section(
+            target = "ci.overview",
+            name = "Overview",
+            description = "Simplified pull request and post-merge design documentation journeys.",
+            sources = listOf(config.visualContractSource),
+            orientation = CiVisualPlan.Orientation.HORIZONTAL,
+            nodes = nodes,
+            connections = listOf(
+                connection("overview-pr-trigger", "overview-pr", "overview-ci", triggerLabel(ciPipeline)),
+                connection("overview-ci-check", "overview-ci", "overview-ci-check", "Publish check"),
+                connection("overview-check-gate", "overview-ci-check", "overview-gate", "Required check"),
+                connection("overview-gate-main", "overview-gate", "overview-main", "Merge"),
+                connection("overview-main-figma", "overview-main", "overview-figma", triggerLabel(figmaPipeline)),
+                connection("overview-figma-model", "overview-figma", "overview-model", "Generate and publish"),
+                connection("overview-model-check", "overview-model", "overview-figma-check", "Verify model hash")
+            ),
+            config = config
+        )
+    }
+
+    private fun createPullRequestSection(
+        pipeline: CiPipeline,
+        config: CiVisualPlanConfig
+    ): CiVisualPlan.Section {
+        val nodes = mutableListOf(
+            visualNode("pr", CiVisualPlan.Type.GIT_REFERENCE, CiVisualPlan.Environment.GITHUB, "Pull Request", "Contains the branch revision proposed for main.", config.branchProtectionSource, 0, 0, config),
+            pipelineNode("pipeline-${pipeline.id}", pipeline, 1, 0, config)
+        )
+        pipeline.jobs.forEachIndexed { index, job -> nodes += jobNode("job-${job.id}", job, 2 + index, 0, config) }
+        val checks = publishedChecks(pipeline)
+        checks.forEachIndexed { index, check ->
+            nodes += visualNode("check-$index", CiVisualPlan.Type.CHECK, CiVisualPlan.Environment.TEAMCITY, check, "Publishes the CI result to GitHub.", config.teamCitySource, 2 + pipeline.jobs.size, index, config)
+        }
+        nodes += visualNode("merge-gate", CiVisualPlan.Type.GATE, CiVisualPlan.Environment.GITHUB, "Pull request merge gate", "Requires TeamCity CI before merging.", config.branchProtectionSource, 3 + pipeline.jobs.size, 0, config)
+        nodes += visualNode("main", CiVisualPlan.Type.GIT_REFERENCE, CiVisualPlan.Environment.GITHUB, "main", "Receives the reviewed change after the gate passes.", config.branchProtectionSource, 4 + pipeline.jobs.size, 0, config)
+
+        val connections = mutableListOf(connection("pr-trigger", "pr", "pipeline-${pipeline.id}", triggerLabel(pipeline)))
+        pipeline.jobs.forEachIndexed { index, job ->
+            connections += connection(
+                "pipeline-job-${job.id}",
+                if (index == 0) "pipeline-${pipeline.id}" else "job-${pipeline.jobs[index - 1].id}",
+                "job-${job.id}",
+                if (index == 0) "Run pipeline" else "Continue"
+            )
+        }
+        checks.forEachIndexed { index, _ ->
+            connections += connection("job-check-$index", pipeline.jobs.lastOrNull()?.let { "job-${it.id}" } ?: "pipeline-${pipeline.id}", "check-$index", "Publish check")
+            connections += connection("check-gate-$index", "check-$index", "merge-gate", "Required check")
+        }
+        connections += connection("gate-main", "merge-gate", "main", "Merge")
+        return section("ci.pullRequestIntegration", "Pull Request Integration", "Detailed merge-gate flow derived from the effective CI pipeline.", listOf(config.teamCitySource, config.branchProtectionSource), CiVisualPlan.Orientation.HORIZONTAL, nodes, connections, config)
+    }
+
+    private fun createPostMergeSection(
+        topology: CiExternalTopology,
+        pipeline: CiPipeline,
+        config: CiVisualPlanConfig
+    ): CiVisualPlan.Section {
+        val externalById = topology.nodes.associateBy(CiNode::id)
+        val operator = externalById["operator"]
+        val codex = externalById["codex-mcp-client"]
+        val figmaDocument = externalById["figma-design-document"]
+        val artifactJob = pipeline.jobs.find { job ->
+            job.artifacts.any { artifact -> artifactPathContains(artifact.path, config.officialDesignModelPath) }
+        }
+        val checkJob = artifactJob?.let { generated ->
+            pipeline.jobs.find { job ->
+                job.dependencies.any { dependency ->
+                    dependency.jobId == generated.id && dependency.artifactPaths.any { path ->
+                        artifactPathContains(path, config.officialDesignModelPath)
+                    }
+                }
+            }
+        }
+        val orderedJobs = listOfNotNull(artifactJob, checkJob) + pipeline.jobs.filter { job ->
+            job.id != artifactJob?.id && job.id != checkJob?.id
+        }
+        val jobRows = orderedJobs.mapIndexed { index, job -> job.id to 2 + index * 2 }.toMap()
+        val nodes = mutableListOf(
+            visualNode("main", CiVisualPlan.Type.GIT_REFERENCE, CiVisualPlan.Environment.GITHUB, "main", "Starts documentation verification after successful CI.", config.teamCitySource, 0, 0, config),
+            pipelineNode("pipeline-${pipeline.id}", pipeline, 1, 0, config)
+        )
+        pipeline.jobs.forEachIndexed { index, job ->
+            nodes += jobNode("job-${job.id}", job, jobRows[job.id] ?: 2 + index * 2, 0, config)
+        }
+        val artifactRow = artifactJob?.let { (jobRows[it.id] ?: 2) + 1 } ?: 2
+        nodes += visualNode("design-model", CiVisualPlan.Type.ARTIFACT, CiVisualPlan.Environment.JSON, "design-model.json", "Official repository snapshot consumed by visual synchronization.", config.teamCitySource, artifactRow, 0, config)
+        val checkRow = maxOf(2 + pipeline.jobs.size * 2, nodes.maxOf { node -> node.row + 1 })
+        val checks = publishedChecks(pipeline)
+        checks.forEachIndexed { index, check ->
+            nodes += visualNode("figma-check-$index", CiVisualPlan.Type.CHECK, CiVisualPlan.Environment.TEAMCITY, check, "Publishes the post-merge documentation result.", config.teamCitySource, checkRow, index, config)
+        }
+        operator?.let { nodes += externalNode("operator", it, checkRow + 1, 0, config) }
+        codex?.let { nodes += externalNode("codex", it, checkRow + 2, 0, config) }
+        figmaDocument?.let { nodes += externalNode("figma-document", it, checkRow + 3, 0, config) }
+
+        val connections = mutableListOf(connection("main-trigger", "main", "pipeline-${pipeline.id}", triggerLabel(pipeline)))
+        artifactJob?.let {
+            connections += connection("pipeline-generate", "pipeline-${pipeline.id}", "job-${it.id}", "Run pipeline")
+            connections += connection("generate-artifact", "job-${it.id}", "design-model", "Publish artifact")
+        }
+        checkJob?.let { connections += connection("artifact-check", "design-model", "job-${it.id}", "Consume artifact") }
+        checks.forEachIndexed { index, _ ->
+            connections += connection("check-status-$index", checkJob?.let { "job-${it.id}" } ?: "pipeline-${pipeline.id}", "figma-check-$index", "Publish status")
+        }
+        if (operator != null && checks.isNotEmpty()) connections += connection("mismatch-operator", "figma-check-0", "operator", "Mismatch requires action")
+        if (operator != null && codex != null) connections += connection("operator-codex", "operator", "codex", "Request visual synchronization")
+        if (codex != null && figmaDocument != null) connections += connection("codex-figma", "codex", "figma-document", "Apply visual changes")
+        if (figmaDocument != null && checkJob != null) connections += connection("rerun", "figma-document", "job-${checkJob.id}", "Rerun via HTTPS client")
+        return section("ci.postMergeDesignDocumentation", "Post-merge Design Documentation", "Official model generation, visual synchronization, and verification loop.", listOf(config.teamCitySource, config.officialSyncSource), CiVisualPlan.Orientation.HORIZONTAL, nodes, connections, config)
+    }
+
+    private fun createInfrastructureSection(
+        topology: CiExternalTopology,
+        config: CiVisualPlanConfig
+    ): CiVisualPlan.Section {
+        val placement = infrastructurePlacement()
+        val nodes = topology.nodes.mapIndexed { index, node ->
+            val position = placement[node.id] ?: Position(index, 0)
+            externalNode("external-${node.id}", node, position.row, position.column, config)
+        }
+        val nodeIds = topology.nodes.associate { node -> node.id to "external-${node.id}" }
+        val connections = topology.connections.map { edge ->
+            connection("external-${edge.id}", nodeIds[edge.sourceNodeId], nodeIds[edge.targetNodeId], edge.label)
+        }
+        return section("ci.infrastructureAndAccess", "Infrastructure and Access", "External systems, trust boundaries, authentication paths, and automation modes.", listOf(config.topologySource, "docs/ci/external-topology-validation.md"), CiVisualPlan.Orientation.GRID, nodes, connections, config)
+    }
+
+    private fun createWindowsRuntimeSection(
+        runtime: CiWindowsRuntime,
+        config: CiVisualPlanConfig
+    ): CiVisualPlan.Section {
+        val nodes = runtime.services.mapIndexed { index, service ->
+            visualNode("windows-runtime-${service.id}", CiVisualPlan.Type.SYSTEM, windowsRuntimeEnvironment(service.id), service.name, service.description, config.windowsRuntimeSource, 0, index, config).copy(
+                runtime = CiVisualPlan.Runtime(runtime.platform, service.service, service.startup, service.identity)
+            )
+        }
+        return section("ci.windowsRuntime", "Windows Service Runtime", "Versioned inventory of the Windows services that host the local CI runtime.", listOf(config.windowsRuntimeSource, config.windowsRuntimeRunbookSource), CiVisualPlan.Orientation.GRID, nodes, emptyList(), config)
+    }
+
+    private fun section(
+        target: String,
+        name: String,
+        description: String,
+        sources: List<String>,
+        orientation: CiVisualPlan.Orientation,
+        nodes: List<CiVisualPlan.Node>,
+        connections: List<CiVisualPlan.Connection>,
+        config: CiVisualPlanConfig
+    ) = CiVisualPlan.Section(target, name, description, orientation, sources.map { source -> CiVisualPlan.HeaderSource(source, sourceUrl(source, config)) }, nodes, connections)
+
+    private fun pipelineNode(id: String, pipeline: CiPipeline, row: Int, column: Int, config: CiVisualPlanConfig) =
+        visualNode(id, CiVisualPlan.Type.PIPELINE, CiVisualPlan.Environment.TEAMCITY, pipeline.name, pipelineDescription(pipeline.name, config), config.teamCitySource, row, column, config)
+
+    private fun jobNode(id: String, job: CiJob, row: Int, column: Int, config: CiVisualPlanConfig) =
+        visualNode(id, CiVisualPlan.Type.JOB, CiVisualPlan.Environment.TEAMCITY, job.name, jobDescription(job.name), config.teamCitySource, row, column, config).copy(
+            steps = job.steps.map { step -> summarizeCommand(step.command, step.name) }.joinToString("\n").ifEmpty { null }
+        )
+
+    private fun externalNode(id: String, node: CiNode, row: Int, column: Int, config: CiVisualPlanConfig) =
+        visualNode(id, node.type.toVisualType(), externalEnvironment(node.id), node.name, node.description, config.topologySource, row, column, config)
+
+    private fun visualNode(
+        id: String,
+        type: CiVisualPlan.Type,
+        environment: CiVisualPlan.Environment,
+        name: String,
+        description: String,
+        source: String,
+        row: Int,
+        column: Int,
+        config: CiVisualPlanConfig
+    ) = CiVisualPlan.Node(id, type, environment, name, description, null, null, source, sourceUrl(source, config), row, column)
+
+    private fun connection(id: String, source: String?, target: String?, label: String): CiVisualPlan.Connection {
+        require(source != null && target != null) { "CI visual connection '$id' has an unknown endpoint." }
+        return CiVisualPlan.Connection(id, source, target, label)
+    }
+
+    private fun publishedChecks(pipeline: CiPipeline) = pipeline.jobs.flatMap(CiJob::publishedChecks).map(CiJob.PublishedCheck::name)
+
+    fun artifactPathContains(publishedPath: String, requiredFile: String): Boolean {
+        val normalizedPublishedPath = normalizeArtifactPath(publishedPath)
+        val normalizedRequiredFile = normalizeArtifactPath(requiredFile)
+        return normalizedPublishedPath == normalizedRequiredFile || normalizedRequiredFile.startsWith("$normalizedPublishedPath/")
+    }
+
+    private fun normalizeArtifactPath(path: String): String = path
+        .substringBefore("=>")
+        .trim()
+        .replace('\\', '/')
+        .replace(Regex("/(?:\\*\\*?|\\*\\.\\*)$"), "")
+        .removeSuffix("/")
+
+    private fun requirePipeline(configuration: CiConfiguration, name: String): CiPipeline =
+        configuration.pipelines.find { pipeline -> pipeline.name == name }
+            ?: throw IllegalArgumentException("Effective CI configuration is missing pipeline '$name'.")
+
+    private fun triggerLabel(pipeline: CiPipeline): String {
+        val trigger = pipeline.triggers.firstOrNull() ?: return "Run manually"
+        return when (trigger.type) {
+            CiTrigger.Type.Vcs -> "VCS trigger ${trigger.branchFilter.orEmpty()}".trim()
+            CiTrigger.Type.PipelineFinish -> "After ${trigger.dependencyPipelineId ?: "pipeline"} succeeds"
+            CiTrigger.Type.Schedule -> trigger.type.serializedName
+        }
+    }
+
+    private fun summarizeCommand(command: String, fallback: String): String = when {
+        "teamcity-configs:generate" in command -> "Generate effective TeamCity configuration"
+        "generateFigmaDesignModel" in command -> "Generate design model"
+        "checkFigmaTrunkSync" in command -> "Check Figma trunk sync"
+        Regex("gradlew(?:\\.bat)?\\s+check(?:\\s|$)", RegexOption.IGNORE_CASE).containsMatchIn(command) -> "Gradle check"
+        else -> fallback
+    }
+
+    private fun pipelineDescription(name: String, config: CiVisualPlanConfig): String =
+        if (name == config.ciPipelineName) "Validates pull requests and branch revisions before merge."
+        else "Verifies post-merge Figma documentation against main."
+
+    private fun jobDescription(name: String): String = when (name) {
+        "Verify" -> "Runs repository verification and publishes the required CI check."
+        "Generate main design model" -> "Builds and publishes the official design-model.json artifact."
+        "Check Figma trunk sync" -> "Compares current Figma metadata with the official model hash."
+        else -> "Executes an effective TeamCity pipeline job."
+    }
+
+    fun externalEnvironment(id: String): CiVisualPlan.Environment = externalEnvironments[id]
+        ?: throw IllegalArgumentException("External CI node '$id' has no .ci icon environment mapping.")
+
+    fun windowsRuntimeEnvironment(id: String): CiVisualPlan.Environment = windowsRuntimeEnvironments[id]
+        ?: throw IllegalArgumentException("Windows CI runtime service '$id' has no .ci icon environment mapping.")
+
+    private fun sourceUrl(source: String, config: CiVisualPlanConfig) = "${config.githubMainBlobUrl}/$source"
+
+    private fun CiNode.Type.toVisualType(): CiVisualPlan.Type = CiVisualPlan.Type.entries.single { type ->
+        type.wireValue == serializedName
+    }
+
+    private fun infrastructurePlacement() = mapOf(
+        "browser" to Position(0, 0),
+        "teamcity-cli" to Position(0, 1),
+        "github-app" to Position(0, 2),
+        "operator" to Position(0, 3),
+        "cloudflare-access" to Position(1, 1),
+        "cloudflare-tunnel" to Position(2, 1),
+        "teamcity-server" to Position(3, 1),
+        "github-repository" to Position(3, 2),
+        "build-agent" to Position(4, 1),
+        "codex-mcp-client" to Position(4, 3),
+        "figma-api" to Position(5, 2),
+        "figma-design-document" to Position(6, 2)
+    )
+
+    private data class Position(val row: Int, val column: Int)
+
+    private companion object {
+        val externalEnvironments = mapOf(
+            "operator" to CiVisualPlan.Environment.OPERATOR,
+            "browser" to CiVisualPlan.Environment.BROWSER,
+            "teamcity-cli" to CiVisualPlan.Environment.TERMINAL,
+            "github-repository" to CiVisualPlan.Environment.GITHUB,
+            "github-app" to CiVisualPlan.Environment.GITHUB,
+            "cloudflare-access" to CiVisualPlan.Environment.CLOUDFLARE,
+            "cloudflare-tunnel" to CiVisualPlan.Environment.CLOUDFLARE,
+            "teamcity-server" to CiVisualPlan.Environment.TEAMCITY,
+            "build-agent" to CiVisualPlan.Environment.TEAMCITY,
+            "codex-mcp-client" to CiVisualPlan.Environment.CODEX,
+            "figma-api" to CiVisualPlan.Environment.FIGMA,
+            "figma-design-document" to CiVisualPlan.Environment.FIGMA
+        )
+        val windowsRuntimeEnvironments = mapOf(
+            "teamcity-server" to CiVisualPlan.Environment.TEAMCITY,
+            "build-agent" to CiVisualPlan.Environment.TEAMCITY,
+            "cloudflare-tunnel" to CiVisualPlan.Environment.CLOUDFLARE
+        )
+    }
+}

--- a/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/writer/VisualSyncPlanner.kt
+++ b/repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/writer/VisualSyncPlanner.kt
@@ -59,7 +59,14 @@ class VisualSyncPlanner(
         }
 
         val modelChanged = previousMetadata.modelHash != manifest.modelHash
-        val writerChanged = previousMetadata.writerHash != manifest.writerHash
+        val compiledWriterChanged = previousMetadata.writerHash != manifest.writerHash
+        val writerChangedScopes = allScopes.filter { scope ->
+            manifest.writerScopeFingerprints[scope] !=
+                previousMetadata.writerScopeFingerprints?.get(scope)
+        }
+        val metadataWriterChanged = manifest.writerScopeFingerprints["metadata"] !=
+            previousMetadata.writerScopeFingerprints?.get("metadata")
+        val writerChanged = compiledWriterChanged || writerChangedScopes.isNotEmpty() || metadataWriterChanged
         if (!modelChanged && !writerChanged) {
             return plan(VisualSyncDecision.NONE, "visual-input-unchanged", identity, emptyList(), manifest)
         }
@@ -82,18 +89,7 @@ class VisualSyncPlanner(
             )
         }
 
-        val writerChangedScopes = if (writerChanged) {
-            allScopes.filter { scope ->
-                manifest.writerScopeFingerprints[scope] !=
-                    previousMetadata.writerScopeFingerprints?.get(scope)
-            }
-        } else {
-            emptyList()
-        }
-        val metadataWriterChanged = writerChanged &&
-            manifest.writerScopeFingerprints["metadata"] !=
-            previousMetadata.writerScopeFingerprints?.get("metadata")
-        if (writerChanged && writerChangedScopes.isEmpty() && !metadataWriterChanged) {
+        if (compiledWriterChanged && writerChangedScopes.isEmpty() && !metadataWriterChanged) {
             return plan(
                 VisualSyncDecision.FULL,
                 "writer-changed-outside-known-scope-fingerprints",

--- a/repo/figma-design-sync/domain/src/test/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual/CiVisualPlannerTest.kt
+++ b/repo/figma-design-sync/domain/src/test/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual/CiVisualPlannerTest.kt
@@ -1,0 +1,181 @@
+package com.marmatsan.figmaDesignSync.domain.service.visual
+
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConfiguration
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiConnection
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiExternalTopology
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiJob
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiNode
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiPipeline
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiTrigger
+import com.marmatsan.figmaDesignSync.domain.model.ci.CiWindowsRuntime
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlan
+import com.marmatsan.figmaDesignSync.domain.model.visual.CiVisualPlanConfig
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.time.LocalDate
+
+internal class CiVisualPlannerTest : FunSpec({
+    val planner = CiVisualPlanner()
+
+    test("creates the five CI documentation sections from portable models") {
+        val plan = planner.create(topology(), windowsRuntime(), configuration(), visualConfig)
+
+        plan.parentName shouldBe "Continuous Integration and Design Documentation"
+        plan.sections.map(CiVisualPlan.Section::target) shouldContainExactly listOf(
+            "ci.overview",
+            "ci.pullRequestIntegration",
+            "ci.postMergeDesignDocumentation",
+            "ci.infrastructureAndAccess",
+            "ci.windowsRuntime"
+        )
+        plan.sections.map(CiVisualPlan.Section::orientation) shouldContainExactly listOf(
+            CiVisualPlan.Orientation.HORIZONTAL,
+            CiVisualPlan.Orientation.HORIZONTAL,
+            CiVisualPlan.Orientation.HORIZONTAL,
+            CiVisualPlan.Orientation.GRID,
+            CiVisualPlan.Orientation.GRID
+        )
+    }
+
+    test("summarizes post-merge jobs and connects the official model flow") {
+        val section = planner.create(topology(), windowsRuntime(), configuration(), visualConfig)
+            .sections.single { it.target == "ci.postMergeDesignDocumentation" }
+
+        section.nodes.single { it.name == "Generate main design model" }.steps shouldBe
+            "Generate effective TeamCity configuration\nGenerate design model"
+        section.connections
+            .filter { it.id in setOf("pipeline-generate", "generate-artifact", "artifact-check") }
+            .map { it.source to it.target } shouldContainExactly listOf(
+                "pipeline-Root_FigmaSync" to "job-generate",
+                "job-generate" to "design-model",
+                "design-model" to "job-check"
+            )
+        section.connections.map(CiVisualPlan.Connection::label).contains("Rerun via HTTPS client") shouldBe true
+    }
+
+    test("maps explicit external and Windows environments") {
+        planner.externalEnvironment("operator") shouldBe CiVisualPlan.Environment.OPERATOR
+        planner.externalEnvironment("codex-mcp-client") shouldBe CiVisualPlan.Environment.CODEX
+        planner.windowsRuntimeEnvironment("cloudflare-tunnel") shouldBe CiVisualPlan.Environment.CLOUDFLARE
+        shouldThrow<IllegalArgumentException> { planner.externalEnvironment("unknown") }
+            .message shouldContain "no .ci icon environment mapping"
+    }
+
+    test("normalizes TeamCity artifact publication paths") {
+        planner.artifactPathContains(
+            "build\\reports\\figma-sync\\** => figma-sync",
+            "build/reports/figma-sync/design-model.json"
+        ) shouldBe true
+        planner.artifactPathContains(
+            "build/reports/unrelated",
+            "build/reports/figma-sync/design-model.json"
+        ) shouldBe false
+    }
+})
+
+private fun configuration() = CiConfiguration(
+    pipelines = listOf(
+        CiPipeline(
+            id = "Root_Ci",
+            name = "CI",
+            triggers = listOf(CiTrigger(CiTrigger.Type.Vcs, "+:*", null, null)),
+            jobs = listOf(
+                job(
+                    id = "verify",
+                    name = "Verify",
+                    steps = listOf(CiJob.Step("RUNNER_1", "Run Gradle check", ".\\gradlew.bat check")),
+                    checks = listOf(CiJob.PublishedCheck("TeamCity CI"))
+                )
+            )
+        ),
+        CiPipeline(
+            id = "Root_FigmaSync",
+            name = "Figma Sync",
+            triggers = listOf(CiTrigger(CiTrigger.Type.PipelineFinish, null, "Root_Ci", true)),
+            jobs = listOf(
+                job(
+                    id = "check",
+                    name = "Check Figma trunk sync",
+                    steps = listOf(CiJob.Step("RUNNER_1", "Check", ".\\gradlew.bat checkFigmaTrunkSync")),
+                    dependencies = listOf(CiJob.Dependency("generate", listOf("build/reports/figma-sync"))),
+                    checks = listOf(CiJob.PublishedCheck("TeamCity Figma Sync"))
+                ),
+                job(
+                    id = "generate",
+                    name = "Generate main design model",
+                    steps = listOf(
+                        CiJob.Step("RUNNER_1", "Generate config", ".\\mvnw.cmd teamcity-configs:generate"),
+                        CiJob.Step("RUNNER_2", "Generate model", ".\\gradlew.bat generateFigmaDesignModel")
+                    ),
+                    artifacts = listOf(CiJob.Artifact("build/reports/figma-sync", true, true))
+                )
+            )
+        )
+    ),
+    vcsRoots = emptyList()
+)
+
+private fun job(
+    id: String,
+    name: String,
+    steps: List<CiJob.Step>,
+    artifacts: List<CiJob.Artifact> = emptyList(),
+    dependencies: List<CiJob.Dependency> = emptyList(),
+    checks: List<CiJob.PublishedCheck> = emptyList()
+) = CiJob(id, name, steps, emptyList(), artifacts, dependencies, checks)
+
+private fun topology() = CiExternalTopology(
+    schemaVersion = 1,
+    validation = CiExternalTopology.Validation(LocalDate.parse("2026-07-18"), 90),
+    nodes = listOf(
+        CiNode("operator", CiNode.Type.Actor, "Operator", "Starts manual actions."),
+        CiNode("cloudflare-access", CiNode.Type.System, "Cloudflare Access", "Applies access policy."),
+        CiNode("teamcity-server", CiNode.Type.System, "TeamCity Server", "Orchestrates pipelines."),
+        CiNode("codex-mcp-client", CiNode.Type.System, "Codex/MCP Client", "Applies visual changes."),
+        CiNode("figma-design-document", CiNode.Type.System, "Figma Design Document", "Stores visual documentation.")
+    ),
+    connections = listOf(
+        CiConnection(
+            id = "operator-access",
+            sourceNodeId = "operator",
+            targetNodeId = "cloudflare-access",
+            label = "Open TeamCity",
+            description = "Open protected TeamCity.",
+            protocol = "HTTPS",
+            authentication = emptyList(),
+            policy = null,
+            path = null,
+            automation = CiConnection.Automation.Manual,
+            annotation = null
+        )
+    )
+)
+
+private fun windowsRuntime() = CiWindowsRuntime(
+    schemaVersion = 1,
+    validation = CiWindowsRuntime.Validation(LocalDate.parse("2026-07-18"), 90),
+    platform = "Windows",
+    services = listOf(
+        CiWindowsRuntime.Service("teamcity-server", "TeamCity Server", "Hosts TeamCity.", "TeamCity", "Automatic", "NT SERVICE\\TeamCity"),
+        CiWindowsRuntime.Service("build-agent", "Build Agent", "Runs builds.", "TCBuildAgent", "Automatic", "NT SERVICE\\TCBuildAgent"),
+        CiWindowsRuntime.Service("cloudflare-tunnel", "Cloudflare Tunnel", "Publishes TeamCity.", "Cloudflared", "Automatic", "LocalSystem")
+    )
+)
+
+private val visualConfig = CiVisualPlanConfig(
+    configurationModelName = "teamCity",
+    ciPipelineName = "CI",
+    figmaPipelineName = "Figma Sync",
+    githubMainBlobUrl = "https://github.com/marmatsan/water-my-plants/blob/main",
+    teamCitySource = ".teamcity/settings.kts",
+    topologySource = "docs/ci/external-topology.yaml",
+    windowsRuntimeSource = "docs/ci/windows-runtime.yaml",
+    windowsRuntimeRunbookSource = "docs/runbooks/teamcity-cloudflare-access.md",
+    visualContractSource = "docs/ci/visual-model-contract.md",
+    branchProtectionSource = "docs/ci/main-branch-protection.md",
+    officialSyncSource = "repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md",
+    officialDesignModelPath = "build/reports/figma-sync/design-model.json"
+)

--- a/repo/figma-design-sync/domain/src/test/kotlin/com/marmatsan/figmaDesignSync/domain/service/writer/VisualSyncPlannerTest.kt
+++ b/repo/figma-design-sync/domain/src/test/kotlin/com/marmatsan/figmaDesignSync/domain/service/writer/VisualSyncPlannerTest.kt
@@ -52,6 +52,20 @@ internal class VisualSyncPlannerTest : FunSpec({
         plan.body.executionScopes.shouldContainExactly("preflight", "waterMyPlants.libraries.androidx")
     }
 
+    test("Kotlin planner changes select their scope even when the compiled TypeScript hash is unchanged") {
+        val previous = previousMetadata().copy(
+            writerScopeFingerprints = previousMetadata().writerScopeFingerprints?.plus(
+                "waterMyPlants.libraries.androidx" to "sha256:catalog-writer-old"
+            )
+        )
+
+        val plan = planner.create(manifest, previous)
+
+        plan.body.decision shouldBe VisualSyncDecision.PARTIAL
+        plan.body.reason shouldBe "writer-scope-fingerprints-changed"
+        plan.body.executionScopes.shouldContainExactly("preflight", "waterMyPlants.libraries.androidx")
+    }
+
     test("metadata-only writer changes still create a partial metadata plan") {
         val previous = previousMetadata().copy(
             writerHash = "sha256:writer-old",

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
@@ -91,6 +91,7 @@ internal object WaterMyPlantsFigmaWriterProjectConfig {
         headerLinkPropertyName = "Link",
         githubMainBlobUrl = GITHUB_MAIN_BLOB_URL,
         githubMainTreeUrl = GITHUB_MAIN_TREE_URL,
+        ciConfigurationModelName = "teamCity",
         ciPipelineName = "CI",
         figmaPipelineName = "Figma Sync",
         teamCitySource = ".teamcity/settings.kts",

--- a/repo/figma-design-sync/project-config/src/test/kotlin/com/marmatsan/figmaDesignSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
+++ b/repo/figma-design-sync/project-config/src/test/kotlin/com/marmatsan/figmaDesignSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
@@ -21,6 +21,7 @@ internal class FigmaWriterProjectConfigJsonTest : FunSpec({
         root.getValue("OFFICIAL_STAGING_NAMESPACE").jsonPrimitive.content shouldBe
             "water_my_plants_sync_staging"
         root.getValue("PROJECT_VERSION_COMPONENT_ID").jsonPrimitive.content shouldBe "63075:591"
+        root.getValue("CI_CONFIGURATION_MODEL_NAME").jsonPrimitive.content shouldBe "teamCity"
         root.getValue("CATALOG_TARGET_NAMES").jsonArray.map { it.jsonPrimitive.content }
             .shouldContainExactly(
                 "waterMyPlants.libraries",
@@ -79,6 +80,7 @@ internal class FigmaWriterProjectConfigJsonTest : FunSpec({
             "HEADER_LINK_PROPERTY_NAME",
             "GITHUB_MAIN_BLOB_URL",
             "GITHUB_MAIN_TREE_URL",
+            "CI_CONFIGURATION_MODEL_NAME",
             "CI_PIPELINE_NAME",
             "FIGMA_PIPELINE_NAME",
             "TEAMCITY_SOURCE",

--- a/repo/figma-design-sync/project-config/water-my-plants/change-impact-policy.json
+++ b/repo/figma-design-sync/project-config/water-my-plants/change-impact-policy.json
@@ -61,6 +61,9 @@
   ],
   "figmaVisualWriterPaths": [
     "repo/figma-design-sync/tools/src/*",
+    "repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/visual/*",
+    "repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual/*",
+    "repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/visual/*",
     "repo/figma-design-sync/project-config/water-my-plants/figma-config.ts"
   ],
   "figmaVisualTargetRules": [
@@ -81,7 +84,13 @@
       "targets": ["headers"]
     },
     {
-      "paths": ["repo/figma-design-sync/tools/src/figma/figma-ci-*", "repo/figma-design-sync/tools/src/domain/ci/*"],
+      "paths": [
+        "repo/figma-design-sync/tools/src/figma/figma-ci-*",
+        "repo/figma-design-sync/tools/src/domain/ci/*",
+        "repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/model/visual/*",
+        "repo/figma-design-sync/domain/src/main/kotlin/com/marmatsan/figmaDesignSync/domain/service/visual/*",
+        "repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/json/visual/*"
+      ],
       "targets": ["ci.overview", "ci.pullRequestIntegration", "ci.postMergeDesignDocumentation", "ci.infrastructureAndAccess", "ci.windowsRuntime"]
     },
     {

--- a/repo/figma-design-sync/project-config/water-my-plants/figma-config.ts
+++ b/repo/figma-design-sync/project-config/water-my-plants/figma-config.ts
@@ -83,6 +83,7 @@ export const HEADER_LINK_PROPERTY_NAME = "Link";
 
 export const GITHUB_MAIN_BLOB_URL = "https://github.com/marmatsan/water-my-plants/blob/main";
 export const GITHUB_MAIN_TREE_URL = "https://github.com/marmatsan/water-my-plants/tree/main";
+export const CI_CONFIGURATION_MODEL_NAME = "teamCity";
 export const CI_PIPELINE_NAME = "CI";
 export const FIGMA_PIPELINE_NAME = "Figma Sync";
 export const TEAMCITY_SOURCE = ".teamcity/settings.kts";

--- a/repo/figma-design-sync/tools/src/domain/design-model.ts
+++ b/repo/figma-design-sync/tools/src/domain/design-model.ts
@@ -37,6 +37,7 @@ export type SyncFigmaDesignModelOptions = {
   sectionNodeOverrides?: Record<string, string>;
   catalogRootFilters?: Partial<Record<SyncTargetName, string[]>>;
   catalogCleanupOnlyTargets?: SyncTargetName[];
+  ciVisualPlan?: import("./ci/create-ci-visual-plan").CiVisualPlan;
   executionMetadata?: SyncExecutionMetadata;
 };
 

--- a/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-design-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -21,6 +21,7 @@ import {
   type CiVisualConnection,
   type CiVisualNode,
   type CiVisualOrientation,
+  type CiVisualPlan,
   type CiVisualSection,
 } from "../domain/ci/create-ci-visual-plan";
 import type { DesignModel } from "../domain/design-model";
@@ -55,13 +56,17 @@ const CONNECTOR_LABEL_COLLISION_GAP = 16;
 const CONNECTOR_LABEL_MAX_TEXT_WIDTH = 280;
 
 export class FigmaCiDocumentationSyncGateway implements CiDocumentationSyncGateway {
-  async syncCiDocumentation(designModel: DesignModel, targetNames: string[]) {
+  async syncCiDocumentation(
+    designModel: DesignModel,
+    targetNames: string[],
+    visualPlan?: CiVisualPlan
+  ) {
     const unknownTargets = targetNames.filter((target) => !CI_VISUAL_TARGET_NAMES.includes(target as any));
     if (unknownTargets.length > 0) {
       throw new Error(`Unknown CI documentation target(s): ${unknownTargets.join(", ")}.`);
     }
 
-    const plan = createCiVisualPlan(designModel);
+    const plan = visualPlan ?? createCiVisualPlan(designModel);
     const page = await requirePage(CI_DOCUMENTATION_PAGE_ID);
     const nodeComponent = await requireComponent(CI_NODE_COMPONENT_ID);
     const modeCollection = await requireVariableCollection(CI_VARIABLE_COLLECTION_NAME);

--- a/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
+++ b/repo/figma-design-sync/tools/src/ports/sync-gateways.ts
@@ -74,7 +74,11 @@ export type CatalogTreeSyncGateway = {
 };
 
 export type CiDocumentationSyncGateway = {
-  syncCiDocumentation(designModel: DesignModel, targetNames: string[]): Promise<CiDocumentationSyncResult>;
+  syncCiDocumentation(
+    designModel: DesignModel,
+    targetNames: string[],
+    visualPlan?: import("../domain/ci/create-ci-visual-plan").CiVisualPlan
+  ): Promise<CiDocumentationSyncResult>;
 };
 
 export type MetadataSyncGateway = {

--- a/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
+++ b/repo/figma-design-sync/tools/src/usecases/sync-figma-design-model.ts
@@ -91,7 +91,11 @@ export async function syncFigmaDesignModel(
 
   const ciTargets = CI_SYNC_TARGETS.filter((target) => requestedTargets.has(target));
   const ciSyncResult = ciTargets.length > 0
-    ? await dependencies.ciDocumentationSyncGateway.syncCiDocumentation(designModel, ciTargets)
+    ? await dependencies.ciDocumentationSyncGateway.syncCiDocumentation(
+        designModel,
+        ciTargets,
+        options.ciVisualPlan
+      )
     : emptyCiDocumentationSyncResult();
   completedTargets.push(...ciTargets);
 

--- a/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
+++ b/repo/figma-design-sync/tools/tests/sync-preflight-target.test.ts
@@ -166,6 +166,32 @@ test("preflight validates and synchronizes a granular CI documentation target", 
   assert.deepEqual(result.updatedCiSections, ["ci.overview"]);
 });
 
+test("forwards the Kotlin-precomputed CI visual plan to the Figma boundary", async () => {
+  const calls: string[] = [];
+  const dependencies = fakeDependencies(calls);
+  let receivedPlan;
+  dependencies.ciDocumentationSyncGateway.syncCiDocumentation = async (_model, targets, visualPlan) => {
+    receivedPlan = visualPlan;
+    return {
+      updatedCiSections: targets,
+      createdCiNodes: [],
+      createdCiConnectors: [],
+      mutatedNodeIds: [],
+    };
+  };
+  const ciVisualPlan = {
+    parentName: "Continuous Integration and Design Documentation" as const,
+    sections: [],
+  };
+
+  await syncFigmaDesignModel(mainDesignModel(), dependencies, {
+    targets: ["ci.overview"],
+    ciVisualPlan,
+  });
+
+  assert.equal(receivedPlan, ciVisualPlan);
+});
+
 function mainDesignModel() {
   return {
     branch: "main",
@@ -211,7 +237,7 @@ function fakeDependencies(calls: string[]) {
       },
     },
     ciDocumentationSyncGateway: {
-      async syncCiDocumentation(_designModel, targetNames) {
+      async syncCiDocumentation(_designModel, targetNames, _visualPlan?) {
         calls.push("ci");
         return {
           updatedCiSections: targetNames,


### PR DESCRIPTION
## Summary

- add portable Kotlin CI visual-plan models and deterministic planner
- adapt `design-model.json` CI content to target-scoped plan JSON and inject it into official MCP runner options
- keep TypeScript as the Figma Plugin API boundary with a temporary preview fallback
- include Kotlin visual sources in scoped writer fingerprints and detect those changes independently from the compiled TypeScript hash
- document the new Kotlin/TypeScript ownership boundary

## Verification

- `./gradlew.bat check` (168 tasks)
- `./gradlew.bat :figma-design-sync:domain:test :figma-design-sync:data:test :figma-design-sync:project-config:test`
- `npm test`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1 -FailOnCoverageGap`
- `./gradlew.bat classifyFigmaChangeImpact` -> `model-content (full-verification)`

No official design model was generated locally and no Figma write was performed.