### PR TITLE
feat(figma-design-sync): add verified Kotlin PNG uploader

### DIFF
--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -12,7 +12,9 @@ sources:
   - repo/gradle-plugins/settings.gradle.kts
   - repo/figma-design-sync/settings.gradle.kts
   - repo/figma-design-sync/data/build.gradle.kts
+  - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploader.kt
   - repo/figma-design-sync/project-config/build.gradle.kts
+  - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt
 ---
 
 # Project Structure
@@ -92,10 +94,10 @@ configuration:
 | Path | Gradle module | Purpose |
 |------|---------------|---------|
 | `repo/figma-design-sync/domain/` | `:domain` | Portable design-model types and ports. |
-| `repo/figma-design-sync/data/` | `:data` | Portable filesystem, Gradle, catalog-provider, CI, official MCP SDK, runner-generation, and checkpoint adapters. It does not depend on `water-my-plants-catalog` in production. |
+| `repo/figma-design-sync/data/` | `:data` | Portable filesystem, Gradle, catalog-provider, CI, official MCP SDK, allow-listed PNG upload, runner-generation, and checkpoint adapters. It does not depend on `water-my-plants-catalog` in production. |
 | `repo/figma-design-sync/plugin/` | `:plugin` | Reusable Gradle tasks, model generation, checks, and composition. |
 | `repo/figma-design-sync/teamcity-adapter/` | `:teamcity-adapter` | Optional Kotlin translation from generated TeamCity YAML/XML to the portable CI model, plus typed TeamCity CLI access for artifacts and runs. |
-| `repo/figma-design-sync/project-config/` | `:project-config` | Water My Plants paths, concrete catalog and CI providers, Figma identities, visual targets, credential adapters, repository-specific TeamCity orchestration, and adapter contract tests. |
+| `repo/figma-design-sync/project-config/` | `:project-config` | Water My Plants paths, concrete catalog and CI providers, Figma identities, visual targets, credential adapters, verified official payload upload, repository-specific TeamCity orchestration, and adapter contract tests. |
 | `repo/figma-design-sync/tools/` | not a Gradle module | TypeScript writer evaluated inside the Figma Plugin API runtime, plus preview tooling selected through the active project configuration. |
 
 The root build applies the Water My Plants project adapter. That adapter applies

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -132,6 +132,10 @@ used by CI.
 - `prepareTeamCityFigmaSyncHandoff`: Water My Plants project adapter that
   prepares a validated local handoff from a TeamCity build id or existing
   artifact directory. Keep its TeamCity CLI boundary in `teamcity-adapter`.
+- `uploadOfficialFigmaPayload`: Water My Plants project adapter that accepts
+  only a successful main TeamCity build and a single-use
+  `mcp.figma.com/mcp/upload/.../submit` URL, then verifies and uploads the
+  manifest-declared PNG through Kotlin.
 - `rerunTeamCityFigmaSync`: Water My Plants project adapter that obtains
   credentials through a port, exchanges Cloudflare service auth, and reuses or
   queues the official `main` pipeline. Keep TeamCity CLI operations in

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -171,6 +171,9 @@ Run these from the repository root:
 .\gradlew.bat classifyFigmaChangeImpact
 .\gradlew.bat validateOfficialFigmaArtifactSet `
     -PfigmaArtifactDirectory=<artifact-directory>
+.\gradlew.bat uploadOfficialFigmaPayload `
+    -PfigmaTeamCityBuildId=<job-run-id> `
+    -PfigmaMcpUploadUrl=<single-use-upload-url>
 ```
 
 Task responsibilities:
@@ -185,6 +188,7 @@ Task responsibilities:
 | `verifyOfficialFigmaSync` | Validates the downloaded scope identity and runs the trunk metadata check only for `full-verification`. |
 | `validateOfficialFigmaArtifactSet` | Validates that the downloaded model, scope, plan, and runner manifests share one official `main` identity before the MCP handoff. |
 | `prepareTeamCityFigmaSyncHandoff` | Water My Plants Kotlin adapter that downloads or opens official TeamCity artifacts, validates them, and writes `figma-sync-handoff.json`. |
+| `uploadOfficialFigmaPayload` | Water My Plants Kotlin adapter that downloads one successful main TeamCity artifact, verifies its manifest-declared PNG, and uploads it only to an allow-listed single-use Figma MCP URL. |
 | `rerunTeamCityFigmaSync` | Water My Plants Kotlin adapter that authenticates through Cloudflare, reuses or queues the official TeamCity pipeline, and optionally waits for success. |
 | `checkFigmaVersionNaming` | Fails when version keys do not follow the Figma naming contract. |
 | `checkFigmaCatalogUsage` | Fails when catalog entries are declared but unused according to the repository usage contract. |
@@ -230,6 +234,12 @@ runner writes `10-official-sync-payload.png`, that image is uploaded to Figma,
 and the staging runner extracts and validates the model plus MCP script before
 storing the script as plain text in temporary shared plugin data. Avoiding a
 second Base64 encoding keeps the staging entry below Figma's per-entry limit.
+The repository-specific `uploadOfficialFigmaPayload` task keeps this transfer
+Kotlin-first: it validates the successful main TeamCity build, cross-file
+artifact identity, payload length and SHA-256, PNG signature, and exact
+`https://mcp.figma.com/mcp/upload/<id>/submit?scaleMode=FILL` destination before
+sending any bytes. The single-use URL is internal task state and is never
+written to the handoff summary or task output.
 Each visual target then runs in a separate, lexically ordered MCP call. Catalog
 targets are further split by declared root and end with a cleanup-only call.
 This keeps the complete synchronization mandatory without exceeding the MCP

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KotlinSdkMcpClient.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KotlinSdkMcpClient.kt
@@ -5,12 +5,6 @@ import com.marmatsan.figmaDesignSync.domain.port.writer.McpClientPort
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.sse.SSE
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.isSuccess
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
@@ -25,6 +19,8 @@ class KotlinSdkMcpClient private constructor(
     private val httpClient: HttpClient,
     private val client: Client
 ) : McpClientPort {
+    private val assetUploader = KtorFigmaPngAssetUploader()
+
     override suspend fun listToolNames(): List<String> = client.listTools().tools.map { tool -> tool.name }
 
     override suspend fun readTextResource(uri: String): String = client.readResource(
@@ -51,13 +47,7 @@ class KotlinSdkMcpClient private constructor(
         arguments = mapOf("fileKey" to fileKey, "count" to count)
     ).toDomain()
 
-    override suspend fun uploadAsset(url: String, bytes: ByteArray) {
-        val response = httpClient.post(url) {
-            header(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
-            setBody(bytes)
-        }
-        require(response.status.isSuccess()) { "Payload upload failed with HTTP ${response.status.value}." }
-    }
+    override suspend fun uploadAsset(url: String, bytes: ByteArray) = assetUploader.upload(url, bytes)
 
     override fun close() {
         runBlocking { client.close() }

--- a/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploader.kt
+++ b/repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploader.kt
@@ -1,0 +1,81 @@
+package com.marmatsan.figmaDesignSync.data.mcp
+
+import com.marmatsan.figmaDesignSync.data.png.PayloadPngEncoder
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import java.net.URI
+import kotlinx.coroutines.runBlocking
+
+/** Uploads one validated official PNG only to a single-use Figma MCP asset URL. */
+class KtorFigmaPngAssetUploader internal constructor(
+    private val send: suspend (URI, ByteArray) -> Int
+) {
+    constructor() : this(::sendWithKtor)
+
+    suspend fun upload(url: String, bytes: ByteArray) {
+        val target = requireAllowedTarget(url)
+        require(bytes.size in 1..PayloadPngEncoder.MAX_FIGMA_UPLOAD_ASSET_BYTES) {
+            "Official Figma payload must contain between 1 and " +
+                "${PayloadPngEncoder.MAX_FIGMA_UPLOAD_ASSET_BYTES} bytes."
+        }
+        require(bytes.startsWith(PayloadPngEncoder.PNG_SIGNATURE)) {
+            "Official Figma payload is not a PNG file."
+        }
+
+        val status = send(target, bytes)
+        require(status in 200..299) { "Payload upload failed with HTTP $status." }
+    }
+
+    fun uploadBlocking(url: String, bytes: ByteArray) = runBlocking { upload(url, bytes) }
+
+    private fun requireAllowedTarget(url: String): URI {
+        val target = runCatching { URI(url) }.getOrElse { failure ->
+            throw IllegalArgumentException("Figma upload URL is invalid.", failure)
+        }
+        require(!target.isOpaque && target.scheme.equals("https", ignoreCase = true)) {
+            "Figma upload URL must use HTTPS."
+        }
+        require(target.host.equals(ALLOWED_HOST, ignoreCase = true)) {
+            "Figma upload URL host must be $ALLOWED_HOST."
+        }
+        require(target.port == -1 || target.port == HTTPS_PORT) {
+            "Figma upload URL must use the default HTTPS port."
+        }
+        require(target.userInfo == null && target.fragment == null) {
+            "Figma upload URL must not contain user info or a fragment."
+        }
+        require(UPLOAD_PATH.matches(target.path)) {
+            "Figma upload URL path is not an MCP asset submit endpoint."
+        }
+        require(target.rawQuery == EXPECTED_QUERY) {
+            "Figma upload URL must use the expected PNG placement query."
+        }
+        return target
+    }
+
+    private fun ByteArray.startsWith(prefix: ByteArray): Boolean =
+        size >= prefix.size && prefix.indices.all { index -> this[index] == prefix[index] }
+
+    private companion object {
+        const val ALLOWED_HOST = "mcp.figma.com"
+        const val HTTPS_PORT = 443
+        const val EXPECTED_QUERY = "scaleMode=FILL"
+        val UPLOAD_PATH = Regex(
+            "^/mcp/upload/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-" +
+                "[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/submit$"
+        )
+
+        suspend fun sendWithKtor(target: URI, bytes: ByteArray): Int =
+            HttpClient(CIO) { followRedirects = false }.use { client ->
+                client.post(target.toString()) {
+                    header(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    setBody(bytes)
+                }.status.value
+            }
+    }
+}

--- a/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploaderTest.kt
+++ b/repo/figma-design-sync/data/src/test/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploaderTest.kt
@@ -1,0 +1,77 @@
+package com.marmatsan.figmaDesignSync.data.mcp
+
+import com.marmatsan.figmaDesignSync.data.png.PayloadPngEncoder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+internal class KtorFigmaPngAssetUploaderTest : FunSpec({
+    val uploadUrl =
+        "https://mcp.figma.com/mcp/upload/0d188fd2-0c70-46f5-b30a-6dd4f3904998/submit?scaleMode=FILL"
+    val png = PayloadPngEncoder().encode("{}")
+
+    test("uploads a PNG only to the exact Figma MCP submit endpoint") {
+        var capturedUrl = ""
+        var capturedBytes = byteArrayOf()
+        val uploader = KtorFigmaPngAssetUploader { target, bytes ->
+            capturedUrl = target.toString()
+            capturedBytes = bytes
+            204
+        }
+
+        uploader.uploadBlocking(uploadUrl, png)
+
+        capturedUrl shouldBe uploadUrl
+        capturedBytes shouldBe png
+    }
+
+    test("rejects upload targets outside the single-use Figma MCP contract") {
+        val invalidUrls = listOf(
+            uploadUrl.replace("https://", "http://"),
+            uploadUrl.replace("mcp.figma.com", "example.com"),
+            uploadUrl.replace("mcp.figma.com", "mcp.figma.com.example.com"),
+            uploadUrl.replace("mcp.figma.com", "mcp.figma.com:8443"),
+            uploadUrl.replace("/mcp/upload/", "/other/upload/"),
+            uploadUrl.replace("?scaleMode=FILL", "?scaleMode=FIT"),
+            uploadUrl.replace("https://", "https://user@mcp.figma.com/")
+        )
+        var sends = 0
+        val uploader = KtorFigmaPngAssetUploader { _, _ ->
+            sends += 1
+            204
+        }
+
+        invalidUrls.forEach { url ->
+            shouldThrow<IllegalArgumentException> { uploader.uploadBlocking(url, png) }
+        }
+
+        sends shouldBe 0
+    }
+
+    test("rejects non-PNG content and oversized payloads before sending") {
+        var sends = 0
+        val uploader = KtorFigmaPngAssetUploader { _, _ ->
+            sends += 1
+            204
+        }
+
+        shouldThrow<IllegalArgumentException> {
+            uploader.uploadBlocking(uploadUrl, "not-a-png".encodeToByteArray())
+        }
+        shouldThrow<IllegalArgumentException> {
+            uploader.uploadBlocking(uploadUrl, ByteArray(10 * 1024 * 1024 + 1))
+        }
+
+        sends shouldBe 0
+    }
+
+    test("reports a failed Figma upload status") {
+        val uploader = KtorFigmaPngAssetUploader { _, _ -> 500 }
+
+        val failure = shouldThrow<IllegalArgumentException> {
+            uploader.uploadBlocking(uploadUrl, png)
+        }
+
+        failure.message shouldBe "Payload upload failed with HTTP 500."
+    }
+})

--- a/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
+++ b/repo/figma-design-sync/docs/runbooks/mcp-chunk-transport.md
@@ -9,7 +9,9 @@ review-cycle-days: 90
 sources:
   - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGenerator.kt
   - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/McpRunnerExecutor.kt
+  - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploader.kt
   - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/png/PayloadPngEncoder.kt
+  - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt
 ---
 
 # MCP Payload Transport Runbook
@@ -97,11 +99,30 @@ roots use one call per root followed by a cleanup-only call. The PNG asset is a
 transport artifact only; the staging runner removes the uploaded image node
 after extracting the payload.
 
-`upload_assets` returns a single-use URL under `https://mcp.figma.com`. Upload
-the raw PNG bytes with an explicit `Content-Type: image/png` header. Sending it
-as multipart form data or the default `application/octet-stream` is rejected.
+`upload_assets` returns a single-use URL under `https://mcp.figma.com`. For
+Water My Plants, pass that URL and the official TeamCity child run id to the
+Kotlin uploader:
+
+```powershell
+.\gradlew.bat uploadOfficialFigmaPayload `
+    -PfigmaTeamCityBuildId=<job-run-id> `
+    -PfigmaMcpUploadUrl="<single-use-upload-url>"
+```
+
+The task downloads the successful main artifact again so the HTTP boundary
+cannot be pointed at an arbitrary local file. It checks the cross-file contract,
+manifest PNG declaration, byte length, SHA-256, PNG signature, default HTTPS
+port, exact `mcp.figma.com` host, submit path, and `scaleMode=FILL` query before
+sending `Content-Type: image/png`. The URL is neither logged nor persisted.
 Request a new URL after any failed or consumed upload attempt; do not reuse an
 old URL.
+
+If the environment cannot start the TeamCity CLI from a Gradle child process,
+download the child run with the authenticated `teamcity run download` command
+and use `-PfigmaArtifactDirectory` plus the mandatory
+`-PfigmaExpectedGitSha`. This fallback still accepts only a complete official
+artifact set and its manifest-declared PNG; it never accepts a standalone image
+path.
 
 `upload_assets` may place the temporary image on the current Figma page, which
 does not have to be the metadata page. Uploaded assets are direct page children,
@@ -285,7 +306,9 @@ the required write tools.
 
 - `data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGenerator.kt`
 - `data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/McpRunnerExecutor.kt`
+- `data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploader.kt`
 - `data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/png/PayloadPngEncoder.kt`
+- `project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt`
 - `tools/src/sync-trunk-design-model.ts`
 
 ## Run The Planned Visual Sync

--- a/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
+++ b/repo/figma-design-sync/docs/runbooks/official-artifact-visual-sync.md
@@ -4,13 +4,16 @@ type: runbook
 scope: repo/figma-design-sync
 owner: figma-design-sync
 status: active
-last-reviewed: 2026-07-18
+last-reviewed: 2026-07-19
 review-cycle-days: 90
 sources:
   - .teamcity/settings.kts
   - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGenerator.kt
   - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/PrepareTeamCityFigmaSyncHandoffTask.kt
   - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityFigmaSyncHandoffPreparer.kt
+  - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt
+  - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityOfficialFigmaPayloadUploader.kt
+  - repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCliClient.kt
   - repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/task/artifact/ValidateOfficialFigmaArtifactSetTask.kt
 ---
 
@@ -212,12 +215,36 @@ Codex-operated Figma MCP unit at a time, then record success or failure through
 the Kotlin checkpoint executor. The task never writes to Figma and never
 records a unit automatically.
 
+For PNG transport, request one upload URL from Figma `upload_assets`, then pass
+that single-use URL and the same child run id to the narrow Kotlin uploader:
+
+```powershell
+.\gradlew.bat uploadOfficialFigmaPayload `
+    -PfigmaTeamCityBuildId=<job-run-id> `
+    -PfigmaMcpUploadUrl="<single-use-upload-url>"
+```
+
+The task revalidates that the build is successful, belongs to `main`, and is
+the `Generate main design model` job. It then validates the artifact contract,
+visual manifest, PNG length, SHA-256, signature, and destination allow-list
+before posting. It never prints or stores the upload URL. Run
+`10-stage-payload-from-png.mcp.js` only after this command succeeds.
+
+If the workstation uses reusable command permissions, authorize only
+`.\gradlew.bat uploadOfficialFigmaPayload`. Do not replace the task with
+`Invoke-WebRequest` or grant a generic outbound-upload permission.
+
 When artifacts were downloaded through another authorized route, validate them
-without a second download:
+without a second download. The explicit revision is mandatory in this mode:
 
 ```powershell
 .\gradlew.bat prepareTeamCityFigmaSyncHandoff `
     -PfigmaArtifactDirectory=<downloaded-figma-sync-directory>
+
+.\gradlew.bat uploadOfficialFigmaPayload `
+    -PfigmaArtifactDirectory=<downloaded-figma-sync-directory> `
+    -PfigmaExpectedGitSha=<exact-main-git-sha> `
+    -PfigmaMcpUploadUrl="<single-use-upload-url>"
 ```
 
 After all selected visual units and metadata complete, use the handoff's
@@ -249,3 +276,6 @@ official artifact from the authoritative `main` run.
 - `data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/writer/OfficialMcpRunnerGenerator.kt`
 - `project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/PrepareTeamCityFigmaSyncHandoffTask.kt`
 - `project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityFigmaSyncHandoffPreparer.kt`
+- `project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt`
+- `project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityOfficialFigmaPayloadUploader.kt`
+- `teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCliClient.kt`

--- a/repo/figma-design-sync/project-config/README.md
+++ b/repo/figma-design-sync/project-config/README.md
@@ -89,11 +89,31 @@ and invokes the portable Gradle tasks from `.teamcity/settings.kts`.
 
 The Kotlin `prepareTeamCityFigmaSyncHandoff` task owns TeamCity artifact
 inspection, download, contract validation, and executor preparation. The
+Kotlin `uploadOfficialFigmaPayload` task accepts only a successful main
+`Generate main design model` build, verifies the manifest-declared PNG bytes,
+and posts them only to the exact single-use HTTPS endpoint returned by Figma
+`upload_assets`. It runs the TeamCity CLI from the repository root so the
+versioned `teamcity.toml` connection is authoritative. Its URL is internal task
+state and the task never logs or writes it. The
 Kotlin `rerunTeamCityFigmaSync` task owns Cloudflare token exchange, active-run
 deduplication, queueing, and optional waiting. It obtains credentials through
 `TeamCityAutomationCredentialsProvider`; the default environment adapter keeps
 PowerShell SecretStore and other workstation-specific vaults outside the
 module. No Figma synchronization workflow depends on `tools/teamcity/`.
+
+The upload task accepts these Gradle properties:
+
+| Property | Default | Meaning |
+|----------|---------|---------|
+| `figmaTeamCityBuildId` | none | Required successful main `Generate main design model` job id. |
+| `figmaArtifactDirectory` | none | Alternative validated official artifact directory; mutually exclusive with the build id. |
+| `figmaMcpUploadUrl` | none | Required single-use `mcp.figma.com` PNG submit URL returned by `upload_assets`. |
+| `figmaExpectedGitSha` | none | Exact revision expected in the official artifact contract; required with `figmaArtifactDirectory`. |
+| `figmaHandoffDestinationRoot` | `tmp/teamcity` | Ignored directory used for the validated TeamCity download. |
+
+When the workstation supports reusable command approvals, scope the standing
+permission to `.\gradlew.bat uploadOfficialFigmaPayload`. Do not grant a
+generic PowerShell or arbitrary HTTP-upload permission.
 
 The rerun task accepts these Gradle properties:
 

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityFigmaSyncHandoffPreparer.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityFigmaSyncHandoffPreparer.kt
@@ -60,6 +60,14 @@ class TeamCityFigmaSyncHandoffPreparer(
         val commandPrefix =
             ".\\gradlew.bat runFigmaMcp " +
                 "-PfigmaMcpManifest=\"$visualManifest\" -PfigmaMcpPlan=\"${artifacts.planPath}\""
+        val uploadPayloadCommand = request.buildId?.let { buildId ->
+            ".\\gradlew.bat uploadOfficialFigmaPayload " +
+                "-PfigmaTeamCityBuildId=$buildId " +
+                "-PfigmaMcpUploadUrl=\"SINGLE_USE_UPLOAD_URL\""
+        } ?: ".\\gradlew.bat uploadOfficialFigmaPayload " +
+            "-PfigmaArtifactDirectory=\"${artifacts.artifactDirectory}\" " +
+            "-PfigmaExpectedGitSha=${validated.gitSha} " +
+            "-PfigmaMcpUploadUrl=\"SINGLE_USE_UPLOAD_URL\""
         val summary = buildJsonObject {
             put("schemaVersion", 1)
             put("preparedAt", clock.instant().toString())
@@ -89,6 +97,7 @@ class TeamCityFigmaSyncHandoffPreparer(
                             "-PfigmaMcpSummary=\"SHORT_ERROR\""
                     )
                     put("execute", commandPrefix)
+                    put("uploadPayload", uploadPayloadCommand)
                     put("rerun", ".\\gradlew.bat rerunTeamCityFigmaSync -PfigmaTeamCityWait=true")
                 }
             )

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityOfficialFigmaPayloadUploader.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityOfficialFigmaPayloadUploader.kt
@@ -1,0 +1,104 @@
+package com.marmatsan.figmaDesignSync.projectConfig
+
+import com.marmatsan.figmaDesignSync.data.figma.artifact.OfficialFigmaArtifactSetReader
+import com.marmatsan.figmaDesignSync.data.hash.Sha256Hash
+import com.marmatsan.figmaDesignSync.data.json.writer.ExecutableRunnerManifestJson
+import com.marmatsan.figmaDesignSync.data.mcp.KtorFigmaPngAssetUploader
+import java.io.File
+import java.nio.file.Files
+
+/** Uploads the verified PNG from one official main artifact set. */
+class TeamCityOfficialFigmaPayloadUploader(
+    private val handoffPreparer: TeamCityFigmaSyncHandoffPreparer =
+        TeamCityFigmaSyncHandoffPreparer(),
+    private val artifactReader: OfficialFigmaArtifactSetReader = OfficialFigmaArtifactSetReader(),
+    private val manifestJson: ExecutableRunnerManifestJson = ExecutableRunnerManifestJson(),
+    private val uploadPng: (String, ByteArray) -> Unit =
+        KtorFigmaPngAssetUploader()::uploadBlocking
+) {
+    fun upload(request: Request): Result {
+        require((request.buildId == null) xor (request.artifactDirectory == null)) {
+            "Configure exactly one of figmaTeamCityBuildId or figmaArtifactDirectory."
+        }
+        if (request.artifactDirectory != null) {
+            require(!request.expectedGitSha.isNullOrBlank()) {
+                "figmaExpectedGitSha is required with figmaArtifactDirectory."
+            }
+        }
+        val handoff = handoffPreparer.prepare(
+            TeamCityFigmaSyncHandoffPreparer.Request(
+                buildId = request.buildId,
+                artifactDirectory = request.artifactDirectory,
+                destinationRoot = request.destinationRoot,
+                expectedGitSha = request.expectedGitSha,
+                mainBranchAliases = request.mainBranchAliases,
+                requiredBuildTypeName = request.requiredBuildTypeName
+            )
+        )
+        val artifacts = artifactReader.read(handoff.artifactDirectory.absolutePath)
+        val manifestPath = requireNotNull(artifacts.visualManifestPath) {
+            "Official artifact set does not contain one visual manifest."
+        }
+        val manifest = manifestJson.read(manifestPath.toString())
+        require(manifest.mode == "official" && manifest.fullVisualSync && !manifest.writeMetadata) {
+            "Figma payload upload requires the official full visual manifest."
+        }
+        require(manifest.transport == PNG_TRANSPORT) {
+            "Figma payload upload requires PNG transport; found '${manifest.transport}'."
+        }
+        val payload = requireNotNull(manifest.payloadImage) {
+            "Official visual manifest does not declare a PNG payload."
+        }
+        require(File(payload.fileName).name == payload.fileName) {
+            "Official PNG payload must use a file name without path segments."
+        }
+        val runnerDirectory = requireNotNull(manifestPath.parent).toAbsolutePath().normalize()
+        val payloadPath = runnerDirectory.resolve(payload.fileName).normalize()
+        require(payloadPath.parent == runnerDirectory && Files.isRegularFile(payloadPath)) {
+            "Official PNG payload does not exist beside its visual manifest."
+        }
+        val bytes = Files.readAllBytes(payloadPath)
+        require(bytes.size == payload.byteLength) {
+            "Official PNG payload length mismatch: ${bytes.size} != ${payload.byteLength}."
+        }
+        val actualHash = Sha256Hash.of(bytes)
+        require(actualHash == payload.sha256) {
+            "Official PNG payload hash mismatch: $actualHash != ${payload.sha256}."
+        }
+
+        uploadPng(request.uploadUrl, bytes)
+        return Result(
+            buildId = request.buildId,
+            gitSha = manifest.gitSha,
+            modelHash = manifest.modelHash,
+            payloadFileName = payload.fileName,
+            payloadByteLength = payload.byteLength,
+            payloadSha256 = payload.sha256,
+            artifactDirectory = handoff.artifactDirectory
+        )
+    }
+
+    data class Request(
+        val buildId: Long?,
+        val artifactDirectory: File?,
+        val uploadUrl: String,
+        val destinationRoot: File,
+        val expectedGitSha: String? = null,
+        val mainBranchAliases: Set<String> = setOf("main", "<default>", "refs/heads/main"),
+        val requiredBuildTypeName: String = "Generate main design model"
+    )
+
+    data class Result(
+        val buildId: Long?,
+        val gitSha: String,
+        val modelHash: String,
+        val payloadFileName: String,
+        val payloadByteLength: Int,
+        val payloadSha256: String,
+        val artifactDirectory: File
+    )
+
+    private companion object {
+        const val PNG_TRANSPORT = "png"
+    }
+}

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/UploadOfficialFigmaPayloadTask.kt
@@ -1,0 +1,79 @@
+package com.marmatsan.figmaDesignSync.projectConfig
+
+import com.marmatsan.figmaDesignSync.teamcityAdapter.TeamCityCliClient
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/** Gradle entry point for uploading one verified official TeamCity PNG payload. */
+@DisableCachingByDefault(because = "Downloads an official artifact and uploads its PNG to Figma")
+abstract class UploadOfficialFigmaPayloadTask : DefaultTask() {
+    @get:Input
+    @get:Optional
+    abstract val buildId: Property<Long>
+
+    @get:InputDirectory
+    @get:Optional
+    abstract val artifactDirectory: DirectoryProperty
+
+    @get:Internal
+    abstract val uploadUrl: Property<String>
+
+    @get:Internal
+    abstract val destinationRoot: DirectoryProperty
+
+    @get:Internal
+    abstract val projectDirectory: DirectoryProperty
+
+    @get:Input
+    @get:Optional
+    abstract val expectedGitSha: Property<String>
+
+    @get:Input
+    abstract val mainBranchAliases: ListProperty<String>
+
+    @get:Input
+    abstract val requiredBuildTypeName: Property<String>
+
+    @TaskAction
+    fun upload() {
+        val artifacts = artifactDirectory.orNull?.asFile
+        require((buildId.orNull == null) xor (artifacts == null)) {
+            "Configure exactly one of figmaTeamCityBuildId or figmaArtifactDirectory."
+        }
+        if (artifacts != null) {
+            require(!expectedGitSha.orNull.isNullOrBlank()) {
+                "figmaExpectedGitSha is required with figmaArtifactDirectory."
+            }
+        }
+        val teamCityClient = TeamCityCliClient(workingDirectory = projectDirectory.get().asFile)
+        val handoffPreparer = TeamCityFigmaSyncHandoffPreparer(teamCityClient = teamCityClient)
+        val result = TeamCityOfficialFigmaPayloadUploader(
+            handoffPreparer = handoffPreparer
+        ).upload(
+            TeamCityOfficialFigmaPayloadUploader.Request(
+                buildId = buildId.orNull,
+                artifactDirectory = artifacts,
+                uploadUrl = uploadUrl.get(),
+                destinationRoot = destinationRoot.get().asFile,
+                expectedGitSha = expectedGitSha.orNull,
+                mainBranchAliases = mainBranchAliases.get().toSet(),
+                requiredBuildTypeName = requiredBuildTypeName.get()
+            )
+        )
+        logger.lifecycle(
+            "Uploaded official Figma payload from " +
+                (result.buildId?.let { build -> "TeamCity build $build" }
+                    ?: "the validated artifact directory") + ": " +
+                "${result.payloadFileName} (${result.payloadByteLength} bytes, " +
+                "${result.payloadSha256}); gitSha=${result.gitSha}, modelHash=${result.modelHash}."
+        )
+    }
+}

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/WaterMyPlantsFigmaDesignSyncGradlePlugin.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/WaterMyPlantsFigmaDesignSyncGradlePlugin.kt
@@ -166,6 +166,29 @@ class WaterMyPlantsFigmaDesignSyncGradlePlugin : Plugin<Project> {
             requiredBuildTypeName.set("Generate main design model")
         }
 
+        project.tasks.register<UploadOfficialFigmaPayloadTask>("uploadOfficialFigmaPayload") {
+            group = "documentation"
+            description = "Uploads the verified PNG from one successful main TeamCity Figma artifact set."
+            buildId.convention(
+                project.providers.gradleProperty("figmaTeamCityBuildId").map(String::toLong)
+            )
+            artifactDirectory.set(
+                project.layout.dir(
+                    project.providers.gradleProperty("figmaArtifactDirectory").map(::File)
+                )
+            )
+            uploadUrl.convention(project.providers.gradleProperty("figmaMcpUploadUrl"))
+            destinationRoot.convention(
+                project.layout.dir(
+                    project.providers.gradleProperty("figmaHandoffDestinationRoot").map(::File)
+                ).orElse(project.layout.projectDirectory.dir("tmp/teamcity"))
+            )
+            projectDirectory.set(project.layout.projectDirectory)
+            expectedGitSha.convention(project.providers.gradleProperty("figmaExpectedGitSha"))
+            mainBranchAliases.set(listOf("main", "<default>", "refs/heads/main"))
+            requiredBuildTypeName.set("Generate main design model")
+        }
+
         project.tasks.register<RerunTeamCityFigmaSyncTask>("rerunTeamCityFigmaSync") {
             group = "documentation"
             description = "Validates or reruns the official TeamCity Figma Sync pipeline."

--- a/repo/figma-design-sync/project-config/src/test/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityFigmaSyncHandoffPreparerTest.kt
+++ b/repo/figma-design-sync/project-config/src/test/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityFigmaSyncHandoffPreparerTest.kt
@@ -4,6 +4,7 @@ import com.marmatsan.figmaDesignSync.data.hash.Sha256Hash
 import com.marmatsan.figmaDesignSync.data.json.writer.ExecutableRunnerManifestJson
 import com.marmatsan.figmaDesignSync.data.json.writer.VisualSyncPlanJson
 import com.marmatsan.figmaDesignSync.domain.model.writer.ExecutableRunnerManifest
+import com.marmatsan.figmaDesignSync.domain.model.writer.RunnerPayloadImage
 import com.marmatsan.figmaDesignSync.domain.model.writer.VisualSyncDecision
 import com.marmatsan.figmaDesignSync.domain.model.writer.VisualSyncIdentity
 import com.marmatsan.figmaDesignSync.domain.model.writer.VisualSyncPlan
@@ -58,6 +59,11 @@ internal class TeamCityFigmaSyncHandoffPreparerTest : FunSpec({
         result.summary["teamCityBuildId"]?.toString() shouldBe "null"
         result.summary["dryRun"]?.jsonObject?.get("decision")?.jsonPrimitive?.content shouldBe "partial"
         result.summary["nextUnit"]?.jsonPrimitive?.content shouldBe "00-clear-staging.mcp.js"
+        result.summary["commands"]?.jsonObject?.get("uploadPayload")?.jsonPrimitive?.content shouldBe
+            ".\\gradlew.bat uploadOfficialFigmaPayload " +
+                "-PfigmaArtifactDirectory=\"${artifacts.toPath().toAbsolutePath().normalize()}\" " +
+                "-PfigmaExpectedGitSha=abc123 " +
+                "-PfigmaMcpUploadUrl=\"SINGLE_USE_UPLOAD_URL\""
         root.deleteRecursively()
     }
 
@@ -94,7 +100,7 @@ internal class TeamCityFigmaSyncHandoffPreparerTest : FunSpec({
     }
 })
 
-private fun File.writeArtifactFixture() {
+internal fun File.writeArtifactFixture(payloadBytes: ByteArray? = null) {
     resolve("design-model.json").writeText(
         """{"branch":"main","gitSha":"abc123","modelHash":"model-hash"}"""
     )
@@ -103,12 +109,14 @@ private fun File.writeArtifactFixture() {
     val visualManifest = visual.writeManifest(
         targets = listOf("preflight"),
         fullVisualSync = true,
-        writeMetadata = false
+        writeMetadata = false,
+        payloadBytes = payloadBytes
     )
     val metadataManifest = metadata.writeManifest(
         targets = listOf("metadata"),
         fullVisualSync = false,
-        writeMetadata = true
+        writeMetadata = true,
+        payloadBytes = payloadBytes
     )
     VisualSyncPlanJson().run {
         val body = VisualSyncPlanBody(
@@ -150,12 +158,23 @@ private fun File.writeArtifactFixture() {
 private fun File.writeManifest(
     targets: List<String>,
     fullVisualSync: Boolean,
-    writeMetadata: Boolean
+    writeMetadata: Boolean,
+    payloadBytes: ByteArray?
 ): ExecutableRunnerManifest {
     val fileName = if (writeMetadata) "99-run-target.mcp.js" else "99-00-preflight.mcp.js"
     val source = "return { target: '${targets.single()}' };\n"
     resolve("00-clear-staging.mcp.js").writeText("return { cleared: true };\n")
     resolve(fileName).writeText(source)
+    val payloadImage = payloadBytes?.let { bytes ->
+        val payloadFileName = "10-official-sync-payload.png"
+        resolve(payloadFileName).writeBytes(bytes)
+        RunnerPayloadImage(
+            fileName = payloadFileName,
+            byteLength = bytes.size,
+            sha256 = Sha256Hash.of(bytes),
+            textKeyword = "figmaSyncPayload"
+        )
+    }
     val files = listOf("00-clear-staging.mcp.js", fileName)
     val fileHashes = files.associateWith { name -> Sha256Hash.of(resolve(name).readBytes()) }
     val draft = ExecutableRunnerManifest(
@@ -166,7 +185,7 @@ private fun File.writeManifest(
         target = targets.first(),
         targets = targets,
         writeMetadata = writeMetadata,
-        transport = "chunks",
+        transport = if (payloadImage == null) "chunks" else "png",
         namespace = "test_staging",
         sectionNodeId = null,
         roots = emptyList(),
@@ -189,7 +208,7 @@ private fun File.writeManifest(
         ),
         writerScopeFingerprintSchemaVersion = 1,
         executionScopes = mapOf(fileName to targets.single()),
-        payloadImage = null,
+        payloadImage = payloadImage,
         files = files,
         fileHashes = fileHashes,
         manifestHash = ""

--- a/repo/figma-design-sync/project-config/src/test/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityOfficialFigmaPayloadUploaderTest.kt
+++ b/repo/figma-design-sync/project-config/src/test/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityOfficialFigmaPayloadUploaderTest.kt
@@ -1,0 +1,157 @@
+package com.marmatsan.figmaDesignSync.projectConfig
+
+import com.marmatsan.figmaDesignSync.data.hash.Sha256Hash
+import com.marmatsan.figmaDesignSync.data.png.PayloadPngEncoder
+import com.marmatsan.figmaDesignSync.teamcityAdapter.TeamCityBuild
+import com.marmatsan.figmaDesignSync.teamcityAdapter.TeamCityBuildArtifactClient
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Files
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+internal class TeamCityOfficialFigmaPayloadUploaderTest : FunSpec({
+    val uploadUrl =
+        "https://mcp.figma.com/mcp/upload/0d188fd2-0c70-46f5-b30a-6dd4f3904998/submit?scaleMode=FILL"
+
+    test("uploads the hash-verified PNG from a successful main TeamCity build") {
+        val root = Files.createTempDirectory("figma-payload-upload").toFile()
+        val payload = PayloadPngEncoder().encode("{\"official\":true}")
+        val client = fixtureClient(payload)
+        val handoffPreparer = TeamCityFigmaSyncHandoffPreparer(
+            teamCityClient = client,
+            clock = Clock.fixed(Instant.parse("2026-07-19T08:00:00Z"), ZoneOffset.UTC)
+        )
+        var uploadedUrl = ""
+        var uploadedBytes = byteArrayOf()
+        val uploader = TeamCityOfficialFigmaPayloadUploader(
+            handoffPreparer = handoffPreparer,
+            uploadPng = { url, bytes ->
+                uploadedUrl = url
+                uploadedBytes = bytes
+            }
+        )
+
+        val result = uploader.upload(
+            TeamCityOfficialFigmaPayloadUploader.Request(
+                buildId = 1672,
+                artifactDirectory = null,
+                uploadUrl = uploadUrl,
+                destinationRoot = root,
+                expectedGitSha = "abc123"
+            )
+        )
+
+        uploadedUrl shouldBe uploadUrl
+        uploadedBytes shouldBe payload
+        result.buildId shouldBe 1672
+        result.gitSha shouldBe "abc123"
+        result.modelHash shouldBe "model-hash"
+        result.payloadByteLength shouldBe payload.size
+        result.payloadSha256 shouldBe Sha256Hash.of(payload)
+        result.artifactDirectory.resolve("figma-sync-handoff.json").shouldExist()
+        root.deleteRecursively()
+    }
+
+    test("rejects a PNG whose bytes no longer match the official manifest") {
+        val root = Files.createTempDirectory("figma-payload-tamper").toFile()
+        val payload = PayloadPngEncoder().encode("{\"official\":true}")
+        val client = fixtureClient(payload) { outputDirectory ->
+            val path = outputDirectory.resolve(
+                "mcp-runners/visual/10-official-sync-payload.png"
+            )
+            val tampered = path.readBytes()
+            tampered[tampered.lastIndex] = (tampered.last() + 1).toByte()
+            path.writeBytes(tampered)
+        }
+        var uploads = 0
+        val uploader = TeamCityOfficialFigmaPayloadUploader(
+            handoffPreparer = TeamCityFigmaSyncHandoffPreparer(teamCityClient = client),
+            uploadPng = { _, _ -> uploads += 1 }
+        )
+
+        val failure = shouldThrow<IllegalArgumentException> {
+            uploader.upload(
+                TeamCityOfficialFigmaPayloadUploader.Request(
+                    buildId = 1672,
+                    artifactDirectory = null,
+                    uploadUrl = uploadUrl,
+                    destinationRoot = root
+                )
+            )
+        }
+
+        failure.message?.startsWith("Official PNG payload hash mismatch:") shouldBe true
+        uploads shouldBe 0
+        root.deleteRecursively()
+    }
+
+    test("uploads a previously downloaded artifact only with an explicit revision") {
+        val root = Files.createTempDirectory("figma-payload-directory").toFile()
+        val artifacts = root.resolve("artifacts").apply {
+            mkdirs()
+            writeArtifactFixture(PayloadPngEncoder().encode("{\"official\":true}"))
+        }
+        val client = object : TeamCityBuildArtifactClient {
+            override fun readBuild(buildId: Long): TeamCityBuild =
+                error("TeamCity must not be called")
+
+            override fun downloadArtifacts(buildId: Long, outputDirectory: File) =
+                error("TeamCity must not be called")
+        }
+        var uploads = 0
+        val uploader = TeamCityOfficialFigmaPayloadUploader(
+            handoffPreparer = TeamCityFigmaSyncHandoffPreparer(teamCityClient = client),
+            uploadPng = { _, _ -> uploads += 1 }
+        )
+
+        val missingRevision = shouldThrow<IllegalArgumentException> {
+            uploader.upload(
+                TeamCityOfficialFigmaPayloadUploader.Request(
+                    buildId = null,
+                    artifactDirectory = artifacts,
+                    uploadUrl = uploadUrl,
+                    destinationRoot = root
+                )
+            )
+        }
+        missingRevision.message shouldBe
+            "figmaExpectedGitSha is required with figmaArtifactDirectory."
+
+        uploader.upload(
+            TeamCityOfficialFigmaPayloadUploader.Request(
+                buildId = null,
+                artifactDirectory = artifacts,
+                uploadUrl = uploadUrl,
+                destinationRoot = root,
+                expectedGitSha = "abc123"
+            )
+        )
+
+        uploads shouldBe 1
+        root.deleteRecursively()
+    }
+})
+
+private fun fixtureClient(
+    payload: ByteArray,
+    afterWrite: (File) -> Unit = {}
+): TeamCityBuildArtifactClient = object : TeamCityBuildArtifactClient {
+    override fun readBuild(buildId: Long): TeamCityBuild = TeamCityBuild(
+        id = buildId,
+        state = "finished",
+        status = "SUCCESS",
+        branchName = "main",
+        buildTypeName = "Generate main design model",
+        webUrl = null
+    )
+
+    override fun downloadArtifacts(buildId: Long, outputDirectory: File) {
+        outputDirectory.writeArtifactFixture(payload)
+        afterWrite(outputDirectory)
+    }
+}

--- a/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCliClient.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCliClient.kt
@@ -11,8 +11,11 @@ import kotlinx.serialization.json.jsonPrimitive
 /** TeamCity CLI adapter used by local Kotlin operational tasks. */
 class TeamCityCliClient(
     private val environment: Map<String, String?> = emptyMap(),
+    private val workingDirectory: File? = null,
     private val execute: (List<String>, Map<String, String?>) -> CommandResult =
-        { arguments, commandEnvironment -> executeProcess(arguments, commandEnvironment) }
+        { arguments, commandEnvironment ->
+            executeProcess(arguments, commandEnvironment, workingDirectory)
+        }
 ) : TeamCityBuildArtifactClient, TeamCityRunClient {
     override fun readBuild(buildId: Long): TeamCityBuild {
         val root = executeJson("run", "view", buildId.toString(), "--json")
@@ -124,9 +127,11 @@ class TeamCityCliClient(
     private companion object {
         fun executeProcess(
             arguments: List<String>,
-            environment: Map<String, String?>
+            environment: Map<String, String?>,
+            workingDirectory: File?
         ): CommandResult {
             val processBuilder = ProcessBuilder(arguments)
+            workingDirectory?.let(processBuilder::directory)
             environment.forEach { (name, value) ->
                 if (value == null) {
                     processBuilder.environment().remove(name)


### PR DESCRIPTION
## Summary

- add a Kotlin/Ktor PNG uploader restricted to the exact Figma MCP asset endpoint
- add `uploadOfficialFigmaPayload` to validate TeamCity or local official artifacts before transfer
- document the Kotlin-first workflow and the narrowly scoped persistent command permission

## Safety contract

- HTTPS and `mcp.figma.com` only
- exact `/mcp/upload/<uuid>/submit?scaleMode=FILL` endpoint
- PNG signature, 1–10 MB size, manifest length and SHA-256 validation
- no redirects and no upload URL persisted or logged by the task
- metadata remains the last sync phase

## Verification

- `./gradlew.bat :data:test :project-config:test`
- `./gradlew.bat :teamcity-adapter:check :data:check :project-config:check --rerun-tasks`
- `./gradlew.bat check` with the Figma content token loaded from `.env`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1`
- end-to-end negative-path execution rejected a non-allow-listed upload host after validating the official artifact