### PR TITLE
fix(figma-design-sync): queue TeamCity reruns without cookies

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -425,14 +425,14 @@ for the duration of each CLI command. Follow
 for the wrapper, verification procedure, webhook boundary, and the known CSRF
 contract for mutating requests.
 
-Read-only diagnostics and the post-MCP verification rerun use TeamCity CLI.
+Read-only diagnostics and post-MCP verification monitoring use TeamCity CLI.
 The repository Kotlin task exchanges the Cloudflare service credential for a
-short-lived Access JWT, then invokes `teamcity.exe` with the raw
-`cf-access-token` and the dedicated TeamCity automation token. This prevents
-Cloudflare from injecting `CF_Authorization` into the mutating request, so
-TeamCity keeps treating the CLI POST as Bearer-authenticated and does not
-require CSRF. Load the credentials into the process environment as described
-in the access runbook, then run:
+short-lived Access JWT. It uses that token with TeamCity CLI for read-only
+operations and queues the verification through a Kotlin REST adapter that does
+not store cookies or follow redirects. TeamCity therefore receives the POST as
+a Bearer-authenticated request outside its CSRF session flow. Load the
+credentials into the process environment as described in the access runbook,
+then run:
 
 ```powershell
 .\gradlew.bat rerunTeamCityFigmaSync -PfigmaTeamCityWait=true

--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -170,11 +170,11 @@ the file explicitly. None of these generation, artifact, or verification nodes
 may remain isolated.
 
 The rerun uses the repository-owned Kotlin Gradle task. It exchanges the
-Cloudflare service credential for a short-lived raw `cf-access-token`, removes
-the service-token headers, and delegates active-run checks, queueing, and
-waiting to `teamcity.exe` with dedicated Bearer authentication. This avoids
-forwarding Cloudflare's session cookie into TeamCity's CSRF check. The TeamCity
-UI remains the recovery interface. The
+Cloudflare service credential for a short-lived raw `cf-access-token` and
+delegates active-run checks and waiting to `teamcity.exe`. Queueing uses a
+cookie-free Kotlin REST adapter with dedicated Bearer authentication and no
+redirect following. This keeps Cloudflare's session cookie out of TeamCity's
+CSRF check. The TeamCity UI remains the recovery interface. The
 repository-owned handoff downloads and validates the official artifact, then
 selects the next checkpoint unit without writing Figma. It is represented as a
 technical annotation on the handoff connection, not as another domain artifact.

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -4,7 +4,7 @@ type: runbook
 scope: repository-ci
 owner: ci-platform
 status: active
-last-reviewed: 2026-07-18
+last-reviewed: 2026-07-19
 review-cycle-days: 90
 sources:
   - .teamcity/settings.kts
@@ -12,6 +12,7 @@ sources:
   - docs/ci/windows-runtime.yaml
   - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/RerunTeamCityFigmaSyncTask.kt
   - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/EnvironmentTeamCityAutomationCredentialsProvider.kt
+  - repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRestRunStarter.kt
 ---
 
 # TeamCity Cloudflare Access Runbook
@@ -242,21 +243,25 @@ this route. Two consecutive CSRF reads therefore return different values, even
 when the HTTP client reuses one cookie container.
 
 TeamCity recommends clearing session cookies for unsafe requests authenticated
-with a Bearer token. The repository wrapper follows that contract while
-delegating TeamCity operations to the official CLI:
+with a Bearer token. TeamCity CLI 1.3.0 still retains the Cloudflare cookie for
+the mutating request, so the repository task separates its read and write
+transports:
 
 1. It exchanges the Cloudflare service-token headers for the short-lived Access
    JWT returned in `CF_Authorization`.
-2. It removes the service-token headers from the child process environment.
-3. It invokes `teamcity.exe` with temporary `TEAMCITY_TOKEN` and
-   `TEAMCITY_HEADER_CF_ACCESS_TOKEN` values for active-run checks, queueing, and
+2. It invokes `teamcity.exe` with temporary `TEAMCITY_TOKEN` and
+   `TEAMCITY_HEADER_CF_ACCESS_TOKEN` values only for active-run checks and
    waiting.
+3. It queues the build through `TeamCityRestRunStarter`, which sends Bearer and
+   `CF-Access-Token` headers without installing a cookie handler and without
+   following redirects.
 
-The POST does not resend the service-token pair because that would cause
-Cloudflare to inject a new `CF_Authorization` cookie into the request seen by
-TeamCity. Do not remove the application's `Allow` policy while this transport
-is in use; Cloudflare requires service-token headers on every request when an
-application has only `Service Auth` policies.
+The POST neither resends the service-token pair nor replays the exchanged
+`CF_Authorization` cookie. TeamCity therefore evaluates it as a Bearer request
+without a session and skips the CSRF check. Do not remove the application's
+`Allow` policy while this transport is in use; Cloudflare requires
+service-token headers on every request when an application has only `Service
+Auth` policies.
 
 The repository-owned rerun orchestration is Kotlin. Its credential port reads
 `TEAMCITY_TOKEN` and either `TEAMCITY_HEADER_CF_ACCESS_TOKEN` or the
@@ -297,8 +302,9 @@ The Kotlin task:
 - is fixed to `WaterMyPlants_WaterMyPlantsFigmaSync` on `main`;
 - obtains the Cloudflare and dedicated TeamCity credentials through a port;
 - converts the Cloudflare authorization cookie into the raw
-  `cf-access-token` header used only by the child CLI process;
-- delegates active-run queries, queueing, and waiting to TeamCity CLI;
+  `cf-access-token` header used by the CLI and REST adapters;
+- delegates active-run queries and waiting to TeamCity CLI;
+- queues through a Kotlin JDK HTTP adapter with no cookie store or redirects;
 - reuses a queued or running `Figma Sync` instead of creating a duplicate;
 - checks for an accepted active run before treating an uncertain start as a
   failure;

--- a/repo/figma-design-sync/AGENTS.md
+++ b/repo/figma-design-sync/AGENTS.md
@@ -138,8 +138,9 @@ used by CI.
   manifest-declared PNG through Kotlin.
 - `rerunTeamCityFigmaSync`: Water My Plants project adapter that obtains
   credentials through a port, exchanges Cloudflare service auth, and reuses or
-  queues the official `main` pipeline. Keep TeamCity CLI operations in
-  `teamcity-adapter` and secret-store selection outside portable modules.
+  queues the official `main` pipeline. Keep TeamCity CLI reads and cookie-free
+  REST writes in `teamcity-adapter`, and keep secret-store selection outside
+  portable modules.
 - Treat `figmaDesignSync` as a CI-owned verification step. Developers may run it
   locally for diagnosis, but CI is the source of truth before merging into
   `main`.

--- a/repo/figma-design-sync/project-config/README.md
+++ b/repo/figma-design-sync/project-config/README.md
@@ -99,7 +99,10 @@ Kotlin `rerunTeamCityFigmaSync` task owns Cloudflare token exchange, active-run
 deduplication, queueing, and optional waiting. It obtains credentials through
 `TeamCityAutomationCredentialsProvider`; the default environment adapter keeps
 PowerShell SecretStore and other workstation-specific vaults outside the
-module. No Figma synchronization workflow depends on `tools/teamcity/`.
+module. Read-only run discovery and waiting use TeamCity CLI. Queueing uses the
+cookie-free Kotlin REST adapter so Bearer-authenticated POST requests do not
+enter TeamCity's CSRF session flow. No Figma synchronization workflow depends
+on `tools/teamcity/`.
 
 The upload task accepts these Gradle properties:
 
@@ -122,15 +125,15 @@ The rerun task accepts these Gradle properties:
 | `figmaTeamCityServerUrl` | `https://teamcity.marmatsan.dev` | Public HTTPS TeamCity endpoint. |
 | `figmaTeamCityValidateOnly` | `false` | Validate both authentication layers without queueing. |
 | `figmaTeamCityWait` | `false` | Wait for the reused or queued run and require success. |
-| `figmaTeamCityPollIntervalSeconds` | `10` | TeamCity CLI watch interval. |
-| `figmaTeamCityTimeoutMinutes` | `60` | Maximum TeamCity CLI watch duration. |
+| `figmaTeamCityPollIntervalSeconds` | `10` | TeamCity CLI watch interval after queueing. |
+| `figmaTeamCityTimeoutMinutes` | `60` | Maximum TeamCity CLI watch duration after queueing. |
 
 Credentials enter only through `TEAMCITY_TOKEN` plus either a short-lived
 `TEAMCITY_HEADER_CF_ACCESS_TOKEN` or the
 `TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID` and
 `TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET` pair. The task exchanges the pair for
-the short-lived token before starting the CLI child process and never logs the
-values.
+the short-lived token before starting either transport and never logs the
+values or stores response cookies.
 
 ## Verification
 

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/RerunTeamCityFigmaSyncTask.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/RerunTeamCityFigmaSyncTask.kt
@@ -1,6 +1,8 @@
 package com.marmatsan.figmaDesignSync.projectConfig
 
+import com.marmatsan.figmaDesignSync.teamcityAdapter.TeamCityCompositeRunClient
 import com.marmatsan.figmaDesignSync.teamcityAdapter.TeamCityCliClient
+import com.marmatsan.figmaDesignSync.teamcityAdapter.TeamCityRestRunStarter
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -34,13 +36,21 @@ abstract class RerunTeamCityFigmaSyncTask : DefaultTask() {
     @TaskAction
     fun rerun() {
         val credentials = EnvironmentTeamCityAutomationCredentialsProvider().load(serverUrl.get())
-        val client = TeamCityCliClient(
+        val cliClient = TeamCityCliClient(
             environment = mapOf(
                 "TEAMCITY_URL" to credentials.serverUrl,
                 "TEAMCITY_TOKEN" to credentials.teamCityToken,
                 "TEAMCITY_HEADER_CF_ACCESS_TOKEN" to credentials.cloudflareAccessToken,
                 "TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID" to null,
                 "TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET" to null
+            )
+        )
+        val client = TeamCityCompositeRunClient(
+            readClient = cliClient,
+            runStarter = TeamCityRestRunStarter(
+                serverUrl = credentials.serverUrl,
+                teamCityToken = credentials.teamCityToken,
+                cloudflareAccessToken = credentials.cloudflareAccessToken
             )
         )
         val result = TeamCityFigmaSyncRerunner(

--- a/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityAutomationCredentials.kt
+++ b/repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/TeamCityAutomationCredentials.kt
@@ -1,6 +1,6 @@
 package com.marmatsan.figmaDesignSync.projectConfig
 
-/** Short-lived credentials supplied to the TeamCity CLI child process. */
+/** Short-lived credentials supplied to the TeamCity CLI and REST adapters. */
 data class TeamCityAutomationCredentials(
     val serverUrl: String,
     val teamCityToken: String,

--- a/repo/figma-design-sync/teamcity-adapter/README.md
+++ b/repo/figma-design-sync/teamcity-adapter/README.md
@@ -5,11 +5,12 @@ configuration and the portable `figma-design-sync` CI model. It owns every
 TeamCity YAML/XML parsing rule required to populate pipelines, jobs, triggers,
 artifacts, published checks, dependencies, and VCS roots.
 
-It also exposes `TeamCityCliClient`, the typed CLI boundary used by
-project-config operational tasks to inspect and download successful TeamCity
-artifact sets, find active runs, queue a run, and wait for its result without
-PowerShell orchestration. Authentication is supplied as a per-process
-environment map so the adapter does not own a particular secret store.
+It also exposes typed operational boundaries without PowerShell orchestration.
+`TeamCityCliClient` inspects and downloads successful TeamCity artifact sets,
+finds active runs, and waits for their results. `TeamCityRestRunStarter` queues
+a run through a cookie-free Bearer request, while `TeamCityCompositeRunClient`
+combines those read and write transports. Authentication is supplied at the
+adapter boundary so this module does not own a particular secret store.
 
 The public entry point is `TeamCityCiConfigurationProvider`. A project selects
 that class through `figmaDesignSync.ciConfigurationProviderClassName`, supplies

--- a/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCompositeRunClient.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCompositeRunClient.kt
@@ -1,0 +1,25 @@
+package com.marmatsan.figmaDesignSync.teamcityAdapter
+
+/** Composes read-only TeamCity operations with an independently secured run starter. */
+class TeamCityCompositeRunClient(
+    private val readClient: TeamCityRunClient,
+    private val runStarter: TeamCityRunStarter
+) : TeamCityRunClient {
+    override fun listRuns(
+        buildTypeId: String,
+        branch: String,
+        status: String,
+        limit: Int
+    ): List<TeamCityRun> = readClient.listRuns(buildTypeId, branch, status, limit)
+
+    override fun startRun(buildTypeId: String, branch: String): TeamCityRun =
+        runStarter.startRun(buildTypeId, branch)
+
+    override fun watchRun(
+        buildId: Long,
+        pollIntervalSeconds: Int,
+        timeoutMinutes: Int
+    ): TeamCityRun = readClient.watchRun(buildId, pollIntervalSeconds, timeoutMinutes)
+
+    override fun readRun(buildId: Long): TeamCityRun = readClient.readRun(buildId)
+}

--- a/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRestRunStarter.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRestRunStarter.kt
@@ -1,0 +1,114 @@
+package com.marmatsan.figmaDesignSync.teamcityAdapter
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/** Cookie-free REST adapter for queueing a TeamCity run with Bearer authentication. */
+class TeamCityRestRunStarter(
+    serverUrl: String,
+    private val teamCityToken: String,
+    private val cloudflareAccessToken: String,
+    private val send: (URI, Map<String, String>, String) -> Response = ::sendRequest
+) : TeamCityRunStarter {
+    private val endpoint = URI.create("${serverUrl.trimEnd('/')}/app/rest/buildQueue").also { uri ->
+        require(uri.scheme.equals("https", ignoreCase = true)) {
+            "The public TeamCity automation endpoint must use HTTPS."
+        }
+        require(uri.host != null && uri.userInfo == null && uri.query == null && uri.fragment == null) {
+            "The public TeamCity automation endpoint must be an absolute HTTPS origin."
+        }
+    }
+
+    init {
+        require(teamCityToken.isNotBlank()) { "The TeamCity automation token must not be blank." }
+        require(cloudflareAccessToken.isNotBlank()) {
+            "The Cloudflare Access token must not be blank."
+        }
+    }
+
+    override fun startRun(buildTypeId: String, branch: String): TeamCityRun {
+        require(buildTypeId.isNotBlank()) { "The TeamCity build type id must not be blank." }
+        require(branch.isNotBlank()) { "The TeamCity branch must not be blank." }
+        val body = buildJsonObject {
+            put("buildType", buildJsonObject { put("id", buildTypeId) })
+            put("branchName", branch)
+        }.toString()
+        val response = send(
+            endpoint,
+            mapOf(
+                "Accept" to "application/json",
+                "Authorization" to "Bearer $teamCityToken",
+                "CF-Access-Token" to cloudflareAccessToken,
+                "Content-Type" to "application/json"
+            ),
+            body
+        )
+        require(response.statusCode in 200..299) {
+            "TeamCity REST queue request failed with HTTP ${response.statusCode}: " +
+                response.body.take(MAX_ERROR_BODY_LENGTH)
+        }
+        val root = runCatching { Json.parseToJsonElement(response.body).jsonObject }
+            .getOrElse { error ->
+                throw IllegalArgumentException("TeamCity REST returned invalid JSON.", error)
+            }
+        return root.toTeamCityRun(defaultBranch = branch)
+    }
+
+    data class Response(
+        val statusCode: Int,
+        val body: String
+    )
+
+    private companion object {
+        const val MAX_ERROR_BODY_LENGTH = 500
+        val requestTimeout: Duration = Duration.ofSeconds(30)
+
+        fun sendRequest(
+            uri: URI,
+            headers: Map<String, String>,
+            body: String
+        ): Response {
+            val requestBuilder = HttpRequest.newBuilder(uri)
+                .timeout(requestTimeout)
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+            headers.forEach(requestBuilder::header)
+            val response = HttpClient.newBuilder()
+                .connectTimeout(requestTimeout)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build()
+                .send(
+                    requestBuilder.build(),
+                    HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+                )
+            return Response(statusCode = response.statusCode(), body = response.body())
+        }
+    }
+}
+
+private fun JsonObject.toTeamCityRun(defaultBranch: String): TeamCityRun =
+    TeamCityRun(
+        id = requiredString("id").toLong(),
+        state = requiredString("state"),
+        status = optionalString("status"),
+        statusText = optionalString("statusText"),
+        branchName = optionalString("branchName") ?: defaultBranch,
+        webUrl = optionalString("webUrl")
+    )
+
+private fun JsonObject.requiredString(name: String): String =
+    optionalString(name)
+        ?: throw IllegalArgumentException("TeamCity REST response is missing '$name'.")
+
+private fun JsonObject.optionalString(name: String): String? =
+    this[name]?.jsonPrimitive?.contentOrNull

--- a/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRunClient.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRunClient.kt
@@ -1,15 +1,13 @@
 package com.marmatsan.figmaDesignSync.teamcityAdapter
 
 /** Typed operations required to validate, queue, and wait for TeamCity runs. */
-interface TeamCityRunClient {
+interface TeamCityRunClient : TeamCityRunStarter {
     fun listRuns(
         buildTypeId: String,
         branch: String,
         status: String,
         limit: Int = 1
     ): List<TeamCityRun>
-
-    fun startRun(buildTypeId: String, branch: String): TeamCityRun
 
     fun watchRun(
         buildId: Long,

--- a/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRunStarter.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRunStarter.kt
@@ -1,0 +1,6 @@
+package com.marmatsan.figmaDesignSync.teamcityAdapter
+
+/** Mutating boundary for queueing one TeamCity run. */
+fun interface TeamCityRunStarter {
+    fun startRun(buildTypeId: String, branch: String): TeamCityRun
+}

--- a/repo/figma-design-sync/teamcity-adapter/src/test/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCompositeRunClientTest.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/test/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityCompositeRunClientTest.kt
@@ -1,0 +1,46 @@
+package com.marmatsan.figmaDesignSync.teamcityAdapter
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+internal class TeamCityCompositeRunClientTest : FunSpec({
+    test("uses the independent starter for mutating requests") {
+        val readClient = object : TeamCityRunClient {
+            override fun listRuns(
+                buildTypeId: String,
+                branch: String,
+                status: String,
+                limit: Int
+            ): List<TeamCityRun> = emptyList()
+
+            override fun startRun(buildTypeId: String, branch: String): TeamCityRun =
+                error("The read client must not queue a run")
+
+            override fun watchRun(
+                buildId: Long,
+                pollIntervalSeconds: Int,
+                timeoutMinutes: Int
+            ): TeamCityRun = error("Not used")
+
+            override fun readRun(buildId: Long): TeamCityRun = error("Not used")
+        }
+        val queued = TeamCityRun(
+            id = 1681,
+            state = "queued",
+            status = null,
+            statusText = null,
+            branchName = "main",
+            webUrl = "https://teamcity.example/build/1681"
+        )
+        val client = TeamCityCompositeRunClient(
+            readClient = readClient,
+            runStarter = TeamCityRunStarter { buildTypeId, branch ->
+                buildTypeId shouldBe "WaterMyPlants_WaterMyPlantsFigmaSync"
+                branch shouldBe "main"
+                queued
+            }
+        )
+
+        client.startRun("WaterMyPlants_WaterMyPlantsFigmaSync", "main") shouldBe queued
+    }
+})

--- a/repo/figma-design-sync/teamcity-adapter/src/test/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRestRunStarterTest.kt
+++ b/repo/figma-design-sync/teamcity-adapter/src/test/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRestRunStarterTest.kt
@@ -1,0 +1,102 @@
+package com.marmatsan.figmaDesignSync.teamcityAdapter
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import java.net.URI
+
+internal class TeamCityRestRunStarterTest : FunSpec({
+    test("queues a run with Bearer and Cloudflare headers but no cookies") {
+        var requestedUri: URI? = null
+        var requestedHeaders: Map<String, String>? = null
+        var requestedBody: String? = null
+        val starter = TeamCityRestRunStarter(
+            serverUrl = "https://teamcity.example/",
+            teamCityToken = "teamcity-token",
+            cloudflareAccessToken = "cloudflare-token"
+        ) { uri, headers, body ->
+            requestedUri = uri
+            requestedHeaders = headers
+            requestedBody = body
+            TeamCityRestRunStarter.Response(
+                statusCode = 200,
+                body =
+                    """
+                    {
+                      "id": 1680,
+                      "state": "queued",
+                      "branchName": "main",
+                      "webUrl": "https://teamcity.example/build/1680"
+                    }
+                    """.trimIndent()
+            )
+        }
+
+        starter.startRun("WaterMyPlants_WaterMyPlantsFigmaSync", "main") shouldBe
+            TeamCityRun(
+                id = 1680,
+                state = "queued",
+                status = null,
+                statusText = null,
+                branchName = "main",
+                webUrl = "https://teamcity.example/build/1680"
+            )
+        requestedUri shouldBe URI.create("https://teamcity.example/app/rest/buildQueue")
+        requestedHeaders shouldBe mapOf(
+            "Accept" to "application/json",
+            "Authorization" to "Bearer teamcity-token",
+            "CF-Access-Token" to "cloudflare-token",
+            "Content-Type" to "application/json"
+        )
+        requestedHeaders.orEmpty().shouldNotContainKey("Cookie")
+        requestedBody shouldBe
+            "{\"buildType\":{\"id\":\"WaterMyPlants_WaterMyPlantsFigmaSync\"}," +
+                "\"branchName\":\"main\"}"
+    }
+
+    test("rejects redirects instead of following them with authorization headers") {
+        val starter = TeamCityRestRunStarter(
+            serverUrl = "https://teamcity.example",
+            teamCityToken = "teamcity-token",
+            cloudflareAccessToken = "cloudflare-token"
+        ) { _, _, _ ->
+            TeamCityRestRunStarter.Response(statusCode = 302, body = "redirect")
+        }
+
+        val exception = shouldThrow<IllegalArgumentException> {
+            starter.startRun("WaterMyPlants_WaterMyPlantsFigmaSync", "main")
+        }
+
+        exception.message shouldBe
+            "TeamCity REST queue request failed with HTTP 302: redirect"
+    }
+
+    test("rejects a malformed successful response") {
+        val starter = TeamCityRestRunStarter(
+            serverUrl = "https://teamcity.example",
+            teamCityToken = "teamcity-token",
+            cloudflareAccessToken = "cloudflare-token"
+        ) { _, _, _ ->
+            TeamCityRestRunStarter.Response(statusCode = 200, body = "not-json")
+        }
+
+        val exception = shouldThrow<IllegalArgumentException> {
+            starter.startRun("WaterMyPlants_WaterMyPlantsFigmaSync", "main")
+        }
+
+        exception.message shouldBe "TeamCity REST returned invalid JSON."
+    }
+
+    test("requires an HTTPS TeamCity origin") {
+        val exception = shouldThrow<IllegalArgumentException> {
+            TeamCityRestRunStarter(
+                serverUrl = "http://teamcity.example",
+                teamCityToken = "teamcity-token",
+                cloudflareAccessToken = "cloudflare-token"
+            )
+        }
+
+        exception.message shouldBe "The public TeamCity automation endpoint must use HTTPS."
+    }
+})


### PR DESCRIPTION
## Summary

- route the mutating TeamCity build-queue request through a Kotlin REST adapter
- keep active-run discovery, artifact reads, and completion monitoring on TeamCity CLI
- send only Bearer and `CF-Access-Token` headers, with no cookie store and no redirect following
- document the split read/write transport and the verified CSRF recovery contract

## Root cause

TeamCity CLI 1.2.1 and 1.3.0 replay the Cloudflare `CF_Authorization` cookie on mutating requests. TeamCity then treats the POST as session-authenticated and rejects it because the CLI does not provide a matching CSRF token.

## Impact

`rerunTeamCityFigmaSync` can now reuse or queue the official `main` Figma Sync pipeline without falling back to the TeamCity UI. Credentials remain runtime-managed, and no PowerShell orchestration or repository-stored secret was added.

## Validation

- `./gradlew.bat :figma-design-sync:domain:check :figma-design-sync:data:check :figma-design-sync:teamcity-adapter:check :figma-design-sync:plugin:check :figma-design-sync:project-config:check checkFigmaVersionNaming checkFigmaCatalogUsage`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1`
- authenticated validation via `rerunTeamCityFigmaSync -PfigmaTeamCityValidateOnly=true`
- real rerun via `rerunTeamCityFigmaSync -PfigmaTeamCityWait=true`: TeamCity Figma Sync build 1680 finished successfully
