### PR TITLE
feat(ci): add typed verification plan

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -94,6 +94,12 @@ The pipeline:
   decision; documentation-only changes then run `git diff --check`, while every
   other change runs `.\gradlew.bat check --stacktrace` so Gradle failures retain
   their diagnostic context in the TeamCity build log;
+- generates `build/reports/ci/ci-plan.json` through the repository-owned Kotlin
+  planner before verification. The plan is currently observational: it records
+  typed verification units, dependencies, capabilities, and reasons, while the
+  existing Figma classifier remains authoritative for task selection;
+- publishes `build/reports/ci` as pipeline evidence so the observational plan
+  can be compared with the work that actually ran;
 - blocks invalid dependency version key names through
   `checkFigmaVersionNaming`, which is wired into the Gradle `check` lifecycle;
 - blocks unused dependency catalog entries through `checkFigmaCatalogUsage`,

--- a/.teamcity/documentation-coverage.json
+++ b/.teamcity/documentation-coverage.json
@@ -36,6 +36,20 @@
       "documentationPaths": [".teamcity/README.md", "docs/runbooks/teamcity-cloudflare-access.md"]
     },
     {
+      "id": "ci-planner",
+      "sourcePaths": [
+        "repo/ci/*",
+        "repo/ci/src/*",
+        "repo/ci/build.gradle.kts",
+        "repo/ci/settings.gradle.kts"
+      ],
+      "documentationPaths": [
+        "repo/ci/README.md",
+        "docs/reference/ci-verification-plan.md",
+        ".teamcity/README.md"
+      ]
+    },
+    {
       "id": "figma-sync-implementation",
       "sourcePaths": [
         "repo/figma-design-sync/tools/*",

--- a/.teamcity/scripts/invoke-ci-verification.ps1
+++ b/.teamcity/scripts/invoke-ci-verification.ps1
@@ -13,7 +13,7 @@ Push-Location $repositoryRoot
 try {
     & (Join-Path $PSScriptRoot "validate-documentation.ps1") -FailOnCoverageGap
 
-    & $gradleWrapper classifyFigmaChangeImpact --stacktrace
+    & $gradleWrapper generateCiPlan classifyFigmaChangeImpact --stacktrace
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -97,6 +97,10 @@ object WaterMyPlantsCi : Pipeline({
         features {
             feature(GitHubStatusPublisher("TeamCity CI"))
         }
+
+        outputFiles {
+            pipelineArtifacts("build/reports/ci")
+        }
     }
 })
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,12 @@ plugins {
     id("com.marmatsan.android") apply false
     id("com.marmatsan.bddTest") apply false
     id("com.marmatsan.compose") apply false
+    id("com.marmatsan.ci") apply true
     id("com.marmatsan.waterMyPlantsFigmaDesignSync") apply true
     id("com.marmatsan.protobuf") apply false
     id("com.marmatsan.unitTest") apply false
+}
+
+tasks.named("check") {
+    dependsOn(gradle.includedBuild("ci").task(":check"))
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,7 @@ them.
 - [ADR-0002: Distribute Figma Design Sync as a Gradle Plugin](decisions/adr-0002-distribute-figma-design-sync-as-gradle-plugin.md)
 - [ADR-0003: Keep the Figma Runtime Boundary in TypeScript](decisions/adr-0003-keep-figma-runtime-boundary-in-typescript.md)
 - [ADR-0004: Use JSON for Figma Writer Project Configuration](decisions/adr-0004-use-json-for-figma-writer-project-configuration.md)
+
+## CI References
+
+- [CI Verification Plan](reference/ci-verification-plan.md)

--- a/docs/reference/ci-verification-plan.md
+++ b/docs/reference/ci-verification-plan.md
@@ -9,7 +9,6 @@ review-cycle-days: 180
 sources:
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlan.kt
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
-  - build/reports/ci/ci-plan.json
 ---
 
 # CI Verification Plan

--- a/docs/reference/ci-verification-plan.md
+++ b/docs/reference/ci-verification-plan.md
@@ -1,0 +1,78 @@
+---
+title: CI verification plan
+type: reference
+scope: repository
+owner: repository-tooling
+status: active
+last-reviewed: 2026-07-19
+review-cycle-days: 180
+sources:
+  - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlan.kt
+  - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
+  - build/reports/ci/ci-plan.json
+---
+
+# CI Verification Plan
+
+## Purpose
+
+This reference defines the provider-neutral contract that selects repository
+verification work. TeamCity consumes the plan sequentially while the project
+has one agent. A future multi-agent topology may execute independent units in
+parallel without changing this contract.
+
+## Contract
+
+`generateCiPlan` writes `build/reports/ci/ci-plan.json` with:
+
+| Field | Meaning |
+|-------|---------|
+| `schemaVersion` | Version of the JSON compatibility contract. |
+| `mode` | `observation` until plan-based task omission becomes authoritative, then `enforced`. |
+| `comparisonBase` | Git revision used as the start of the committed diff. |
+| `head` | Exact revision being planned. |
+| `scope` | Primary path classification for reporting. |
+| `changedFiles` | Normalized repository-relative paths. |
+| `changedModules` | Directly changed Gradle modules; empty in schema version 1 observation mode. |
+| `affectedModules` | Changed modules plus transitive consumers; empty in schema version 1 observation mode. |
+| `verificationUnits` | Allow-listed work units, dependencies, capabilities, Gradle tasks, and reasons. |
+| `fullVerification` | Whether root `check` remains required. |
+| `fallbackReason` | Fail-closed explanation when targeted classification is unsafe. |
+
+Stable verification unit identifiers are `documentation`, `repository-diff`,
+`teamcity-dsl`, `figma-tooling`, `dependency-catalog`,
+`gradle-verification`, and `publish-reports`.
+
+## Invariants
+
+- Unknown or empty change sets require full verification.
+- Plan output contains no executable shell commands.
+- CI adapters map stable identifiers to versioned, reviewed commands.
+- Documentation validation remains repository-wide because its coverage rules
+  relate implementation paths to required documentation changes.
+- Observation mode cannot omit verification that the previous CI flow ran.
+- The required GitHub status remains `TeamCity CI`.
+
+## Performance Baseline
+
+The ten most recent successful `main` CI pipeline heads before this rollout
+(TeamCity runs `1615` through `1685`, sampled on 2026-07-19) establish the
+comparison baseline:
+
+| Metric | Minimum | Median | Maximum |
+|--------|---------|--------|---------|
+| Queue wait | 19 s | 28.5 s | 47 s |
+| Aggregate execution | 21 s | 41.5 s | 51 s |
+
+Future enforced selection records the same metrics for documentation-only,
+module-only, tooling, and full-verification changes. A targeted path must not
+reduce correctness, and full verification must not regress materially merely
+because the plan is visible.
+
+## Sources
+
+- `repo/ci` contains the executable models, classifier, Git adapter, JSON
+  writer, Gradle task, and tests.
+- `.teamcity/settings.kts` publishes the report.
+- `.teamcity/scripts/invoke-ci-verification.ps1` invokes the plan in
+  observation mode before the existing authoritative classifier.

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -10,6 +10,7 @@ sources:
   - settings.gradle.kts
   - repo/dependency-catalog/settings.gradle.kts
   - repo/gradle-plugins/settings.gradle.kts
+  - repo/ci/settings.gradle.kts
   - repo/figma-design-sync/settings.gradle.kts
   - repo/figma-design-sync/data/build.gradle.kts
   - repo/figma-design-sync/data/src/main/kotlin/com/marmatsan/figmaDesignSync/data/mcp/KtorFigmaPngAssetUploader.kt
@@ -70,11 +71,14 @@ modules support the repository and CI; they are not production app modules.
 |------|----------------|---------|
 | `repo/dependency-catalog/` | `dependency-catalog` | Parent included build for the reusable catalog engine and the Water My Plants catalog definition. |
 | `repo/gradle-plugins/` | `gradle-plugins` | Convention plugins used by app modules and other repository builds. |
+| `repo/ci/` | `ci` | Provider-neutral Kotlin planner that generates the versioned CI verification contract. |
 | `repo/figma-design-sync/` | `figma-design-sync` | Kotlin infrastructure that generates and executes the Figma sync contract, plus the TypeScript boundary evaluated by the Figma Plugin API. |
 
-The root build includes `repo/gradle-plugins` and `repo/figma-design-sync`
-through `pluginManagement.includeBuild(...)`. Both included builds consume
-`repo/dependency-catalog`.
+The root build includes `repo/gradle-plugins`, `repo/ci`, and
+`repo/figma-design-sync` through `pluginManagement.includeBuild(...)`.
+`repo/gradle-plugins` and `repo/figma-design-sync` consume the dependency
+catalog model. `repo/ci` reads only the central version properties while
+remaining independent from the concrete dependency trees.
 
 `repo/dependency-catalog` contains two Gradle modules with a one-way dependency:
 

--- a/repo/ci/README.md
+++ b/repo/ci/README.md
@@ -1,0 +1,28 @@
+# Repository CI Planner
+
+`repo/ci` owns the provider-neutral Kotlin contract that decides which
+verification units apply to a committed repository change.
+
+## Boundaries
+
+- Domain models and classification do not depend on TeamCity, GitHub Actions,
+  Gradle APIs, PowerShell, or Figma Design Sync.
+- The Git adapter resolves the committed diff against `origin/main`.
+- The Gradle plugin is the current composition root and registers
+  `generateCiPlan` in the Water My Plants root build.
+- CI providers consume allow-listed unit identifiers and Gradle task names;
+  they must never execute arbitrary commands read from the JSON report.
+
+The generated contract is documented in
+[`docs/reference/ci-verification-plan.md`](../../docs/reference/ci-verification-plan.md).
+
+## Verification
+
+```powershell
+.\gradlew.bat :ci:check
+.\gradlew.bat generateCiPlan
+```
+
+The first rollout is observational. TeamCity publishes the plan but continues
+to use the existing Figma change-impact classifier to select the authoritative
+verification path.

--- a/repo/ci/build.gradle.kts
+++ b/repo/ci/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    `java-gradle-plugin`
+    id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+dependencies {
+    implementation(gradleApi())
+    implementation(libs.org.jetbrains.kotlinx.serialization.json)
+
+    testImplementation(libs.io.kotest.runner.junit5)
+    testImplementation(libs.io.kotest.assertions.core)
+    testRuntimeOnly(libs.org.junit.jupiter.platform.launcher)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}
+
+gradlePlugin {
+    plugins.register("com.marmatsan.ci") {
+        id = "com.marmatsan.ci"
+        implementationClass = "com.marmatsan.ci.plugin.CiGradlePlugin"
+        displayName = "Water My Plants CI Planner"
+        description = "Generates the typed repository verification plan consumed by CI adapters."
+    }
+}

--- a/repo/ci/settings.gradle.kts
+++ b/repo/ci/settings.gradle.kts
@@ -1,0 +1,56 @@
+@file:Suppress("UnstableApiUsage")
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    val versions = java.util.Properties().apply {
+        file("../dependency-catalog/versions.properties").inputStream().use(::load)
+    }
+
+    plugins {
+        id("org.jetbrains.kotlin.jvm") version versions.getProperty("kotlinVersion")
+        id("org.jetbrains.kotlin.plugin.serialization") version versions.getProperty("kotlinVersion")
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    val versions = java.util.Properties().apply {
+        file("../dependency-catalog/versions.properties").inputStream().use(::load)
+    }
+
+    versionCatalogs {
+        create("libs") {
+            library(
+                "org.jetbrains.kotlinx.serialization.json",
+                "org.jetbrains.kotlinx",
+                "kotlinx-serialization-json"
+            ).version(versions.getProperty("serializationLibraryVersion"))
+            library(
+                "io.kotest.runner.junit5",
+                "io.kotest",
+                "kotest-runner-junit5"
+            ).version(versions.getProperty("kotestLibraryVersion"))
+            library(
+                "io.kotest.assertions.core",
+                "io.kotest",
+                "kotest-assertions-core"
+            ).version(versions.getProperty("kotestLibraryVersion"))
+            library(
+                "org.junit.jupiter.platform.launcher",
+                "org.junit.platform",
+                "junit-platform-launcher"
+            ).withoutVersion()
+        }
+    }
+}
+
+rootProject.name = "ci"

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/data/git/GitRepositoryChangeSetSource.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/data/git/GitRepositoryChangeSetSource.kt
@@ -1,0 +1,52 @@
+package com.marmatsan.ci.data.git
+
+import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import java.io.File
+
+/** Reads the committed change set used by CI without depending on a CI provider. */
+class GitRepositoryChangeSetSource {
+    fun read(repositoryRoot: File, comparisonBaseOverride: String? = null): RepositoryChangeSet {
+        val root = repositoryRoot.canonicalFile
+        val head = git(root, "rev-parse", "HEAD")
+        val base = comparisonBaseOverride?.takeIf(String::isNotBlank) ?: defaultBase(root, head)
+        val changedFiles = git(
+            root,
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRD",
+            "$base..$head"
+        ).lineSequence().map(::normalize).filter(String::isNotBlank).toList()
+
+        return RepositoryChangeSet(
+            comparisonBase = base,
+            head = head,
+            changedFiles = changedFiles
+        )
+    }
+
+    private fun defaultBase(root: File, head: String): String {
+        git(root, "rev-parse", "--verify", "origin/main")
+        val main = git(root, "rev-parse", "origin/main")
+        return if (head == main) {
+            git(root, "rev-parse", "$head^")
+        } else {
+            git(root, "merge-base", "HEAD", "origin/main")
+        }
+    }
+
+    private fun git(root: File, vararg arguments: String): String {
+        val safeDirectory = root.absolutePath.replace('\\', '/')
+        val process = ProcessBuilder(listOf("git", "-c", "safe.directory=$safeDirectory") + arguments)
+            .directory(root)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        val exitCode = process.waitFor()
+        check(exitCode == 0) {
+            "Failed to run git ${arguments.joinToString(" ")}: ${output.trim()}"
+        }
+        return output.trim()
+    }
+
+    private fun normalize(path: String): String = path.trim().replace('\\', '/')
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/data/json/CiPlanJson.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/data/json/CiPlanJson.kt
@@ -1,0 +1,23 @@
+package com.marmatsan.ci.data.json
+
+import com.marmatsan.ci.domain.model.CiPlan
+import java.io.File
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class CiPlanJson {
+    fun write(plan: CiPlan, output: File) {
+        output.parentFile.mkdirs()
+        output.writeText(format.encodeToString(plan) + System.lineSeparator())
+    }
+
+    fun read(source: String): CiPlan = format.decodeFromString(source)
+
+    private companion object {
+        val format = Json {
+            prettyPrint = true
+            encodeDefaults = true
+            explicitNulls = true
+        }
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlan.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlan.kt
@@ -1,0 +1,19 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.Serializable
+
+/** Provider-neutral verification plan generated for one repository revision. */
+@Serializable
+data class CiPlan(
+    val schemaVersion: Int,
+    val mode: CiPlanMode,
+    val comparisonBase: String?,
+    val head: String,
+    val scope: CiScope,
+    val changedFiles: List<String>,
+    val changedModules: List<String>,
+    val affectedModules: List<String>,
+    val verificationUnits: List<VerificationUnit>,
+    val fullVerification: Boolean,
+    val fallbackReason: String?
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlanMode.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlanMode.kt
@@ -1,0 +1,13 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CiPlanMode {
+    @SerialName("observation")
+    OBSERVATION,
+
+    @SerialName("enforced")
+    ENFORCED
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiScope.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiScope.kt
@@ -1,0 +1,28 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CiScope {
+    @SerialName("documentation-only")
+    DOCUMENTATION_ONLY,
+
+    @SerialName("teamcity")
+    TEAMCITY,
+
+    @SerialName("figma-tooling")
+    FIGMA_TOOLING,
+
+    @SerialName("dependency-infrastructure")
+    DEPENDENCY_INFRASTRUCTURE,
+
+    @SerialName("application")
+    APPLICATION,
+
+    @SerialName("mixed")
+    MIXED,
+
+    @SerialName("unknown")
+    UNKNOWN
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/RepositoryChangeSet.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/RepositoryChangeSet.kt
@@ -1,0 +1,7 @@
+package com.marmatsan.ci.domain.model
+
+data class RepositoryChangeSet(
+    val comparisonBase: String?,
+    val head: String,
+    val changedFiles: List<String>
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/VerificationUnit.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/VerificationUnit.kt
@@ -1,0 +1,15 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.Serializable
+
+/** One allow-listed unit that a CI provider may execute sequentially or in parallel. */
+@Serializable
+data class VerificationUnit(
+    val id: VerificationUnitId,
+    val required: Boolean,
+    val needs: List<VerificationUnitId>,
+    val capabilities: List<String>,
+    val parallelSafe: Boolean,
+    val gradleTasks: List<String>,
+    val reasons: List<String>
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/VerificationUnitId.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/VerificationUnitId.kt
@@ -1,0 +1,28 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class VerificationUnitId {
+    @SerialName("documentation")
+    DOCUMENTATION,
+
+    @SerialName("repository-diff")
+    REPOSITORY_DIFF,
+
+    @SerialName("teamcity-dsl")
+    TEAMCITY_DSL,
+
+    @SerialName("figma-tooling")
+    FIGMA_TOOLING,
+
+    @SerialName("dependency-catalog")
+    DEPENDENCY_CATALOG,
+
+    @SerialName("gradle-verification")
+    GRADLE_VERIFICATION,
+
+    @SerialName("publish-reports")
+    PUBLISH_REPORTS
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
@@ -1,0 +1,178 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.CiPlan
+import com.marmatsan.ci.domain.model.CiPlanMode
+import com.marmatsan.ci.domain.model.CiScope
+import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.model.VerificationUnit
+import com.marmatsan.ci.domain.model.VerificationUnitId
+
+/** Pure classifier that turns repository paths into provider-neutral verification units. */
+class CiPlanFactory {
+    fun create(changeSet: RepositoryChangeSet): CiPlan {
+        val changedFiles = changeSet.changedFiles.map(::normalize).distinct().sorted()
+        val categories = changedFiles.map(::category).toSet()
+        val documentationOnly = changedFiles.isNotEmpty() && categories == setOf(PathCategory.DOCUMENTATION)
+        val unknown = changedFiles.isEmpty() || PathCategory.UNKNOWN in categories
+        val scope = scope(categories, documentationOnly, unknown)
+        val fullVerification = !documentationOnly
+        val fallbackReason = when {
+            changedFiles.isEmpty() -> "No changed files were resolved; verification fails closed."
+            unknown -> "At least one changed path has no targeted verification policy."
+            else -> null
+        }
+
+        return CiPlan(
+            schemaVersion = SCHEMA_VERSION,
+            mode = CiPlanMode.OBSERVATION,
+            comparisonBase = changeSet.comparisonBase,
+            head = changeSet.head,
+            scope = scope,
+            changedFiles = changedFiles,
+            changedModules = emptyList(),
+            affectedModules = emptyList(),
+            verificationUnits = units(categories, documentationOnly, fullVerification, fallbackReason),
+            fullVerification = fullVerification,
+            fallbackReason = fallbackReason
+        )
+    }
+
+    private fun units(
+        categories: Set<PathCategory>,
+        documentationOnly: Boolean,
+        fullVerification: Boolean,
+        fallbackReason: String?
+    ): List<VerificationUnit> = listOf(
+        unit(
+            id = VerificationUnitId.DOCUMENTATION,
+            required = true,
+            capabilities = listOf("powershell"),
+            reasons = listOf("Documentation structure and coverage are repository-wide invariants.")
+        ),
+        unit(
+            id = VerificationUnitId.REPOSITORY_DIFF,
+            required = documentationOnly,
+            needs = listOf(VerificationUnitId.DOCUMENTATION),
+            capabilities = listOf("git"),
+            reasons = requiredReasons(documentationOnly, "Every changed path is documentation-only.")
+        ),
+        unit(
+            id = VerificationUnitId.TEAMCITY_DSL,
+            required = PathCategory.TEAMCITY in categories,
+            needs = listOf(VerificationUnitId.DOCUMENTATION),
+            capabilities = listOf("java", "maven", "teamcity-cli"),
+            reasons = requiredReasons(PathCategory.TEAMCITY in categories, "TeamCity configuration changed.")
+        ),
+        unit(
+            id = VerificationUnitId.FIGMA_TOOLING,
+            required = PathCategory.FIGMA in categories,
+            needs = listOf(VerificationUnitId.DOCUMENTATION),
+            capabilities = listOf("java", "android-sdk", "node"),
+            reasons = requiredReasons(PathCategory.FIGMA in categories, "Figma Design Sync implementation changed.")
+        ),
+        unit(
+            id = VerificationUnitId.DEPENDENCY_CATALOG,
+            required = PathCategory.DEPENDENCY_INFRASTRUCTURE in categories,
+            needs = listOf(VerificationUnitId.DOCUMENTATION),
+            capabilities = listOf("java", "android-sdk"),
+            reasons = requiredReasons(
+                PathCategory.DEPENDENCY_INFRASTRUCTURE in categories,
+                "Dependency catalog or Gradle infrastructure changed."
+            )
+        ),
+        unit(
+            id = VerificationUnitId.GRADLE_VERIFICATION,
+            required = fullVerification,
+            needs = listOf(VerificationUnitId.DOCUMENTATION),
+            capabilities = listOf("java", "android-sdk"),
+            gradleTasks = if (fullVerification) listOf("check") else emptyList(),
+            reasons = when {
+                fallbackReason != null -> listOf(fallbackReason)
+                fullVerification -> listOf("Observation mode preserves the existing full Gradle verification.")
+                else -> emptyList()
+            }
+        ),
+        unit(
+            id = VerificationUnitId.PUBLISH_REPORTS,
+            required = true,
+            needs = listOf(
+                VerificationUnitId.DOCUMENTATION,
+                VerificationUnitId.REPOSITORY_DIFF,
+                VerificationUnitId.TEAMCITY_DSL,
+                VerificationUnitId.FIGMA_TOOLING,
+                VerificationUnitId.DEPENDENCY_CATALOG,
+                VerificationUnitId.GRADLE_VERIFICATION
+            ),
+            capabilities = emptyList(),
+            parallelSafe = false,
+            reasons = listOf("The plan and verification evidence must remain inspectable.")
+        )
+    )
+
+    private fun unit(
+        id: VerificationUnitId,
+        required: Boolean,
+        needs: List<VerificationUnitId> = emptyList(),
+        capabilities: List<String>,
+        parallelSafe: Boolean = true,
+        gradleTasks: List<String> = emptyList(),
+        reasons: List<String>
+    ) = VerificationUnit(
+        id = id,
+        required = required,
+        needs = needs,
+        capabilities = capabilities,
+        parallelSafe = parallelSafe,
+        gradleTasks = gradleTasks,
+        reasons = reasons
+    )
+
+    private fun requiredReasons(required: Boolean, reason: String): List<String> =
+        if (required) listOf(reason) else emptyList()
+
+    private fun category(path: String): PathCategory = when {
+        isDocumentation(path) -> PathCategory.DOCUMENTATION
+        path.startsWith(".teamcity/") -> PathCategory.TEAMCITY
+        path.startsWith("repo/figma-design-sync/") -> PathCategory.FIGMA
+        path.startsWith("repo/dependency-catalog/") ||
+            path.startsWith("repo/gradle-plugins/") ||
+            path in ROOT_GRADLE_FILES -> PathCategory.DEPENDENCY_INFRASTRUCTURE
+        path.startsWith("app/") || path.startsWith("core/") || path.startsWith("onboarding/") ->
+            PathCategory.APPLICATION
+        else -> PathCategory.UNKNOWN
+    }
+
+    private fun scope(
+        categories: Set<PathCategory>,
+        documentationOnly: Boolean,
+        unknown: Boolean
+    ): CiScope = when {
+        documentationOnly -> CiScope.DOCUMENTATION_ONLY
+        unknown -> CiScope.UNKNOWN
+        categories.size > 1 -> CiScope.MIXED
+        PathCategory.TEAMCITY in categories -> CiScope.TEAMCITY
+        PathCategory.FIGMA in categories -> CiScope.FIGMA_TOOLING
+        PathCategory.DEPENDENCY_INFRASTRUCTURE in categories -> CiScope.DEPENDENCY_INFRASTRUCTURE
+        PathCategory.APPLICATION in categories -> CiScope.APPLICATION
+        else -> CiScope.UNKNOWN
+    }
+
+    private fun isDocumentation(path: String): Boolean =
+        path.endsWith(".md", ignoreCase = true) || path.endsWith("AGENTS.md", ignoreCase = true)
+
+    private fun normalize(path: String): String = path.trim().replace('\\', '/')
+
+    private enum class PathCategory {
+        DOCUMENTATION,
+        TEAMCITY,
+        FIGMA,
+        DEPENDENCY_INFRASTRUCTURE,
+        APPLICATION,
+        UNKNOWN
+    }
+
+    private companion object {
+        const val SCHEMA_VERSION = 1
+        val ROOT_GRADLE_FILES = setOf("settings.gradle.kts", "build.gradle.kts", "gradle.properties")
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
@@ -1,0 +1,20 @@
+package com.marmatsan.ci.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class CiGradlePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        require(project == project.rootProject) {
+            "com.marmatsan.ci must be applied to the root project."
+        }
+
+        project.tasks.register("generateCiPlan", GenerateCiPlanTask::class.java) { task ->
+            task.group = "verification"
+            task.description = "Generates the provider-neutral CI verification plan."
+            task.repositoryRoot.set(project.layout.projectDirectory)
+            project.providers.gradleProperty("ciComparisonBase").orNull?.let(task.comparisonBaseOverride::set)
+            task.outputFile.convention(project.layout.buildDirectory.file("reports/ci/ci-plan.json"))
+        }
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/GenerateCiPlanTask.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/GenerateCiPlanTask.kt
@@ -1,0 +1,46 @@
+package com.marmatsan.ci.plugin
+
+import com.marmatsan.ci.data.git.GitRepositoryChangeSetSource
+import com.marmatsan.ci.data.json.CiPlanJson
+import com.marmatsan.ci.domain.service.CiPlanFactory
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "The plan depends on Git revision state outside Gradle inputs")
+abstract class GenerateCiPlanTask : DefaultTask() {
+    @get:Internal
+    abstract val repositoryRoot: DirectoryProperty
+
+    @get:Optional
+    @get:Input
+    abstract val comparisonBaseOverride: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val changeSet = GitRepositoryChangeSetSource().read(
+            repositoryRoot = repositoryRoot.get().asFile,
+            comparisonBaseOverride = comparisonBaseOverride.orNull
+        )
+        val plan = CiPlanFactory().create(changeSet)
+        val output = outputFile.get().asFile
+        CiPlanJson().write(plan, output)
+
+        logger.lifecycle(
+            "CI plan generated: scope={}, fullVerification={}, output={}",
+            plan.scope,
+            plan.fullVerification,
+            output.absolutePath
+        )
+    }
+}

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/data/json/CiPlanJsonTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/data/json/CiPlanJsonTest.kt
@@ -1,0 +1,21 @@
+package com.marmatsan.ci.data.json
+
+import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.service.CiPlanFactory
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CiPlanJsonTest : FunSpec({
+    test("round trips the versioned verification contract") {
+        val expected = CiPlanFactory().create(
+            RepositoryChangeSet(
+                comparisonBase = "base-sha",
+                head = "head-sha",
+                changedFiles = listOf(".teamcity/settings.kts")
+            )
+        )
+        val json = CiPlanJson()
+
+        json.read(kotlinx.serialization.json.Json.encodeToString(expected)) shouldBe expected
+    }
+})

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/CiPlanFactoryTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/CiPlanFactoryTest.kt
@@ -1,0 +1,69 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.CiScope
+import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.model.VerificationUnitId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+class CiPlanFactoryTest : FunSpec({
+    test("documentation-only changes avoid full Gradle verification") {
+        val plan = plan("docs/ci/main-branch-protection.md", "repo/ci/README.md")
+
+        plan.scope shouldBe CiScope.DOCUMENTATION_ONLY
+        plan.fullVerification shouldBe false
+        plan.requiredUnitIds() shouldContain VerificationUnitId.REPOSITORY_DIFF
+        plan.requiredUnitIds().contains(VerificationUnitId.GRADLE_VERIFICATION) shouldBe false
+    }
+
+    test("TeamCity changes retain full verification in observation mode") {
+        val plan = plan(".teamcity/settings.kts")
+
+        plan.scope shouldBe CiScope.TEAMCITY
+        plan.fullVerification shouldBe true
+        plan.requiredUnitIds() shouldContain VerificationUnitId.TEAMCITY_DSL
+        plan.gradleTasks() shouldBe listOf("check")
+    }
+
+    test("mixed changes keep all matching units") {
+        val plan = plan("repo/figma-design-sync/tools/package.json", "app/build.gradle.kts")
+
+        plan.scope shouldBe CiScope.MIXED
+        plan.requiredUnitIds() shouldContain VerificationUnitId.FIGMA_TOOLING
+        plan.requiredUnitIds() shouldContain VerificationUnitId.GRADLE_VERIFICATION
+    }
+
+    test("unknown paths fail closed") {
+        val plan = plan("automation/unclassified.txt")
+
+        plan.scope shouldBe CiScope.UNKNOWN
+        plan.fullVerification shouldBe true
+        plan.fallbackReason shouldBe "At least one changed path has no targeted verification policy."
+        plan.gradleTasks() shouldBe listOf("check")
+    }
+
+    test("empty change sets fail closed") {
+        val plan = plan()
+
+        plan.scope shouldBe CiScope.UNKNOWN
+        plan.fullVerification shouldBe true
+        plan.fallbackReason shouldBe "No changed files were resolved; verification fails closed."
+    }
+}) {
+    companion object {
+        private fun plan(vararg paths: String) = CiPlanFactory().create(
+            RepositoryChangeSet(
+                comparisonBase = "base-sha",
+                head = "head-sha",
+                changedFiles = paths.toList()
+            )
+        )
+
+        private fun com.marmatsan.ci.domain.model.CiPlan.requiredUnitIds() =
+            verificationUnits.filter { it.required }.map { it.id }
+
+        private fun com.marmatsan.ci.domain.model.CiPlan.gradleTasks() =
+            verificationUnits.flatMap { it.gradleTasks }
+    }
+}

--- a/repo/dependency-catalog/README.md
+++ b/repo/dependency-catalog/README.md
@@ -22,6 +22,11 @@ compatibility artifact. `:catalog-core` does publish the supporting
 Figma Design Sync plugin. The concrete Water My Plants catalog remains source
 owned and is not part of the portable release.
 
+`versions.properties` is also the central version registry for repository
+included builds. `repo/ci` reads Kotlin, serialization, and test-library
+versions from it during settings evaluation, but does not depend on either
+catalog module or the concrete Water My Plants dependency trees.
+
 ## Public Contract
 
 The Water My Plants project adapter consumes:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ pluginManagement {
     // Custom Gradle plugins
     includeBuild("./repo/gradle-plugins")
     includeBuild("./repo/figma-design-sync")
+    includeBuild("./repo/ci")
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
## What changed

- add a provider-neutral Kotlin CI planner under `repo/ci`
- generate a versioned `build/reports/ci/ci-plan.json` contract
- model verification units, dependencies, capabilities, reasons, and fail-closed fallback
- run the planner in TeamCity observation mode without changing authoritative task selection
- publish the CI plan as TeamCity evidence and document its contract and performance baseline

## Why

The current CI hides documentation validation, change classification, and Gradle verification behind one PowerShell step. A typed plan separates decision policy from execution topology so one TeamCity agent can execute it sequentially now and future agents can fan out the same units without rewriting policy.

## Impact

No verification is omitted in this PR. Documentation-only selection still uses the existing Figma classifier and every other change still runs the full Gradle `check`.

## Verification

- `./gradlew.bat :ci:check generateCiPlan --stacktrace`
- `./gradlew.bat check --stacktrace`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1 -FailOnCoverageGap`
- `./mvnw.cmd -f .teamcity/pom.xml teamcity-configs:generate`
- `teamcity project settings validate .teamcity --verbose`