### PR TITLE
feat(ci): select affected module verification

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -96,9 +96,12 @@ The pipeline:
   inline Windows command adapters:
   documentation-only changes run `git diff --check`, `.teamcity` changes also
   generate the Kotlin DSL with the Maven wrapper, and every non-documentation
-  change runs one `.\gradlew.bat check --stacktrace` invocation;
+  change runs one Gradle invocation with the plan's validated task list;
 - coalesces Figma-tooling and dependency-catalog units into that single heavy
   Gradle invocation while only one agent is available;
+- uses the evaluated Gradle module graph for application changes: the changed
+  modules, all transitive reverse dependents, and `checkFigmaCatalogUsage` run
+  in one Gradle invocation; invalid graphs or unmapped paths use root `check`;
 - publishes `build/reports/ci` as pipeline evidence;
 - blocks invalid dependency version key names through
   `checkFigmaVersionNaming`, which is wired into the Gradle `check` lifecycle;
@@ -295,7 +298,7 @@ steps separately:
 - name: Validate documentation
   script-content: powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\validate-documentation.ps1 -FailOnCoverageGap
 - name: Run Gradle verification
-  script-content: .\gradlew.bat check --stacktrace
+  script-content: .\gradlew.bat %ci.unit.gradle-verification.tasks% --stacktrace
 ```
 
 Conditional steps use `ci.unit.*.required` parameters emitted by the planner.
@@ -304,6 +307,8 @@ The skip/run check is part of each visible generated command because TeamCity
 Every parameter referenced by step content is also declared on the job so it
 does not become an unresolved automatic agent requirement. Heavy verification
 defaults to enabled and the Kotlin plan replaces those defaults at runtime.
+The Gradle command receives only task names validated by the Kotlin TeamCity
+adapter; arbitrary command content is never read from `ci-plan.json`.
 Commands remain defined in versioned TeamCity DSL; the JSON plan never carries
 shell content.
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -84,6 +84,7 @@ object WaterMyPlantsCi : Pipeline({
             param("ci.unit.repository-diff.required", "false")
             param("ci.unit.teamcity-dsl.required", "true")
             param("ci.unit.gradle-verification.required", "true")
+            param("ci.unit.gradle-verification.tasks", "check")
         }
 
         steps {
@@ -131,7 +132,7 @@ object WaterMyPlantsCi : Pipeline({
                         echo Skipped by the enforced CI plan.
                         exit /b 0
                     )
-                    call .\gradlew.bat check --stacktrace
+                    call .\gradlew.bat %ci.unit.gradle-verification.tasks% --stacktrace
                     if errorlevel 1 exit /b 1
                 """.trimIndent()
             })

--- a/docs/reference/ci-verification-plan.md
+++ b/docs/reference/ci-verification-plan.md
@@ -9,6 +9,7 @@ review-cycle-days: 180
 sources:
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlan.kt
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
+  - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/ModuleImpactAnalyzer.kt
 ---
 
 # CI Verification Plan
@@ -32,8 +33,8 @@ parallel without changing this contract.
 | `head` | Exact revision being planned. |
 | `scope` | Primary path classification for reporting. |
 | `changedFiles` | Normalized repository-relative paths. |
-| `changedModules` | Directly changed Gradle modules; empty in schema version 1 observation mode. |
-| `affectedModules` | Changed modules plus transitive consumers; empty in schema version 1 observation mode. |
+| `changedModules` | Gradle modules that own changed implementation paths. |
+| `affectedModules` | Changed modules plus all transitive reverse dependents. |
 | `verificationUnits` | Allow-listed work units, dependencies, capabilities, Gradle tasks, and reasons. |
 | `fullVerification` | Whether root `check` remains required. |
 | `fallbackReason` | Fail-closed explanation when targeted classification is unsafe. |
@@ -51,6 +52,14 @@ Stable verification unit identifiers are `documentation`, `repository-diff`,
   relate implementation paths to required documentation changes.
 - Documentation-only classification is deliberately narrow. Unknown Markdown
   locations fail closed to full verification instead of being treated as docs.
+- The evaluated Gradle project model is the source of truth for module
+  directories and project dependency edges. Synthetic parent projects without
+  build files are not executable modules.
+- An empty graph, duplicate module identity or directory, unresolved edge, or
+  unclassified path fails closed to the root `check` task.
+- Module-only changes run `check` for the changed modules and every transitive
+  consumer. They also run `checkFigmaCatalogUsage`, because removing source can
+  make a dependency declaration unused even when catalog files did not change.
 - The required GitHub status remains `TeamCity CI`.
 
 ## TeamCity Execution
@@ -67,7 +76,7 @@ adapters:
 | `teamcity-dsl` | Generate the TeamCity Kotlin DSL with the Maven wrapper when `.teamcity` changes. |
 | `figma-tooling` | Coalesced into the heavy Gradle verification on the single agent. |
 | `dependency-catalog` | Coalesced into the heavy Gradle verification on the single agent. |
-| `gradle-verification` | Run one root `check` invocation for every non-documentation change. |
+| `gradle-verification` | Run affected module checks plus catalog usage for safe module-only changes; otherwise run root `check`. |
 | `publish-reports` | Publish `build/reports/ci` through the job artifact contract. |
 
 This topology keeps one checkout, one agent allocation, and one authoritative
@@ -98,8 +107,8 @@ because the plan is visible.
   adapters used by `prepareTeamCityCiPlan`.
 - `.teamcity/settings.kts` maps allow-listed parameters to visible sequential
   steps, performs their skip/run decision, and publishes the report. The
-TeamCity 2026.1 Pipeline YAML generator does not serialize inherited build
-step conditions, so the decision is explicit in each generated step command.
-Referenced parameters have job-level defaults to prevent unresolved automatic
-agent requirements; heavy verification defaults to enabled and therefore fails
-closed if runtime replacement is unavailable.
+  TeamCity 2026.1 Pipeline YAML generator does not serialize inherited build
+  step conditions, so the decision is explicit in each generated step command.
+  Referenced parameters have job-level defaults to prevent unresolved automatic
+  agent requirements; heavy verification defaults to enabled and therefore
+  fails closed if runtime replacement is unavailable.

--- a/repo/ci/README.md
+++ b/repo/ci/README.md
@@ -8,8 +8,12 @@ verification units apply to a committed repository change.
 - Domain models and classification do not depend on TeamCity, GitHub Actions,
   Gradle APIs, PowerShell, or Figma Design Sync.
 - The Git adapter resolves the committed diff against `origin/main`.
+- The Gradle adapter snapshots executable root-project modules and declared
+  project dependencies after project evaluation. The domain computes changed
+  modules and transitive reverse dependents without Gradle APIs.
 - The TeamCity adapter converts the plan to escaped, allow-listed build
-  parameters; it does not add provider concerns to the domain model.
+  parameters and validates every emitted Gradle task name; it does not add
+  provider concerns to the domain model.
 - The Gradle plugin is the current composition root and registers
   `generateCiPlan` and `prepareTeamCityCiPlan` in the Water My Plants root
   build.
@@ -30,4 +34,6 @@ The generated contract is documented in
 `generateCiPlan` writes the provider-neutral JSON contract.
 `prepareTeamCityCiPlan` additionally emits TeamCity service messages for the
 reviewed parameter allow-list. TeamCity uses those parameters to run visible
-sequential steps while the repository has one build agent.
+sequential steps while the repository has one build agent. Safe module-only
+changes select affected module `check` tasks plus `checkFigmaCatalogUsage`;
+invalid graphs, unknown paths, and tooling changes retain root `check`.

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/data/gradle/GradleProjectModuleGraphSource.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/data/gradle/GradleProjectModuleGraphSource.kt
@@ -1,0 +1,51 @@
+package com.marmatsan.ci.data.gradle
+
+import com.marmatsan.ci.domain.model.ModuleDependency
+import com.marmatsan.ci.domain.model.RepositoryModule
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
+
+/** Reads the evaluated root Gradle project model into the provider-neutral graph. */
+class GradleProjectModuleGraphSource {
+    fun read(rootProject: Project): RepositoryModuleGraph {
+        require(rootProject == rootProject.rootProject) {
+            "The CI module graph must be read from the root project."
+        }
+
+        val moduleProjects = rootProject.subprojects
+            .filter { project -> project.buildFile.isFile }
+            .sortedBy(Project::getPath)
+        val modules = moduleProjects.map { project ->
+            RepositoryModule(
+                id = project.path,
+                directory = rootProject.relativePath(project.projectDir).replace('\\', '/')
+            )
+        }
+        val dependencies = moduleProjects
+            .flatMap { dependentProject ->
+                dependentProject.configurations.flatMap { configuration ->
+                    configuration.dependencies
+                        .withType(ProjectDependency::class.java)
+                        .map { dependency ->
+                            ModuleDependency(
+                                dependentModule = dependentProject.path,
+                                dependencyModule = dependency.path
+                            )
+                        }
+                }
+            }
+            .distinct()
+            .sortedWith(
+                compareBy(
+                    ModuleDependency::dependentModule,
+                    ModuleDependency::dependencyModule
+                )
+            )
+
+        return RepositoryModuleGraph(
+            modules = modules,
+            dependencies = dependencies
+        )
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/data/teamcity/TeamCityCiPlanParameters.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/data/teamcity/TeamCityCiPlanParameters.kt
@@ -14,7 +14,10 @@ class TeamCityCiPlanParameters {
         "ci.plan.comparisonBase" to plan.comparisonBase.orEmpty(),
         "ci.plan.head" to plan.head,
         "ci.plan.fullVerification" to plan.fullVerification.toString(),
-        "ci.plan.fallbackReason" to plan.fallbackReason.orEmpty()
+        "ci.plan.fallbackReason" to plan.fallbackReason.orEmpty(),
+        "ci.plan.changedModules" to plan.changedModules.joinToString(","),
+        "ci.plan.affectedModules" to plan.affectedModules.joinToString(","),
+        "ci.unit.gradle-verification.tasks" to validatedGradleTasks(plan)
     ).apply {
         plan.verificationUnits.forEach { unit ->
             put("ci.unit.${unit.id.externalName()}.required", unit.required.toString())
@@ -44,5 +47,21 @@ class TeamCityCiPlanParameters {
         VerificationUnitId.DEPENDENCY_CATALOG -> "dependency-catalog"
         VerificationUnitId.GRADLE_VERIFICATION -> "gradle-verification"
         VerificationUnitId.PUBLISH_REPORTS -> "publish-reports"
+    }
+
+    private fun validatedGradleTasks(plan: CiPlan): String {
+        val tasks = plan.verificationUnits
+            .single { unit -> unit.id == VerificationUnitId.GRADLE_VERIFICATION }
+            .gradleTasks
+        require(tasks.all(GRADLE_TASK::matches)) {
+            "The CI plan contains a Gradle task outside the TeamCity allow-list."
+        }
+        return tasks.joinToString(" ")
+    }
+
+    private companion object {
+        val GRADLE_TASK = Regex(
+            "^(?:(?::[A-Za-z0-9_.-]+)+:)?[A-Za-z][A-Za-z0-9_-]*$"
+        )
     }
 }

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/ModuleDependency.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/ModuleDependency.kt
@@ -1,0 +1,7 @@
+package com.marmatsan.ci.domain.model
+
+/** Directed edge from the consuming module to the module it depends on. */
+data class ModuleDependency(
+    val dependentModule: String,
+    val dependencyModule: String
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/ModuleImpact.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/ModuleImpact.kt
@@ -1,0 +1,11 @@
+package com.marmatsan.ci.domain.model
+
+/** Changed modules, their reverse dependents, and any graph validation failure. */
+data class ModuleImpact(
+    val changedModules: List<String>,
+    val affectedModules: List<String>,
+    val fallbackReason: String?
+) {
+    val isValid: Boolean
+        get() = fallbackReason == null
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/RepositoryModule.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/RepositoryModule.kt
@@ -1,0 +1,7 @@
+package com.marmatsan.ci.domain.model
+
+/** Gradle module identity and its repository-relative source directory. */
+data class RepositoryModule(
+    val id: String,
+    val directory: String
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/RepositoryModuleGraph.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/RepositoryModuleGraph.kt
@@ -1,0 +1,7 @@
+package com.marmatsan.ci.domain.model
+
+/** Provider-neutral snapshot of the root Gradle project's module graph. */
+data class RepositoryModuleGraph(
+    val modules: List<RepositoryModule>,
+    val dependencies: List<ModuleDependency>
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
@@ -4,20 +4,37 @@ import com.marmatsan.ci.domain.model.CiPlan
 import com.marmatsan.ci.domain.model.CiPlanMode
 import com.marmatsan.ci.domain.model.CiScope
 import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
 import com.marmatsan.ci.domain.model.VerificationUnit
 import com.marmatsan.ci.domain.model.VerificationUnitId
 
 /** Pure classifier that turns repository paths into provider-neutral verification units. */
 class CiPlanFactory {
-    fun create(changeSet: RepositoryChangeSet): CiPlan {
+    fun create(changeSet: RepositoryChangeSet, moduleGraph: RepositoryModuleGraph): CiPlan {
         val changedFiles = changeSet.changedFiles.map(::normalize).distinct().sorted()
-        val categories = changedFiles.map(::category).toSet()
+        val moduleImpactAnalyzer = ModuleImpactAnalyzer()
+        val moduleImpact = moduleImpactAnalyzer.analyze(
+            changedFiles = changedFiles.filterNot(::isDocumentation),
+            graph = moduleGraph
+        )
+        val categories = changedFiles.map { path ->
+            category(path, moduleGraph, moduleImpactAnalyzer)
+        }.toSet()
         val documentationOnly = changedFiles.isNotEmpty() && categories == setOf(PathCategory.DOCUMENTATION)
-        val unknown = changedFiles.isEmpty() || PathCategory.UNKNOWN in categories
+        val moduleGraphInvalid = changedFiles.any { path -> !isDocumentation(path) } && !moduleImpact.isValid
+        val unknown = changedFiles.isEmpty() || PathCategory.UNKNOWN in categories || moduleGraphInvalid
         val scope = scope(categories, documentationOnly, unknown)
-        val fullVerification = !documentationOnly
+        val targetedModuleVerification =
+            !unknown &&
+                PathCategory.APPLICATION in categories &&
+                categories.all { category ->
+                    category == PathCategory.APPLICATION || category == PathCategory.DOCUMENTATION
+                } &&
+                moduleImpact.affectedModules.isNotEmpty()
+        val fullVerification = !documentationOnly && !targetedModuleVerification
         val fallbackReason = when {
             changedFiles.isEmpty() -> "No changed files were resolved; verification fails closed."
+            moduleGraphInvalid -> moduleImpact.fallbackReason
             unknown -> "At least one changed path has no targeted verification policy."
             else -> null
         }
@@ -29,9 +46,16 @@ class CiPlanFactory {
             head = changeSet.head,
             scope = scope,
             changedFiles = changedFiles,
-            changedModules = emptyList(),
-            affectedModules = emptyList(),
-            verificationUnits = units(categories, documentationOnly, fullVerification, fallbackReason),
+            changedModules = moduleImpact.changedModules,
+            affectedModules = moduleImpact.affectedModules,
+            verificationUnits = units(
+                categories = categories,
+                documentationOnly = documentationOnly,
+                targetedModuleVerification = targetedModuleVerification,
+                fullVerification = fullVerification,
+                affectedModules = moduleImpact.affectedModules,
+                fallbackReason = fallbackReason
+            ),
             fullVerification = fullVerification,
             fallbackReason = fallbackReason
         )
@@ -40,7 +64,9 @@ class CiPlanFactory {
     private fun units(
         categories: Set<PathCategory>,
         documentationOnly: Boolean,
+        targetedModuleVerification: Boolean,
         fullVerification: Boolean,
+        affectedModules: List<String>,
         fallbackReason: String?
     ): List<VerificationUnit> = listOf(
         unit(
@@ -82,12 +108,20 @@ class CiPlanFactory {
         ),
         unit(
             id = VerificationUnitId.GRADLE_VERIFICATION,
-            required = fullVerification,
+            required = !documentationOnly,
             needs = listOf(VerificationUnitId.DOCUMENTATION),
             capabilities = listOf("java", "android-sdk"),
-            gradleTasks = if (fullVerification) listOf("check") else emptyList(),
+            gradleTasks = when {
+                documentationOnly -> emptyList()
+                targetedModuleVerification ->
+                    affectedModules.map { module -> "$module:check" } + CHECK_FIGMA_CATALOG_USAGE
+                else -> listOf("check")
+            },
             reasons = when {
                 fallbackReason != null -> listOf(fallbackReason)
+                targetedModuleVerification -> listOf(
+                    "Changed modules and their transitive reverse dependents can be verified independently."
+                )
                 fullVerification -> listOf("Every non-documentation change retains full Gradle verification.")
                 else -> emptyList()
             }
@@ -130,15 +164,18 @@ class CiPlanFactory {
     private fun requiredReasons(required: Boolean, reason: String): List<String> =
         if (required) listOf(reason) else emptyList()
 
-    private fun category(path: String): PathCategory = when {
+    private fun category(
+        path: String,
+        moduleGraph: RepositoryModuleGraph,
+        moduleImpactAnalyzer: ModuleImpactAnalyzer
+    ): PathCategory = when {
         isDocumentation(path) -> PathCategory.DOCUMENTATION
         path.startsWith(".teamcity/") -> PathCategory.TEAMCITY
         path.startsWith("repo/figma-design-sync/") -> PathCategory.FIGMA
         path.startsWith("repo/dependency-catalog/") ||
             path.startsWith("repo/gradle-plugins/") ||
             path in ROOT_GRADLE_FILES -> PathCategory.DEPENDENCY_INFRASTRUCTURE
-        path.startsWith("app/") || path.startsWith("core/") || path.startsWith("onboarding/") ->
-            PathCategory.APPLICATION
+        moduleImpactAnalyzer.moduleFor(path, moduleGraph) != null -> PathCategory.APPLICATION
         else -> PathCategory.UNKNOWN
     }
 
@@ -186,6 +223,7 @@ class CiPlanFactory {
 
     private companion object {
         const val SCHEMA_VERSION = 1
+        const val CHECK_FIGMA_CATALOG_USAGE = "checkFigmaCatalogUsage"
         val ROOT_GRADLE_FILES = setOf("settings.gradle.kts", "build.gradle.kts", "gradle.properties")
     }
 }

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/ModuleImpactAnalyzer.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/ModuleImpactAnalyzer.kt
@@ -1,0 +1,113 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.ModuleImpact
+import com.marmatsan.ci.domain.model.RepositoryModule
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
+
+/** Resolves changed Gradle modules and their transitive reverse dependents. */
+class ModuleImpactAnalyzer {
+    fun analyze(changedFiles: List<String>, graph: RepositoryModuleGraph): ModuleImpact {
+        validate(graph)?.let { reason ->
+            return ModuleImpact(
+                changedModules = emptyList(),
+                affectedModules = emptyList(),
+                fallbackReason = reason
+            )
+        }
+
+        val changedModules = changedFiles
+            .mapNotNull { path -> moduleFor(path, graph) }
+            .map(RepositoryModule::id)
+            .distinct()
+            .sorted()
+        val reverseDependencies = graph.dependencies
+            .groupBy(
+                keySelector = { dependency -> dependency.dependencyModule },
+                valueTransform = { dependency -> dependency.dependentModule }
+            )
+        val affectedModules = changedModules
+            .flatMap { module -> reverseClosure(module, reverseDependencies) }
+            .distinct()
+            .sorted()
+
+        return ModuleImpact(
+            changedModules = changedModules,
+            affectedModules = affectedModules,
+            fallbackReason = null
+        )
+    }
+
+    fun moduleFor(path: String, graph: RepositoryModuleGraph): RepositoryModule? {
+        val normalizedPath = normalize(path)
+        return graph.modules
+            .filter { module ->
+                val directory = normalize(module.directory).trimEnd('/')
+                normalizedPath == directory || normalizedPath.startsWith("$directory/")
+            }
+            .maxByOrNull { module -> normalize(module.directory).length }
+    }
+
+    private fun validate(graph: RepositoryModuleGraph): String? {
+        if (graph.modules.isEmpty()) {
+            return "The Gradle module graph is empty; verification fails closed."
+        }
+
+        val invalidModule = graph.modules.firstOrNull { module ->
+            !MODULE_ID.matches(module.id) ||
+                module.directory.isBlank() ||
+                normalize(module.directory).startsWith("../") ||
+                normalize(module.directory).contains("/../")
+        }
+        if (invalidModule != null) {
+            return "The Gradle module graph contains an invalid module: ${invalidModule.id}."
+        }
+
+        val duplicateId = graph.modules.groupingBy(RepositoryModule::id).eachCount()
+            .entries.firstOrNull { (_, count) -> count > 1 }
+        if (duplicateId != null) {
+            return "The Gradle module graph contains duplicate module id ${duplicateId.key}."
+        }
+
+        val duplicateDirectory = graph.modules
+            .groupingBy { module -> normalize(module.directory).trimEnd('/') }
+            .eachCount()
+            .entries.firstOrNull { (_, count) -> count > 1 }
+        if (duplicateDirectory != null) {
+            return "The Gradle module graph contains duplicate directory ${duplicateDirectory.key}."
+        }
+
+        val moduleIds = graph.modules.map(RepositoryModule::id).toSet()
+        val unresolvedDependency = graph.dependencies.firstOrNull { dependency ->
+            dependency.dependentModule !in moduleIds || dependency.dependencyModule !in moduleIds
+        }
+        if (unresolvedDependency != null) {
+            return "The Gradle module graph contains an unresolved dependency: " +
+                "${unresolvedDependency.dependentModule} -> ${unresolvedDependency.dependencyModule}."
+        }
+
+        return null
+    }
+
+    private fun reverseClosure(
+        module: String,
+        reverseDependencies: Map<String, List<String>>
+    ): Set<String> {
+        val visited = linkedSetOf<String>()
+        val pending = ArrayDeque<String>()
+        pending.add(module)
+
+        while (pending.isNotEmpty()) {
+            val current = pending.removeFirst()
+            if (!visited.add(current)) continue
+            reverseDependencies[current].orEmpty().sorted().forEach(pending::addLast)
+        }
+
+        return visited
+    }
+
+    private fun normalize(path: String): String = path.trim().replace('\\', '/')
+
+    private companion object {
+        val MODULE_ID = Regex("^(:[A-Za-z0-9_.-]+)+$")
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
@@ -1,5 +1,6 @@
 package com.marmatsan.ci.plugin
 
+import com.marmatsan.ci.data.gradle.GradleProjectModuleGraphSource
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -15,6 +16,20 @@ class CiGradlePlugin : Plugin<Project> {
             task.repositoryRoot.set(project.layout.projectDirectory)
             project.providers.gradleProperty("ciComparisonBase").orNull?.let(task.comparisonBaseOverride::set)
             task.outputFile.convention(project.layout.buildDirectory.file("reports/ci/ci-plan.json"))
+        }
+
+        project.gradle.projectsEvaluated {
+            val graph = GradleProjectModuleGraphSource().read(project)
+            generateCiPlan.configure { task ->
+                task.moduleDirectories.set(
+                    graph.modules.associate { module -> module.id to module.directory }
+                )
+                task.moduleDependencyEdges.set(
+                    graph.dependencies.map { dependency ->
+                        "${dependency.dependentModule}->${dependency.dependencyModule}"
+                    }
+                )
+            }
         }
 
         project.tasks.register("prepareTeamCityCiPlan", PrepareTeamCityCiPlanTask::class.java) { task ->

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/GenerateCiPlanTask.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/GenerateCiPlanTask.kt
@@ -2,10 +2,15 @@ package com.marmatsan.ci.plugin
 
 import com.marmatsan.ci.data.git.GitRepositoryChangeSetSource
 import com.marmatsan.ci.data.json.CiPlanJson
+import com.marmatsan.ci.domain.model.ModuleDependency
+import com.marmatsan.ci.domain.model.RepositoryModule
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
 import com.marmatsan.ci.domain.service.CiPlanFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -26,13 +31,32 @@ abstract class GenerateCiPlanTask : DefaultTask() {
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
+    @get:Input
+    abstract val moduleDirectories: MapProperty<String, String>
+
+    @get:Input
+    abstract val moduleDependencyEdges: ListProperty<String>
+
     @TaskAction
     fun generate() {
         val changeSet = GitRepositoryChangeSetSource().read(
             repositoryRoot = repositoryRoot.get().asFile,
             comparisonBaseOverride = comparisonBaseOverride.orNull
         )
-        val plan = CiPlanFactory().create(changeSet)
+        val moduleGraph = RepositoryModuleGraph(
+            modules = moduleDirectories.get().map { (id, directory) ->
+                RepositoryModule(id = id, directory = directory)
+            },
+            dependencies = moduleDependencyEdges.get().map { edge ->
+                val parts = edge.split(EDGE_SEPARATOR, limit = 2)
+                check(parts.size == 2) { "Invalid serialized module dependency: $edge" }
+                ModuleDependency(
+                    dependentModule = parts.first(),
+                    dependencyModule = parts.last()
+                )
+            }
+        )
+        val plan = CiPlanFactory().create(changeSet, moduleGraph)
         val output = outputFile.get().asFile
         CiPlanJson().write(plan, output)
 
@@ -42,5 +66,9 @@ abstract class GenerateCiPlanTask : DefaultTask() {
             plan.fullVerification,
             output.absolutePath
         )
+    }
+
+    private companion object {
+        const val EDGE_SEPARATOR = "->"
     }
 }

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/TestModuleGraph.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/TestModuleGraph.kt
@@ -1,0 +1,17 @@
+package com.marmatsan.ci
+
+import com.marmatsan.ci.domain.model.ModuleDependency
+import com.marmatsan.ci.domain.model.RepositoryModule
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
+
+fun testModuleGraph(): RepositoryModuleGraph = RepositoryModuleGraph(
+    modules = listOf(
+        RepositoryModule(id = ":app", directory = "app"),
+        RepositoryModule(id = ":core:ui", directory = "core/ui"),
+        RepositoryModule(id = ":onboarding:ui", directory = "onboarding/ui")
+    ),
+    dependencies = listOf(
+        ModuleDependency(dependentModule = ":app", dependencyModule = ":core:ui"),
+        ModuleDependency(dependentModule = ":onboarding:ui", dependencyModule = ":core:ui")
+    )
+)

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/data/gradle/GradleProjectModuleGraphSourceTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/data/gradle/GradleProjectModuleGraphSourceTest.kt
@@ -1,0 +1,65 @@
+package com.marmatsan.ci.data.gradle
+
+import com.marmatsan.ci.domain.model.ModuleDependency
+import com.marmatsan.ci.domain.model.RepositoryModule
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Files
+import org.gradle.testfixtures.ProjectBuilder
+
+class GradleProjectModuleGraphSourceTest : FunSpec({
+    test("reads real module directories and project dependencies from Gradle") {
+        val rootDirectory = Files.createTempDirectory("ci-module-graph").toFile()
+
+        try {
+            val root = ProjectBuilder.builder()
+                .withName("root")
+                .withProjectDir(rootDirectory)
+                .build()
+            val coreParent = childProject(root, "core")
+            val coreUi = childProject(coreParent, "ui", withBuildFile = true)
+            val app = childProject(root, "app", withBuildFile = true)
+            val onboardingParent = childProject(root, "onboarding")
+            val onboardingUi = childProject(onboardingParent, "ui", withBuildFile = true)
+            app.configurations.create("implementation")
+            onboardingUi.configurations.create("implementation")
+            app.dependencies.add("implementation", app.dependencies.project(mapOf("path" to coreUi.path)))
+            onboardingUi.dependencies.add(
+                "implementation",
+                onboardingUi.dependencies.project(mapOf("path" to coreUi.path))
+            )
+
+            GradleProjectModuleGraphSource().read(root) shouldBe RepositoryModuleGraph(
+                modules = listOf(
+                    RepositoryModule(id = ":app", directory = "app"),
+                    RepositoryModule(id = ":core:ui", directory = "core/ui"),
+                    RepositoryModule(id = ":onboarding:ui", directory = "onboarding/ui")
+                ),
+                dependencies = listOf(
+                    ModuleDependency(dependentModule = ":app", dependencyModule = ":core:ui"),
+                    ModuleDependency(dependentModule = ":onboarding:ui", dependencyModule = ":core:ui")
+                )
+            )
+        } finally {
+            rootDirectory.deleteRecursively()
+        }
+    }
+}) {
+    companion object {
+        private fun childProject(
+            parent: org.gradle.api.Project,
+            name: String,
+            withBuildFile: Boolean = false
+        ): org.gradle.api.Project {
+            val directory = File(parent.projectDir, name).apply(File::mkdirs)
+            if (withBuildFile) File(directory, "build.gradle.kts").writeText("")
+            return ProjectBuilder.builder()
+                .withName(name)
+                .withParent(parent)
+                .withProjectDir(directory)
+                .build()
+        }
+    }
+}

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/data/json/CiPlanJsonTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/data/json/CiPlanJsonTest.kt
@@ -2,17 +2,19 @@ package com.marmatsan.ci.data.json
 
 import com.marmatsan.ci.domain.model.RepositoryChangeSet
 import com.marmatsan.ci.domain.service.CiPlanFactory
+import com.marmatsan.ci.testModuleGraph
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class CiPlanJsonTest : FunSpec({
     test("round trips the versioned verification contract") {
         val expected = CiPlanFactory().create(
-            RepositoryChangeSet(
+            changeSet = RepositoryChangeSet(
                 comparisonBase = "base-sha",
                 head = "head-sha",
                 changedFiles = listOf(".teamcity/settings.kts")
-            )
+            ),
+            moduleGraph = testModuleGraph()
         )
         val json = CiPlanJson()
 

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/data/teamcity/TeamCityCiPlanParametersTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/data/teamcity/TeamCityCiPlanParametersTest.kt
@@ -1,18 +1,22 @@
 package com.marmatsan.ci.data.teamcity
 
 import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.model.VerificationUnitId
 import com.marmatsan.ci.domain.service.CiPlanFactory
+import com.marmatsan.ci.testModuleGraph
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class TeamCityCiPlanParametersTest : FunSpec({
     test("exports allow-listed parameters for a TeamCity change") {
         val plan = CiPlanFactory().create(
-            RepositoryChangeSet(
+            changeSet = RepositoryChangeSet(
                 comparisonBase = "base-sha",
                 head = "head-sha",
                 changedFiles = listOf(".teamcity/settings.kts")
-            )
+            ),
+            moduleGraph = testModuleGraph()
         )
 
         TeamCityCiPlanParameters().create(plan) shouldBe linkedMapOf(
@@ -23,6 +27,9 @@ class TeamCityCiPlanParametersTest : FunSpec({
             "ci.plan.head" to "head-sha",
             "ci.plan.fullVerification" to "true",
             "ci.plan.fallbackReason" to "",
+            "ci.plan.changedModules" to "",
+            "ci.plan.affectedModules" to "",
+            "ci.unit.gradle-verification.tasks" to "check",
             "ci.unit.documentation.required" to "true",
             "ci.unit.repository-diff.required" to "false",
             "ci.unit.teamcity-dsl.required" to "true",
@@ -31,5 +38,47 @@ class TeamCityCiPlanParametersTest : FunSpec({
             "ci.unit.gradle-verification.required" to "true",
             "ci.unit.publish-reports.required" to "true"
         )
+    }
+
+    test("exports affected module tasks as a validated TeamCity value") {
+        val plan = CiPlanFactory().create(
+            changeSet = RepositoryChangeSet(
+                comparisonBase = "base-sha",
+                head = "head-sha",
+                changedFiles = listOf("core/ui/src/main/kotlin/Theme.kt")
+            ),
+            moduleGraph = testModuleGraph()
+        )
+
+        val parameters = TeamCityCiPlanParameters().create(plan)
+
+        parameters["ci.plan.changedModules"] shouldBe ":core:ui"
+        parameters["ci.plan.affectedModules"] shouldBe ":app,:core:ui,:onboarding:ui"
+        parameters["ci.unit.gradle-verification.tasks"] shouldBe
+            ":app:check :core:ui:check :onboarding:ui:check checkFigmaCatalogUsage"
+    }
+
+    test("rejects Gradle task values that could inject shell content") {
+        val plan = CiPlanFactory().create(
+            changeSet = RepositoryChangeSet(
+                comparisonBase = "base-sha",
+                head = "head-sha",
+                changedFiles = listOf("app/src/main/kotlin/MainActivity.kt")
+            ),
+            moduleGraph = testModuleGraph()
+        )
+        val unsafePlan = plan.copy(
+            verificationUnits = plan.verificationUnits.map { unit ->
+                if (unit.id == VerificationUnitId.GRADLE_VERIFICATION) {
+                    unit.copy(gradleTasks = listOf("check && publish"))
+                } else {
+                    unit
+                }
+            }
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            TeamCityCiPlanParameters().create(unsafePlan)
+        }
     }
 })

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/CiPlanFactoryTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/CiPlanFactoryTest.kt
@@ -1,9 +1,12 @@
 package com.marmatsan.ci.domain.service
 
-import com.marmatsan.ci.domain.model.CiScope
 import com.marmatsan.ci.domain.model.CiPlanMode
+import com.marmatsan.ci.domain.model.CiScope
+import com.marmatsan.ci.domain.model.ModuleDependency
 import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
 import com.marmatsan.ci.domain.model.VerificationUnitId
+import com.marmatsan.ci.testModuleGraph
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
@@ -61,14 +64,62 @@ class CiPlanFactoryTest : FunSpec({
         plan.requiredUnitIds() shouldContain VerificationUnitId.FIGMA_TOOLING
         plan.requiredUnitIds() shouldContain VerificationUnitId.GRADLE_VERIFICATION
     }
+
+    test("application module changes select only the module and repository-wide catalog usage") {
+        val plan = plan("app/src/main/kotlin/com/marmatsan/MainActivity.kt")
+
+        plan.scope shouldBe CiScope.APPLICATION
+        plan.changedModules shouldBe listOf(":app")
+        plan.affectedModules shouldBe listOf(":app")
+        plan.fullVerification shouldBe false
+        plan.gradleTasks() shouldBe listOf(":app:check", "checkFigmaCatalogUsage")
+    }
+
+    test("core module changes include all transitive reverse dependents") {
+        val plan = plan("core/ui/src/main/kotlin/com/marmatsan/ui/Theme.kt")
+
+        plan.changedModules shouldBe listOf(":core:ui")
+        plan.affectedModules shouldBe listOf(":app", ":core:ui", ":onboarding:ui")
+        plan.gradleTasks() shouldBe listOf(
+            ":app:check",
+            ":core:ui:check",
+            ":onboarding:ui:check",
+            "checkFigmaCatalogUsage"
+        )
+    }
+
+    test("unresolved module graph dependencies fail closed to root check") {
+        val invalidGraph = testModuleGraph().copy(
+            dependencies = testModuleGraph().dependencies + ModuleDependency(
+                dependentModule = ":app",
+                dependencyModule = ":missing"
+            )
+        )
+        val plan = plan(
+            "app/src/main/kotlin/com/marmatsan/MainActivity.kt",
+            moduleGraph = invalidGraph
+        )
+
+        plan.scope shouldBe CiScope.UNKNOWN
+        plan.changedModules shouldBe emptyList()
+        plan.affectedModules shouldBe emptyList()
+        plan.fullVerification shouldBe true
+        plan.gradleTasks() shouldBe listOf("check")
+        plan.fallbackReason shouldBe
+            "The Gradle module graph contains an unresolved dependency: :app -> :missing."
+    }
 }) {
     companion object {
-        private fun plan(vararg paths: String) = CiPlanFactory().create(
-            RepositoryChangeSet(
+        private fun plan(
+            vararg paths: String,
+            moduleGraph: RepositoryModuleGraph = testModuleGraph()
+        ) = CiPlanFactory().create(
+            changeSet = RepositoryChangeSet(
                 comparisonBase = "base-sha",
                 head = "head-sha",
                 changedFiles = paths.toList()
-            )
+            ),
+            moduleGraph = moduleGraph
         )
 
         private fun com.marmatsan.ci.domain.model.CiPlan.requiredUnitIds() =

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/ModuleImpactAnalyzerTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/ModuleImpactAnalyzerTest.kt
@@ -1,0 +1,42 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.ModuleDependency
+import com.marmatsan.ci.domain.model.RepositoryModule
+import com.marmatsan.ci.domain.model.RepositoryModuleGraph
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ModuleImpactAnalyzerTest : FunSpec({
+    test("walks transitive reverse dependencies") {
+        val graph = RepositoryModuleGraph(
+            modules = listOf(
+                RepositoryModule(id = ":app", directory = "app"),
+                RepositoryModule(id = ":core:domain", directory = "core/domain"),
+                RepositoryModule(id = ":feature:plants:domain", directory = "feature/plants/domain")
+            ),
+            dependencies = listOf(
+                ModuleDependency(
+                    dependentModule = ":app",
+                    dependencyModule = ":feature:plants:domain"
+                ),
+                ModuleDependency(
+                    dependentModule = ":feature:plants:domain",
+                    dependencyModule = ":core:domain"
+                )
+            )
+        )
+
+        val impact = ModuleImpactAnalyzer().analyze(
+            changedFiles = listOf("core/domain/src/main/kotlin/Plant.kt"),
+            graph = graph
+        )
+
+        impact.changedModules shouldBe listOf(":core:domain")
+        impact.affectedModules shouldBe listOf(
+            ":app",
+            ":core:domain",
+            ":feature:plants:domain"
+        )
+        impact.fallbackReason shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

- derive the repository module graph from Gradle's evaluated project model
- resolve changed modules and their transitive reverse dependents
- run validated module check tasks plus `checkFigmaCatalogUsage` for module-only changes
- fail closed to the root `check` for invalid graphs, tooling changes, and unknown paths
- expose changed modules, affected modules, and selected tasks through the provider-neutral CI contract

## Verification

- `.\gradlew.bat :ci:check prepareTeamCityCiPlan --rerun-tasks`
- `.\gradlew.bat check` with the Figma token loaded from `.env`
- `.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate`
- `teamcity project settings validate .teamcity --verbose`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1 -FailOnCoverageGap`
- `git diff --check`
- verified configuration-cache reuse for `prepareTeamCityCiPlan`

For this PR, the planner intentionally selects the root `check` because it changes CI tooling itself.