### PR TITLE
feat(ci): expose operational pipeline phases

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -162,15 +162,16 @@ validation scripts and their coverage manifest. Unlike documentation-only
 changes, these revisions still run the normal Gradle CI verification before
 merge.
 
-`prepareOfficialFigmaSync` owns the complete preparation chain in the
-`figma-design-sync` Gradle plugin. It removes the previous report directory,
-classifies the change, conditionally generates TeamCity configuration and the
-official model, builds the MCP runners and plan, and writes `sync-scope.json`.
-`verifyOfficialFigmaSync` validates that downloaded scope against the current
-checkout and delegates to the Kotlin trunk checker only for
-`full-verification`. This prevents a persistent agent checkout from
-republishing a stale model or runner without keeping CI orchestration in
-PowerShell.
+The generation job exposes three Kotlin-owned phases after capability
+validation: change-impact classification, conditional model materialization,
+and MCP runner plus visual-plan construction. The verification job exposes
+scope validation before the conditional metadata check. TeamCity passes
+`figmaOfficialTeamCityPhasedExecution=true` so later Gradle invocations consume
+the artifacts produced by the earlier visible step without repeating it.
+Direct local use keeps the dependency-complete `prepareOfficialFigmaSync` and
+`verifyOfficialFigmaSync` entry points. This prevents a persistent agent
+checkout from republishing a stale model or runner without moving orchestration
+into PowerShell.
 
 Gradle configuration cache and local build cache are enabled in
 [`gradle.properties`](../gradle.properties). The current checked-in Pipeline DSL
@@ -210,15 +211,34 @@ belong to the same branch revision as the pipeline chain being validated.
 
 ### Infrastructure Health
 
-`Infrastructure Health` is a daily, non-gating pipeline scheduled at 06:00 in
-the TeamCity server time zone. It validates the Windows agent toolchain, SDK,
-free disk space, the private TeamCity readiness endpoint, the public HTTPS
-route, and the GitHub App webhook boundary. It publishes machine-readable JSON
-under `build/reports/ci-health` and deliberately does not publish a GitHub
-commit status.
+`Infrastructure Health` is a non-gating pipeline. Its TeamCity schedule remains
+at 06:00 in the server time zone as a 24/7-agent fallback. On the current
+developer workstation, Windows Task Scheduler also queues it after startup as
+soon as TeamCity is ready. It validates the Windows agent toolchain, SDK, free
+disk space, the private TeamCity readiness endpoint, the public HTTPS route,
+and the GitHub App webhook boundary. It publishes machine-readable JSON under
+`build/reports/ci-health` and deliberately does not publish a GitHub commit
+status.
 
-This pipeline cannot report that the TeamCity server, its scheduler, or its
-only agent is completely unavailable because none of its steps would start.
+The startup path is Kotlin first:
+
+- `runTeamCityInfrastructureHealth` validates and queues the exact build type
+  through the local TeamCity REST origin;
+- `invoke-infrastructure-health-at-startup.ps1` waits for readiness and exposes
+  the SecretStore token only to that Gradle process;
+- `install-infrastructure-health-startup-task.ps1` owns the Windows Task
+  Scheduler adapter. Its trigger is `AtStartup`, `StartWhenAvailable` waits for
+  the interactive user session that can unlock SecretStore, and overlapping
+  instances are ignored.
+
+Install or refresh the task from an elevated PowerShell session:
+
+```powershell
+pwsh -NoProfile -File .teamcity/scripts/install-infrastructure-health-startup-task.ps1 -RunNow
+```
+
+This pipeline cannot report that the TeamCity server, Task Scheduler, or its
+only agent is completely unavailable because none of its checks would finish.
 Use an external availability monitor for the public hostname and Cloudflare
 Tunnel when an independent outage signal is required.
 
@@ -424,8 +444,9 @@ For this project, the generated pipeline should:
 - set the official Figma design model environment guard only on `Figma Sync`;
 - emit `buildDependencyTrigger` for `Figma Sync`, pointing at `CI`, with
   `afterSuccessfulBuildOnly=true`;
-- emit a daily trigger and Windows-agent requirement for
-  `Infrastructure Health`;
+- emit a daily fallback trigger and Windows-agent requirement for
+  `Infrastructure Health`, while the separate workstation adapter owns the
+  startup request;
 - run the agent-capability preflight before every Gradle or infrastructure
   health operation.
 

--- a/.teamcity/scripts/install-infrastructure-health-startup-task.ps1
+++ b/.teamcity/scripts/install-infrastructure-health-startup-task.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [string] $TaskName = "Water My Plants - Infrastructure Health at startup",
+    [switch] $RunNow
+)
+
+$ErrorActionPreference = "Stop"
+$startupScript = Join-Path $RepositoryRoot ".teamcity/scripts/invoke-infrastructure-health-at-startup.ps1"
+if (-not (Test-Path -LiteralPath $startupScript -PathType Leaf)) {
+    throw "Infrastructure Health startup adapter was not found at '$startupScript'."
+}
+
+$pwsh = (Get-Command pwsh.exe -ErrorAction Stop).Source
+$userId = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+$arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -RepositoryRoot "{1}"' -f `
+    $startupScript,
+    $RepositoryRoot
+$action = New-ScheduledTaskAction -Execute $pwsh -Argument $arguments
+$trigger = New-ScheduledTaskTrigger -AtStartup
+$principal = New-ScheduledTaskPrincipal `
+    -UserId $userId `
+    -LogonType Interactive `
+    -RunLevel Limited
+$settings = New-ScheduledTaskSettingsSet `
+    -StartWhenAvailable `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit (New-TimeSpan -Minutes 15)
+
+if ($PSCmdlet.ShouldProcess($TaskName, "Register startup Infrastructure Health trigger")) {
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Description "Queues the non-gating Water My Plants Infrastructure Health pipeline after TeamCity is ready." `
+        -Action $action `
+        -Trigger $trigger `
+        -Principal $principal `
+        -Settings $settings `
+        -Force | Out-Null
+
+    if ($RunNow) {
+        Start-ScheduledTask -TaskName $TaskName
+    }
+}
+
+$task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($null -eq $task) {
+    [PSCustomObject]@{
+        TaskName = $TaskName
+        State = "NotRegistered"
+        Author = $userId
+        Description = "Startup Infrastructure Health trigger is not registered."
+    }
+}
+else {
+    $task | Select-Object TaskName, State, Author, Description
+}

--- a/.teamcity/scripts/invoke-infrastructure-health-at-startup.ps1
+++ b/.teamcity/scripts/invoke-infrastructure-health-at-startup.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param(
+    [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path,
+    [string] $TeamCityServerUrl = "http://127.0.0.1:8111",
+    [ValidateRange(1, 1800)]
+    [int] $ReadyTimeoutSeconds = 300,
+    [ValidateRange(1, 60)]
+    [int] $ReadyPollSeconds = 5
+)
+
+$ErrorActionPreference = "Stop"
+$serverUri = [Uri] $TeamCityServerUrl
+$loopbackHosts = @("localhost", "127.0.0.1", "::1")
+if ($serverUri.Scheme -ne "http" -or $serverUri.Host -notin $loopbackHosts) {
+    throw "The startup adapter accepts only the local HTTP TeamCity origin."
+}
+
+$gradleWrapper = Join-Path $RepositoryRoot "gradlew.bat"
+if (-not (Test-Path -LiteralPath $gradleWrapper -PathType Leaf)) {
+    throw "Gradle wrapper was not found at '$gradleWrapper'."
+}
+
+$readyUri = [Uri]::new($serverUri, "/healthCheck/ready")
+$deadline = [DateTimeOffset]::UtcNow.AddSeconds($ReadyTimeoutSeconds)
+$ready = $false
+do {
+    try {
+        $response = Invoke-WebRequest -Uri $readyUri -Method Get -TimeoutSec 5 -UseBasicParsing
+        $ready = $response.StatusCode -eq 200
+    }
+    catch {
+        $ready = $false
+    }
+    if (-not $ready -and [DateTimeOffset]::UtcNow -lt $deadline) {
+        Start-Sleep -Seconds $ReadyPollSeconds
+    }
+} while (-not $ready -and [DateTimeOffset]::UtcNow -lt $deadline)
+
+if (-not $ready) {
+    throw "TeamCity did not become ready at '$readyUri' within $ReadyTimeoutSeconds seconds."
+}
+
+$previousToken = $env:TEAMCITY_TOKEN
+try {
+    $env:TEAMCITY_TOKEN = Get-Secret `
+        -Vault TeamCitySecrets `
+        -Name TeamCityAutomationToken `
+        -AsPlainText
+    if ([string]::IsNullOrWhiteSpace($env:TEAMCITY_TOKEN)) {
+        throw "TeamCityAutomationToken is missing from the TeamCitySecrets vault."
+    }
+
+    Push-Location $RepositoryRoot
+    try {
+        & $gradleWrapper `
+            runTeamCityInfrastructureHealth `
+            "-PteamCityInfrastructureHealthServerUrl=$TeamCityServerUrl"
+        if ($LASTEXITCODE -ne 0) {
+            throw "runTeamCityInfrastructureHealth failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    if ($null -eq $previousToken) {
+        Remove-Item Env:TEAMCITY_TOKEN -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:TEAMCITY_TOKEN = $previousToken
+    }
+    Remove-Variable previousToken -ErrorAction SilentlyContinue
+}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -202,8 +202,16 @@ object WaterMyPlantsFigmaSync : Pipeline({
                 scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-agent-capabilities.ps1 -RequireNode -ExportTeamCityParameters"""
             })
             step(PipelineScriptStep {
-                name = "Prepare Figma Sync"
-                scriptContent = """.\gradlew.bat prepareOfficialFigmaSync --stacktrace"""
+                name = "Classify Figma change impact"
+                scriptContent = """.\gradlew.bat classifyOfficialFigmaSyncChangeImpact -PfigmaOfficialTeamCityPhasedExecution=true --stacktrace"""
+            })
+            step(PipelineScriptStep {
+                name = "Materialize official design model"
+                scriptContent = """.\gradlew.bat materializeFigmaSyncCiConfiguration generateOfficialFigmaSyncModel -PfigmaOfficialTeamCityPhasedExecution=true --stacktrace"""
+            })
+            step(PipelineScriptStep {
+                name = "Build MCP runners and visual plan"
+                scriptContent = """.\gradlew.bat prepareOfficialFigmaSync -PfigmaOfficialTeamCityPhasedExecution=true --stacktrace"""
             })
         }
 
@@ -235,8 +243,12 @@ object WaterMyPlantsFigmaSync : Pipeline({
                 scriptContent = """powershell.exe -NoProfile -ExecutionPolicy Bypass -File .teamcity\scripts\test-agent-capabilities.ps1 -ExportTeamCityParameters"""
             })
             step(PipelineScriptStep {
+                name = "Validate official sync scope"
+                scriptContent = """.\gradlew.bat validateOfficialFigmaSyncScope -PfigmaOfficialTeamCityPhasedExecution=true --stacktrace"""
+            })
+            step(PipelineScriptStep {
                 name = "Verify Figma sync metadata"
-                scriptContent = """.\gradlew.bat verifyOfficialFigmaSync --stacktrace"""
+                scriptContent = """.\gradlew.bat checkOfficialFigmaTrunkSync -PfigmaOfficialTeamCityPhasedExecution=true --stacktrace"""
             })
         }
 

--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -67,9 +67,10 @@ The overview contains three distinct journeys:
 - Post-merge design documentation: successful CI on `main`, Figma Sync model
   generation and verification, the external operator and Codex/MCP write, and
   the verification rerun.
-- Infrastructure health: the daily TeamCity schedule, agent capability and
-  disk checks, HTTPS boundary probes, and the published `ci-health` report.
-  This is an internal scheduled signal, not an independent uptime monitor.
+- Infrastructure health: the Windows startup request plus the daily TeamCity
+  fallback schedule, agent capability and disk checks, HTTPS boundary probes,
+  and the published `ci-health` report. This is an internal host-driven signal,
+  not an independent uptime monitor.
 
 Cloudflare appears as a simplified boundary in the overview. Its policies and
 authentication paths belong in `Infrastructure and Access`.

--- a/docs/runbooks/teamcity-cloudflare-access.md
+++ b/docs/runbooks/teamcity-cloudflare-access.md
@@ -13,6 +13,9 @@ sources:
   - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/RerunTeamCityFigmaSyncTask.kt
   - repo/figma-design-sync/project-config/src/main/kotlin/com/marmatsan/figmaDesignSync/projectConfig/EnvironmentTeamCityAutomationCredentialsProvider.kt
   - repo/figma-design-sync/teamcity-adapter/src/main/kotlin/com/marmatsan/figmaDesignSync/teamcityAdapter/TeamCityRestRunStarter.kt
+  - repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/RunTeamCityInfrastructureHealthTask.kt
+  - .teamcity/scripts/invoke-infrastructure-health-at-startup.ps1
+  - .teamcity/scripts/install-infrastructure-health-startup-task.ps1
 ---
 
 # TeamCity Cloudflare Access Runbook
@@ -114,6 +117,38 @@ An unauthenticated request to the public root should receive the Cloudflare
 Access redirect. A `GET` to the webhook path should reach TeamCity and return
 `400 Bad Request` because it is not a signed GitHub `POST`; an Access redirect
 there means the path-specific bypass policy is broken.
+
+## Queue Infrastructure Health After Startup
+
+The daily 06:00 TeamCity trigger remains useful when the server runs
+continuously, but it cannot recover a time slot missed while this workstation
+was powered off. Windows Task Scheduler therefore queues the same non-gating
+pipeline after startup:
+
+```powershell
+pwsh -NoProfile -File .teamcity/scripts/install-infrastructure-health-startup-task.ps1 -RunNow
+```
+
+The task uses an `AtStartup` trigger and `StartWhenAvailable`. It runs under the
+interactive user identity so PowerShell SecretStore remains available; when no
+user session exists at boot, Windows starts the task once that condition becomes
+available. The adapter waits for `http://127.0.0.1:8111/healthCheck/ready`, loads
+only `TeamCityAutomationToken`, and invokes the Kotlin
+`runTeamCityInfrastructureHealth` task. The Kotlin REST adapter allows plain
+HTTP only for a loopback host, never follows redirects, and does not use the
+public Cloudflare route.
+
+Inspect or test the installed task without exposing credentials:
+
+```powershell
+Get-ScheduledTask -TaskName "Water My Plants - Infrastructure Health at startup"
+Get-ScheduledTaskInfo -TaskName "Water My Plants - Infrastructure Health at startup"
+Start-ScheduledTask -TaskName "Water My Plants - Infrastructure Health at startup"
+```
+
+Keep the scheduled action pointed at the stable repository checkout. Re-run the
+installer if that checkout moves. Do not place the TeamCity token in the task
+arguments, environment block, or exported task XML.
 
 ## Store The Cloudflare Service Token
 

--- a/repo/ci/README.md
+++ b/repo/ci/README.md
@@ -15,8 +15,8 @@ verification units apply to a committed repository change.
   parameters and validates every emitted Gradle task name; it does not add
   provider concerns to the domain model.
 - The Gradle plugin is the current composition root and registers
-  `generateCiPlan` and `prepareTeamCityCiPlan` in the Water My Plants root
-  build.
+  `generateCiPlan`, `prepareTeamCityCiPlan`, and
+  `runTeamCityInfrastructureHealth` in the Water My Plants root build.
 - CI providers consume allow-listed unit identifiers and Gradle task names;
   they must never execute arbitrary commands read from the JSON report.
 
@@ -37,3 +37,9 @@ reviewed parameter allow-list. TeamCity uses those parameters to run visible
 sequential steps while the repository has one build agent. Safe module-only
 changes select affected module `check` tasks plus `checkFigmaCatalogUsage`;
 invalid graphs, unknown paths, and tooling changes retain root `check`.
+
+`runTeamCityInfrastructureHealth` is the Kotlin queueing boundary used by the
+Windows startup adapter. It accepts HTTPS TeamCity origins or the local HTTP
+loopback origin, never follows redirects with the Bearer token, and validates
+the build type plus branch before issuing the REST request. SecretStore access
+and Windows Task Scheduler remain thin PowerShell adapters outside this module.

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/data/teamcity/TeamCityRestRunQueue.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/data/teamcity/TeamCityRestRunQueue.kt
@@ -1,0 +1,92 @@
+package com.marmatsan.ci.data.teamcity
+
+import com.marmatsan.ci.domain.model.TeamCityQueuedRun
+import com.marmatsan.ci.domain.model.TeamCityRunRequest
+import com.marmatsan.ci.domain.port.TeamCityRunQueue
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+
+/** Bearer-authenticated TeamCity REST adapter that never follows redirects. */
+class TeamCityRestRunQueue(
+    serverUrl: String,
+    private val teamCityToken: String,
+    private val post: (URI, Map<String, String>, String) -> Response = ::post
+) : TeamCityRunQueue {
+    private val serverUri = URI.create(serverUrl.trimEnd('/')).also(::requireTrustedOrigin)
+
+    init {
+        require(teamCityToken.isNotBlank()) { "TeamCity automation token must not be blank." }
+    }
+
+    override fun queue(request: TeamCityRunRequest): TeamCityQueuedRun {
+        val uri = serverUri.resolve("/app/rest/buildQueue")
+        val headers = mapOf(
+            "Accept" to "application/json",
+            "Authorization" to "Bearer $teamCityToken",
+            "Content-Type" to "application/json"
+        )
+        val body = buildJsonObject {
+            put("buildType", buildJsonObject { put("id", request.buildTypeId) })
+            put("branchName", request.branch)
+        }.toString()
+        val response = post(uri, headers, body)
+        require(response.statusCode in 200..299) {
+            "TeamCity REST queue request failed with HTTP ${response.statusCode}: ${response.body.take(500)}"
+        }
+        return runCatching {
+            val json = Json.parseToJsonElement(response.body).jsonObject
+            TeamCityQueuedRun(
+                id = json.getValue("id").jsonPrimitive.long,
+                state = json.getValue("state").jsonPrimitive.content,
+                branch = json.getValue("branchName").jsonPrimitive.content,
+                webUrl = json["webUrl"]?.jsonPrimitive?.content
+            )
+        }.getOrElse {
+            throw IllegalArgumentException("TeamCity REST returned invalid JSON.", it)
+        }
+    }
+
+    data class Response(
+        val statusCode: Int,
+        val body: String
+    )
+
+    private companion object {
+        val HTTP_CLIENT: HttpClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .connectTimeout(Duration.ofSeconds(30))
+            .build()
+
+        fun requireTrustedOrigin(uri: URI) {
+            val trusted = uri.scheme.equals("https", ignoreCase = true) ||
+                uri.scheme.equals("http", ignoreCase = true) && uri.host in LOOPBACK_HOSTS
+            require(trusted) {
+                "TeamCity automation requires HTTPS or an HTTP loopback origin."
+            }
+            require(uri.userInfo == null && uri.query == null && uri.fragment == null) {
+                "TeamCity automation origin must not contain credentials, a query, or a fragment."
+            }
+        }
+
+        fun post(uri: URI, headers: Map<String, String>, body: String): Response {
+            val request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .apply { headers.forEach(::header) }
+                .build()
+            val response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString())
+            return Response(response.statusCode(), response.body())
+        }
+
+        val LOOPBACK_HOSTS = setOf("localhost", "127.0.0.1", "::1")
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/TeamCityQueuedRun.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/TeamCityQueuedRun.kt
@@ -1,0 +1,9 @@
+package com.marmatsan.ci.domain.model
+
+/** Minimal result returned after TeamCity accepts a run into its queue. */
+data class TeamCityQueuedRun(
+    val id: Long,
+    val state: String,
+    val branch: String,
+    val webUrl: String?
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/TeamCityRunRequest.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/TeamCityRunRequest.kt
@@ -1,0 +1,7 @@
+package com.marmatsan.ci.domain.model
+
+/** Identifies the TeamCity build configuration and branch that must be queued. */
+data class TeamCityRunRequest(
+    val buildTypeId: String,
+    val branch: String
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/port/TeamCityRunQueue.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/port/TeamCityRunQueue.kt
@@ -1,0 +1,9 @@
+package com.marmatsan.ci.domain.port
+
+import com.marmatsan.ci.domain.model.TeamCityQueuedRun
+import com.marmatsan.ci.domain.model.TeamCityRunRequest
+
+/** Provider-neutral boundary for queueing one TeamCity run. */
+fun interface TeamCityRunQueue {
+    fun queue(request: TeamCityRunRequest): TeamCityQueuedRun
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/QueueTeamCityRun.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/QueueTeamCityRun.kt
@@ -1,0 +1,25 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.TeamCityQueuedRun
+import com.marmatsan.ci.domain.model.TeamCityRunRequest
+import com.marmatsan.ci.domain.port.TeamCityRunQueue
+
+/** Validates and queues an explicit TeamCity build configuration on one branch. */
+class QueueTeamCityRun(
+    private val runQueue: TeamCityRunQueue
+) {
+    fun execute(request: TeamCityRunRequest): TeamCityQueuedRun {
+        require(BUILD_TYPE_ID.matches(request.buildTypeId)) {
+            "TeamCity build type id contains unsupported characters."
+        }
+        require(BRANCH.matches(request.branch)) {
+            "TeamCity branch contains unsupported characters."
+        }
+        return runQueue.queue(request)
+    }
+
+    private companion object {
+        val BUILD_TYPE_ID = Regex("[A-Za-z0-9_.-]+")
+        val BRANCH = Regex("[A-Za-z0-9_./-]+")
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
@@ -38,5 +38,25 @@ class CiGradlePlugin : Plugin<Project> {
             task.dependsOn(generateCiPlan)
             task.planFile.set(generateCiPlan.flatMap(GenerateCiPlanTask::outputFile))
         }
+
+        project.tasks.register(
+            "runTeamCityInfrastructureHealth",
+            RunTeamCityInfrastructureHealthTask::class.java
+        ) { task ->
+            task.group = "verification"
+            task.description = "Queues the non-gating TeamCity Infrastructure Health pipeline."
+            task.serverUrl.convention(
+                project.providers.gradleProperty("teamCityInfrastructureHealthServerUrl")
+                    .orElse("http://127.0.0.1:8111")
+            )
+            task.buildTypeId.convention(
+                project.providers.gradleProperty("teamCityInfrastructureHealthBuildTypeId")
+                    .orElse("WaterMyPlants_WaterMyPlantsInfrastructureHealth")
+            )
+            task.branch.convention(
+                project.providers.gradleProperty("teamCityInfrastructureHealthBranch").orElse("main")
+            )
+            task.teamCityToken.convention(project.providers.environmentVariable("TEAMCITY_TOKEN"))
+        }
     }
 }

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/RunTeamCityInfrastructureHealthTask.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/RunTeamCityInfrastructureHealthTask.kt
@@ -1,0 +1,46 @@
+package com.marmatsan.ci.plugin
+
+import com.marmatsan.ci.data.teamcity.TeamCityRestRunQueue
+import com.marmatsan.ci.domain.model.TeamCityRunRequest
+import com.marmatsan.ci.domain.service.QueueTeamCityRun
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/** Queues the non-gating Infrastructure Health pipeline through a trusted TeamCity origin. */
+@DisableCachingByDefault(because = "Queues an external TeamCity pipeline")
+abstract class RunTeamCityInfrastructureHealthTask : DefaultTask() {
+    @get:Input
+    abstract val serverUrl: Property<String>
+
+    @get:Input
+    abstract val buildTypeId: Property<String>
+
+    @get:Input
+    abstract val branch: Property<String>
+
+    @get:Internal
+    abstract val teamCityToken: Property<String>
+
+    @TaskAction
+    fun queue() {
+        val result = QueueTeamCityRun(
+            TeamCityRestRunQueue(
+                serverUrl = serverUrl.get(),
+                teamCityToken = teamCityToken.get()
+            )
+        ).execute(
+            TeamCityRunRequest(
+                buildTypeId = buildTypeId.get(),
+                branch = branch.get()
+            )
+        )
+        logger.lifecycle(
+            "TeamCity Infrastructure Health queued: runId=${result.id}, " +
+                "branch=${result.branch}, state=${result.state}, webUrl=${result.webUrl.orEmpty()}"
+        )
+    }
+}

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/data/teamcity/TeamCityRestRunQueueTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/data/teamcity/TeamCityRestRunQueueTest.kt
@@ -1,0 +1,82 @@
+package com.marmatsan.ci.data.teamcity
+
+import com.marmatsan.ci.domain.model.TeamCityQueuedRun
+import com.marmatsan.ci.domain.model.TeamCityRunRequest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import java.net.URI
+
+internal class TeamCityRestRunQueueTest : FunSpec({
+    test("queues an infrastructure run through the loopback TeamCity origin") {
+        var requestedUri: URI? = null
+        var requestedHeaders: Map<String, String>? = null
+        var requestedBody: String? = null
+        val queue = TeamCityRestRunQueue(
+            serverUrl = "http://127.0.0.1:8111/",
+            teamCityToken = "teamcity-token"
+        ) { uri, headers, body ->
+            requestedUri = uri
+            requestedHeaders = headers
+            requestedBody = body
+            TeamCityRestRunQueue.Response(
+                statusCode = 200,
+                body =
+                    """
+                    {
+                      "id": 1800,
+                      "state": "queued",
+                      "branchName": "main",
+                      "webUrl": "http://127.0.0.1:8111/build/1800"
+                    }
+                    """.trimIndent()
+            )
+        }
+
+        queue.queue(
+            TeamCityRunRequest(
+                buildTypeId = "WaterMyPlants_WaterMyPlantsInfrastructureHealth",
+                branch = "main"
+            )
+        ) shouldBe TeamCityQueuedRun(
+            id = 1800,
+            state = "queued",
+            branch = "main",
+            webUrl = "http://127.0.0.1:8111/build/1800"
+        )
+        requestedUri shouldBe URI.create("http://127.0.0.1:8111/app/rest/buildQueue")
+        requestedHeaders shouldBe mapOf(
+            "Accept" to "application/json",
+            "Authorization" to "Bearer teamcity-token",
+            "Content-Type" to "application/json"
+        )
+        requestedHeaders.orEmpty().shouldNotContainKey("Cookie")
+        requestedBody shouldBe
+            "{\"buildType\":{\"id\":\"WaterMyPlants_WaterMyPlantsInfrastructureHealth\"}," +
+                "\"branchName\":\"main\"}"
+    }
+
+    test("rejects plain HTTP for a non-loopback TeamCity origin") {
+        val failure = shouldThrow<IllegalArgumentException> {
+            TeamCityRestRunQueue("http://teamcity.example", "teamcity-token")
+        }
+
+        failure.message shouldBe "TeamCity automation requires HTTPS or an HTTP loopback origin."
+    }
+
+    test("rejects redirects instead of forwarding the bearer token") {
+        val queue = TeamCityRestRunQueue(
+            serverUrl = "https://teamcity.example",
+            teamCityToken = "teamcity-token"
+        ) { _, _, _ ->
+            TeamCityRestRunQueue.Response(statusCode = 302, body = "redirect")
+        }
+
+        val failure = shouldThrow<IllegalArgumentException> {
+            queue.queue(TeamCityRunRequest("InfrastructureHealth", "main"))
+        }
+
+        failure.message shouldBe "TeamCity REST queue request failed with HTTP 302: redirect"
+    }
+})

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/QueueTeamCityRunTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/QueueTeamCityRunTest.kt
@@ -1,0 +1,26 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.TeamCityQueuedRun
+import com.marmatsan.ci.domain.model.TeamCityRunRequest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+internal class QueueTeamCityRunTest : FunSpec({
+    test("queues a validated build type and branch") {
+        val expected = TeamCityQueuedRun(1800, "queued", "main", null)
+        val service = QueueTeamCityRun { expected }
+
+        service.execute(TeamCityRunRequest("WaterMyPlants_InfrastructureHealth", "main")) shouldBe expected
+    }
+
+    test("rejects shell syntax in the build type id") {
+        val service = QueueTeamCityRun { TeamCityQueuedRun(1800, "queued", "main", null) }
+
+        val failure = shouldThrow<IllegalArgumentException> {
+            service.execute(TeamCityRunRequest("Health && publish", "main"))
+        }
+
+        failure.message shouldBe "TeamCity build type id contains unsupported characters."
+    }
+})

--- a/repo/figma-design-sync/README.md
+++ b/repo/figma-design-sync/README.md
@@ -197,6 +197,16 @@ Task responsibilities:
 | `generateFigmaDesignModel` | Generates the official JSON artifact inside TeamCity `Figma Sync` on `main`; do not run it as a local publication path. |
 | `checkFigmaTrunkSync` | Compares the generated `modelHash` with Figma shared plugin metadata inside the official pipeline. |
 
+TeamCity may expose official synchronization as sequential steps by passing
+`-PfigmaOfficialTeamCityPhasedExecution=true`. In that mode it invokes
+classification first, model materialization second, runner and visual-plan
+construction third, then scope validation before the metadata check. The flag
+removes only the dependency edges that would repeat an earlier TeamCity step;
+each phase still consumes the files produced in the same job workspace and
+fails closed when a prerequisite is absent. Local and third-party consumers
+must keep using the dependency-complete `prepareOfficialFigmaSync` and
+`verifyOfficialFigmaSync` entry points without this adapter flag.
+
 The change-impact classifier is implemented in Kotlin and is portable across
 Windows, macOS, and Linux. See
 [`docs/reference/change-impact-classification.md`](docs/reference/change-impact-classification.md)

--- a/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
+++ b/repo/figma-design-sync/plugin/src/main/kotlin/com/marmatsan/figmaDesignSync/plugin/gradle/FigmaDesignSyncGradlePlugin.kt
@@ -279,6 +279,9 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
                 delete(project.layout.buildDirectory.dir("reports/figma-sync"))
             }
 
+        val teamCityPhasedOfficialExecution =
+            booleanProperty(project, "figmaOfficialTeamCityPhasedExecution")
+
         val classifyOfficialFigmaSyncChangeImpact =
             project.tasks.register<ClassifyFigmaChangeImpactTask>("classifyOfficialFigmaSyncChangeImpact") {
                 group = "verification"
@@ -301,7 +304,11 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
             project.tasks.register<Exec>("materializeFigmaSyncCiConfiguration") {
                 group = "documentation"
                 description = "Runs the optional CI adapter when the Figma model can change."
-                dependsOn(classifyOfficialFigmaSyncChangeImpact)
+                if (teamCityPhasedOfficialExecution.get()) {
+                    mustRunAfter(classifyOfficialFigmaSyncChangeImpact)
+                } else {
+                    dependsOn(classifyOfficialFigmaSyncChangeImpact)
+                }
                 onlyIf("CI documentation adapter is enabled and Figma impact requires full verification") {
                     extension.ciDocumentationEnabled.get() &&
                         extension.ciConfigurationCommand.get().isNotEmpty() &&
@@ -319,7 +326,11 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
             project.tasks.register<GenerateFigmaDesignModelTask>("generateOfficialFigmaSyncModel") {
                 group = "documentation"
                 description = "Generates the model required by the prepared official Figma Sync scope."
-                dependsOn(materializeFigmaSyncCiConfiguration)
+                if (teamCityPhasedOfficialExecution.get()) {
+                    mustRunAfter(materializeFigmaSyncCiConfiguration)
+                } else {
+                    dependsOn(materializeFigmaSyncCiConfiguration)
+                }
                 onlyIf("Figma change impact requires full verification") {
                     isFullVerification(extension.changeImpactFile.get().asFile)
                 }
@@ -358,7 +369,11 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
         project.tasks.register<PrepareOfficialFigmaSyncTask>("prepareOfficialFigmaSync") {
             group = "documentation"
             description = "Prepares the official model, MCP runners, visual plan, and shared sync scope."
-            dependsOn(generateOfficialFigmaSyncModel)
+            if (teamCityPhasedOfficialExecution.get()) {
+                mustRunAfter(generateOfficialFigmaSyncModel)
+            } else {
+                dependsOn(generateOfficialFigmaSyncModel)
+            }
 
             changeImpactFile.set(extension.changeImpactFile)
             changeImpactPolicyFile.set(extension.changeImpactPolicyFile)
@@ -397,7 +412,11 @@ class FigmaDesignSyncGradlePlugin : Plugin<Project> {
             project.tasks.register<CheckFigmaTrunkSyncTask>("checkOfficialFigmaTrunkSync") {
                 group = "verification"
                 description = "Checks Figma metadata only when the validated official scope can change the model."
-                dependsOn(validateOfficialFigmaSyncScope)
+                if (teamCityPhasedOfficialExecution.get()) {
+                    mustRunAfter(validateOfficialFigmaSyncScope)
+                } else {
+                    dependsOn(validateOfficialFigmaSyncScope)
+                }
                 onlyIf("Validated Figma scope requires full verification") {
                     verifiedOfficialScopeFile.get().asFile
                         .readText()

--- a/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/task/official/OfficialFigmaSyncGradleTasksTest.kt
+++ b/repo/figma-design-sync/plugin/src/test/kotlin/com/marmatsan/figmaDesignSync/plugin/task/official/OfficialFigmaSyncGradleTasksTest.kt
@@ -36,6 +36,52 @@ internal class OfficialFigmaSyncGradleTasksTest : FunSpec({
             project.deleteRecursively()
         }
     }
+
+    test("TeamCity can execute official synchronization as visible sequential phases") {
+        val project = Files.createTempDirectory("official-figma-sync-phases").toFile()
+        try {
+            project.writeFixture()
+            project.initializeGitRepository()
+
+            val property = "-PfigmaOfficialTeamCityPhasedExecution=true"
+            project.runner(
+                "classifyOfficialFigmaSyncChangeImpact",
+                "-PfigmaChangedPaths=docs/example.md",
+                property,
+                "--stacktrace"
+            ).build()
+            val modelPhase = project.runner(
+                "materializeFigmaSyncCiConfiguration",
+                "generateOfficialFigmaSyncModel",
+                property,
+                "--stacktrace"
+            ).build()
+            val runnerPhase = project.runner(
+                "prepareOfficialFigmaSync",
+                property,
+                "--stacktrace"
+            ).build()
+            project.runner(
+                "validateOfficialFigmaSyncScope",
+                property,
+                "--stacktrace"
+            ).build()
+            val metadataPhase = project.runner(
+                "checkOfficialFigmaTrunkSync",
+                property,
+                "--stacktrace"
+            ).build()
+
+            modelPhase.task(":classifyOfficialFigmaSyncChangeImpact") shouldBe null
+            runnerPhase.task(":generateOfficialFigmaSyncModel") shouldBe null
+            metadataPhase.task(":validateOfficialFigmaSyncScope") shouldBe null
+            modelPhase.task(":materializeFigmaSyncCiConfiguration")?.outcome shouldBe TaskOutcome.SKIPPED
+            modelPhase.task(":generateOfficialFigmaSyncModel")?.outcome shouldBe TaskOutcome.SKIPPED
+            metadataPhase.task(":checkOfficialFigmaTrunkSync")?.outcome shouldBe TaskOutcome.SKIPPED
+        } finally {
+            project.deleteRecursively()
+        }
+    }
 })
 
 private fun File.runner(vararg arguments: String): GradleRunner =


### PR DESCRIPTION
## Summary

- expose Figma Sync classification, model materialization, runner planning, scope validation, and metadata verification as sequential TeamCity steps
- preserve dependency-complete local Gradle entry points while avoiding repeated work in the TeamCity phased path
- add a Kotlin REST boundary that queues Infrastructure Health only through HTTPS or the local loopback origin
- add thin SecretStore and Windows Task Scheduler adapters so the pipeline runs after workstation startup while retaining the daily fallback schedule
- document the startup ownership, security boundary, and recovery commands

## Verification

- `.\gradlew.bat check` with the Figma token loaded only for Gradle
- `.\gradlew.bat :ci:check :figma-design-sync:plugin:check --rerun-tasks`
- `.\mvnw.cmd -f .teamcity\pom.xml teamcity-configs:generate`
- `teamcity project settings validate .teamcity --verbose`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1 -FailOnCoverageGap`
- PowerShell parser validation for both startup scripts
- startup-task installer validated with `-WhatIf`
- live Kotlin startup adapter queued Infrastructure Health #1; aggregate #1735 and job #1736 succeeded
- post-commit CI plan selects the fail-closed root `check` for this tooling change

The Windows scheduled task will be registered only after this PR is merged into the stable `main` checkout.