### PR TITLE
feat(ci): model future agent topology

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -99,6 +99,10 @@ The pipeline:
   change runs one Gradle invocation with the plan's validated task list;
 - coalesces Figma-tooling and dependency-catalog units into that single heavy
   Gradle invocation while only one agent is available;
+- keeps the future multi-agent topology inactive. The Kotlin-only
+  `generateCiTopologyPreview -PciAvailableAgents=<count>` task can model the
+  future lanes, dependencies, capabilities, and final status publisher without
+  changing the checked-in TeamCity jobs;
 - uses the evaluated Gradle module graph for application changes: the changed
   modules, all transitive reverse dependents, and `checkFigmaCatalogUsage` run
   in one Gradle invocation; invalid graphs or unmapped paths use root `check`;
@@ -108,6 +112,14 @@ The pipeline:
 - blocks unused dependency catalog entries through `checkFigmaCatalogUsage`,
   which is wired into the Gradle `check` lifecycle;
 - publishes the `TeamCity CI` GitHub status from `Verify`.
+
+When more agents are provisioned, use the executable preview contract in
+[`docs/reference/ci-verification-plan.md`](../docs/reference/ci-verification-plan.md#multi-agent-topology-preview)
+as the migration boundary. The activation change must map its allow-listed
+lanes to TeamCity jobs, preserve the final `TeamCity CI` status, prove agent
+capability parity and artifact handoff, and keep the single-agent DSL available
+until the parallel topology is green. Merely increasing the agent pool does not
+change job concurrency.
 
 TeamCity runs the remaining capability and documentation adapters with Windows
 PowerShell 5.1 (`powershell.exe`). Those scripts must not depend on APIs

--- a/docs/reference/ci-verification-plan.md
+++ b/docs/reference/ci-verification-plan.md
@@ -8,7 +8,9 @@ last-reviewed: 2026-07-19
 review-cycle-days: 180
 sources:
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiPlan.kt
+  - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiExecutionTopology.kt
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiPlanFactory.kt
+  - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiTopologyPlanner.kt
   - repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/ModuleImpactAnalyzer.kt
 ---
 
@@ -83,6 +85,31 @@ This topology keeps one checkout, one agent allocation, and one authoritative
 GitHub status. Coalesced units remain explicit in the JSON so a later
 multi-agent adapter can split them without changing classification policy.
 
+## Multi-Agent Topology Preview
+
+`generateCiTopologyPreview -PciAvailableAgents=<count>` writes
+`build/reports/ci/ci-topology-preview.json`. This is a provider-neutral,
+`preview-only` contract: the active TeamCity Kotlin DSL does not read it and
+continues to define one `Verify` job while only one agent exists.
+
+| Available agents | Previewed execution |
+|------------------|---------------------|
+| `1` | One `verify` lane runs every required unit sequentially and publishes the authoritative status. |
+| `2` | `documentation` runs first; `supplemental-verification` and `gradle-verification` may then run in parallel; `ci-gate` waits for both and publishes the status. |
+| `3+` | `documentation` runs first; repository, tooling, and Gradle lanes may then run in parallel; `ci-gate` waits for every required lane and publishes the status. |
+
+The planner omits empty lanes, derives lane capabilities from their units, and
+preserves every required dependency. It fails when no agent is available,
+when `publish-reports` is missing, when any required unit is lost or reordered,
+or when more than one lane would publish the authoritative status.
+
+Adding agents alone does not activate this topology. Activation requires a
+separate reviewed TeamCity change that provisions equivalent agent
+capabilities, maps each allow-listed lane to a job, keeps `TeamCity CI` as the
+only required GitHub status, and validates cache isolation plus artifact
+handoff. Figma publication remains a default-branch workflow and is not made
+parallel with branch CI by this preview.
+
 ## Performance Baseline
 
 The ten most recent successful `main` CI pipeline heads before this rollout
@@ -104,7 +131,8 @@ because the plan is visible.
 - `repo/ci` contains the executable models, classifier, Git adapter, JSON
   writer, Gradle task, and tests.
 - `repo/ci` also contains the narrow TeamCity parameter and service-message
-  adapters used by `prepareTeamCityCiPlan`.
+  adapters used by `prepareTeamCityCiPlan`, plus the preview-only topology
+  projector used by `generateCiTopologyPreview`.
 - `.teamcity/settings.kts` maps allow-listed parameters to visible sequential
   steps, performs their skip/run decision, and publishes the report. The
   TeamCity 2026.1 Pipeline YAML generator does not serialize inherited build

--- a/repo/ci/README.md
+++ b/repo/ci/README.md
@@ -15,7 +15,7 @@ verification units apply to a committed repository change.
   parameters and validates every emitted Gradle task name; it does not add
   provider concerns to the domain model.
 - The Gradle plugin is the current composition root and registers
-  `generateCiPlan`, `prepareTeamCityCiPlan`, and
+  `generateCiPlan`, `generateCiTopologyPreview`, `prepareTeamCityCiPlan`, and
   `runTeamCityInfrastructureHealth` in the Water My Plants root build.
 - CI providers consume allow-listed unit identifiers and Gradle task names;
   they must never execute arbitrary commands read from the JSON report.
@@ -28,10 +28,17 @@ The generated contract is documented in
 ```powershell
 .\gradlew.bat :ci:check
 .\gradlew.bat generateCiPlan
+.\gradlew.bat generateCiTopologyPreview -PciAvailableAgents=3
 .\gradlew.bat prepareTeamCityCiPlan
 ```
 
 `generateCiPlan` writes the provider-neutral JSON contract.
+`generateCiTopologyPreview` projects its required units into agent lanes under
+`build/reports/ci/ci-topology-preview.json`. The output is explicitly
+`preview-only`: no TeamCity setting consumes it. One agent produces the current
+single `verify` lane; two agents preview supplemental and Gradle lanes; three or
+more agents additionally separate repository and tooling work before one
+authoritative `ci-gate` lane.
 `prepareTeamCityCiPlan` additionally emits TeamCity service messages for the
 reviewed parameter allow-list. TeamCity uses those parameters to run visible
 sequential steps while the repository has one build agent. Safe module-only

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/data/json/CiExecutionTopologyJson.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/data/json/CiExecutionTopologyJson.kt
@@ -1,0 +1,22 @@
+package com.marmatsan.ci.data.json
+
+import com.marmatsan.ci.domain.model.CiExecutionTopology
+import java.io.File
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class CiExecutionTopologyJson {
+    fun write(topology: CiExecutionTopology, output: File) {
+        output.parentFile.mkdirs()
+        output.writeText(format.encodeToString(topology) + System.lineSeparator())
+    }
+
+    fun read(source: String): CiExecutionTopology = format.decodeFromString(source)
+
+    private companion object {
+        val format = Json {
+            prettyPrint = true
+            encodeDefaults = true
+        }
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiExecutionLane.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiExecutionLane.kt
@@ -1,0 +1,14 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.Serializable
+
+/** Ordered verification work that one CI agent may execute in a single job. */
+@Serializable
+data class CiExecutionLane(
+    val id: String,
+    val verificationUnits: List<VerificationUnitId>,
+    val needs: List<String>,
+    val capabilities: List<String>,
+    val parallelSafe: Boolean,
+    val publishesAuthoritativeStatus: Boolean
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiExecutionTopology.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiExecutionTopology.kt
@@ -1,0 +1,16 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.Serializable
+
+/** Preview of how a provider may assign one verification plan to available agents. */
+@Serializable
+data class CiExecutionTopology(
+    val schemaVersion: Int,
+    val activation: CiTopologyActivation,
+    val sourcePlanSchemaVersion: Int,
+    val sourceHead: String,
+    val availableAgents: Int,
+    val mode: CiTopologyMode,
+    val lanes: List<CiExecutionLane>,
+    val authoritativeStatusPublisherLaneId: String
+)

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiTopologyActivation.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiTopologyActivation.kt
@@ -1,0 +1,10 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CiTopologyActivation {
+    @SerialName("preview-only")
+    PREVIEW_ONLY
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiTopologyMode.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/model/CiTopologyMode.kt
@@ -1,0 +1,13 @@
+package com.marmatsan.ci.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CiTopologyMode {
+    @SerialName("single-agent-sequential")
+    SINGLE_AGENT_SEQUENTIAL,
+
+    @SerialName("multi-agent-parallel")
+    MULTI_AGENT_PARALLEL
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiTopologyPlanner.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/domain/service/CiTopologyPlanner.kt
@@ -1,0 +1,139 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.CiExecutionLane
+import com.marmatsan.ci.domain.model.CiExecutionTopology
+import com.marmatsan.ci.domain.model.CiPlan
+import com.marmatsan.ci.domain.model.CiTopologyActivation
+import com.marmatsan.ci.domain.model.CiTopologyMode
+import com.marmatsan.ci.domain.model.VerificationUnit
+import com.marmatsan.ci.domain.model.VerificationUnitId
+
+/** Pure scheduler that preserves unit dependencies while previewing agent allocation. */
+class CiTopologyPlanner {
+    fun create(plan: CiPlan, availableAgents: Int): CiExecutionTopology {
+        require(availableAgents >= 1) { "CI topology requires at least one available agent." }
+
+        val requiredUnits = plan.verificationUnits.filter(VerificationUnit::required)
+        require(requiredUnits.any { unit -> unit.id == VerificationUnitId.PUBLISH_REPORTS }) {
+            "CI topology requires publish-reports as the authoritative final unit."
+        }
+
+        val mode = if (availableAgents == 1) {
+            CiTopologyMode.SINGLE_AGENT_SEQUENTIAL
+        } else {
+            CiTopologyMode.MULTI_AGENT_PARALLEL
+        }
+        val lanes = when (mode) {
+            CiTopologyMode.SINGLE_AGENT_SEQUENTIAL -> singleAgentLanes(requiredUnits)
+            CiTopologyMode.MULTI_AGENT_PARALLEL -> multiAgentLanes(requiredUnits, availableAgents)
+        }
+        check(lanes.flatMap(CiExecutionLane::verificationUnits) == requiredUnits.map(VerificationUnit::id)) {
+            "CI topology must schedule every required verification unit exactly once and in plan order."
+        }
+        val statusPublisher = lanes.single(CiExecutionLane::publishesAuthoritativeStatus)
+
+        return CiExecutionTopology(
+            schemaVersion = SCHEMA_VERSION,
+            activation = CiTopologyActivation.PREVIEW_ONLY,
+            sourcePlanSchemaVersion = plan.schemaVersion,
+            sourceHead = plan.head,
+            availableAgents = availableAgents,
+            mode = mode,
+            lanes = lanes,
+            authoritativeStatusPublisherLaneId = statusPublisher.id
+        )
+    }
+
+    private fun singleAgentLanes(requiredUnits: List<VerificationUnit>): List<CiExecutionLane> =
+        listOf(lane(VERIFY_LANE, requiredUnits, publishesAuthoritativeStatus = true))
+
+    private fun multiAgentLanes(
+        requiredUnits: List<VerificationUnit>,
+        availableAgents: Int
+    ): List<CiExecutionLane> {
+        val laneIdByUnit = requiredUnits.associate { unit ->
+            unit.id to multiAgentLaneId(unit.id, availableAgents)
+        }
+        val orderedLaneIds = if (availableAgents == 2) TWO_AGENT_LANE_ORDER else MANY_AGENT_LANE_ORDER
+        val unitsByLane = requiredUnits.groupBy { unit -> laneIdByUnit.getValue(unit.id) }
+
+        return orderedLaneIds.mapNotNull { laneId ->
+            val units = unitsByLane[laneId].orEmpty()
+            if (units.isEmpty()) return@mapNotNull null
+
+            val dependencies = units
+                .flatMap(VerificationUnit::needs)
+                .mapNotNull(laneIdByUnit::get)
+                .filterNot { dependencyLaneId -> dependencyLaneId == laneId }
+                .distinct()
+
+            lane(
+                id = laneId,
+                units = units,
+                needs = dependencies,
+                publishesAuthoritativeStatus = laneId == GATE_LANE
+            )
+        }
+    }
+
+    private fun multiAgentLaneId(id: VerificationUnitId, availableAgents: Int): String =
+        if (availableAgents == 2) {
+            when (id) {
+                VerificationUnitId.DOCUMENTATION -> DOCUMENTATION_LANE
+                VerificationUnitId.GRADLE_VERIFICATION -> GRADLE_LANE
+                VerificationUnitId.PUBLISH_REPORTS -> GATE_LANE
+                VerificationUnitId.REPOSITORY_DIFF,
+                VerificationUnitId.TEAMCITY_DSL,
+                VerificationUnitId.FIGMA_TOOLING,
+                VerificationUnitId.DEPENDENCY_CATALOG -> SUPPLEMENTAL_LANE
+            }
+        } else {
+            when (id) {
+                VerificationUnitId.DOCUMENTATION -> DOCUMENTATION_LANE
+                VerificationUnitId.REPOSITORY_DIFF,
+                VerificationUnitId.TEAMCITY_DSL -> REPOSITORY_LANE
+                VerificationUnitId.FIGMA_TOOLING,
+                VerificationUnitId.DEPENDENCY_CATALOG -> TOOLING_LANE
+                VerificationUnitId.GRADLE_VERIFICATION -> GRADLE_LANE
+                VerificationUnitId.PUBLISH_REPORTS -> GATE_LANE
+            }
+        }
+
+    private fun lane(
+        id: String,
+        units: List<VerificationUnit>,
+        needs: List<String> = emptyList(),
+        publishesAuthoritativeStatus: Boolean
+    ) = CiExecutionLane(
+        id = id,
+        verificationUnits = units.map(VerificationUnit::id),
+        needs = needs,
+        capabilities = units.flatMap(VerificationUnit::capabilities).distinct(),
+        parallelSafe = units.all(VerificationUnit::parallelSafe),
+        publishesAuthoritativeStatus = publishesAuthoritativeStatus
+    )
+
+    private companion object {
+        const val SCHEMA_VERSION = 1
+        const val VERIFY_LANE = "verify"
+        const val DOCUMENTATION_LANE = "documentation"
+        const val SUPPLEMENTAL_LANE = "supplemental-verification"
+        const val REPOSITORY_LANE = "repository-verification"
+        const val TOOLING_LANE = "tooling-verification"
+        const val GRADLE_LANE = "gradle-verification"
+        const val GATE_LANE = "ci-gate"
+        val TWO_AGENT_LANE_ORDER = listOf(
+            DOCUMENTATION_LANE,
+            SUPPLEMENTAL_LANE,
+            GRADLE_LANE,
+            GATE_LANE
+        )
+        val MANY_AGENT_LANE_ORDER = listOf(
+            DOCUMENTATION_LANE,
+            REPOSITORY_LANE,
+            TOOLING_LANE,
+            GRADLE_LANE,
+            GATE_LANE
+        )
+    }
+}

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/CiGradlePlugin.kt
@@ -40,6 +40,22 @@ class CiGradlePlugin : Plugin<Project> {
         }
 
         project.tasks.register(
+            "generateCiTopologyPreview",
+            GenerateCiTopologyPreviewTask::class.java
+        ) { task ->
+            task.group = "verification"
+            task.description = "Previews provider-neutral CI lanes without changing active TeamCity jobs."
+            task.dependsOn(generateCiPlan)
+            task.planFile.set(generateCiPlan.flatMap(GenerateCiPlanTask::outputFile))
+            task.availableAgents.convention(
+                project.providers.gradleProperty("ciAvailableAgents").map(String::toInt).orElse(1)
+            )
+            task.outputFile.convention(
+                project.layout.buildDirectory.file("reports/ci/ci-topology-preview.json")
+            )
+        }
+
+        project.tasks.register(
             "runTeamCityInfrastructureHealth",
             RunTeamCityInfrastructureHealthTask::class.java
         ) { task ->

--- a/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/GenerateCiTopologyPreviewTask.kt
+++ b/repo/ci/src/main/kotlin/com/marmatsan/ci/plugin/GenerateCiTopologyPreviewTask.kt
@@ -1,0 +1,44 @@
+package com.marmatsan.ci.plugin
+
+import com.marmatsan.ci.data.json.CiExecutionTopologyJson
+import com.marmatsan.ci.data.json.CiPlanJson
+import com.marmatsan.ci.domain.service.CiTopologyPlanner
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "The preview is a diagnostic projection of a Git-derived CI plan")
+abstract class GenerateCiTopologyPreviewTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val planFile: RegularFileProperty
+
+    @get:Input
+    abstract val availableAgents: Property<Int>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val plan = CiPlanJson().read(planFile.get().asFile.readText())
+        val topology = CiTopologyPlanner().create(plan, availableAgents.get())
+        val output = outputFile.get().asFile
+        CiExecutionTopologyJson().write(topology, output)
+
+        logger.lifecycle(
+            "CI topology preview generated: agents={}, mode={}, lanes={}, output={}",
+            topology.availableAgents,
+            topology.mode,
+            topology.lanes.joinToString { lane -> lane.id },
+            output.absolutePath
+        )
+    }
+}

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/data/json/CiExecutionTopologyJsonTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/data/json/CiExecutionTopologyJsonTest.kt
@@ -1,0 +1,28 @@
+package com.marmatsan.ci.data.json
+
+import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.service.CiPlanFactory
+import com.marmatsan.ci.domain.service.CiTopologyPlanner
+import com.marmatsan.ci.testModuleGraph
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CiExecutionTopologyJsonTest : FunSpec({
+    test("round trips the preview topology contract") {
+        val plan = CiPlanFactory().create(
+            changeSet = RepositoryChangeSet(
+                comparisonBase = "base-sha",
+                head = "head-sha",
+                changedFiles = listOf(".teamcity/settings.kts")
+            ),
+            moduleGraph = testModuleGraph()
+        )
+        val expected = CiTopologyPlanner().create(plan, availableAgents = 3)
+        val json = CiExecutionTopologyJson()
+        val output = kotlin.io.path.createTempFile().toFile()
+
+        json.write(expected, output)
+
+        json.read(output.readText()) shouldBe expected
+    }
+})

--- a/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/CiTopologyPlannerTest.kt
+++ b/repo/ci/src/test/kotlin/com/marmatsan/ci/domain/service/CiTopologyPlannerTest.kt
@@ -1,0 +1,111 @@
+package com.marmatsan.ci.domain.service
+
+import com.marmatsan.ci.domain.model.CiExecutionLane
+import com.marmatsan.ci.domain.model.CiPlan
+import com.marmatsan.ci.domain.model.CiTopologyActivation
+import com.marmatsan.ci.domain.model.CiTopologyMode
+import com.marmatsan.ci.domain.model.RepositoryChangeSet
+import com.marmatsan.ci.domain.model.VerificationUnitId
+import com.marmatsan.ci.testModuleGraph
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class CiTopologyPlannerTest : FunSpec({
+    test("one agent keeps every required unit in one authoritative sequential lane") {
+        val plan = plan(".teamcity/settings.kts")
+
+        val topology = CiTopologyPlanner().create(plan, availableAgents = 1)
+
+        topology.activation shouldBe CiTopologyActivation.PREVIEW_ONLY
+        topology.mode shouldBe CiTopologyMode.SINGLE_AGENT_SEQUENTIAL
+        topology.authoritativeStatusPublisherLaneId shouldBe "verify"
+        topology.lanes.map(CiExecutionLane::id) shouldBe listOf("verify")
+        topology.lanes.single().verificationUnits shouldBe plan.requiredUnitIds()
+        topology.lanes.single().publishesAuthoritativeStatus shouldBe true
+    }
+
+    test("two agents preview supplemental and Gradle work in parallel after documentation") {
+        val topology = CiTopologyPlanner().create(
+            plan(".teamcity/settings.kts", "repo/figma-design-sync/tools/package.json"),
+            availableAgents = 2
+        )
+
+        topology.mode shouldBe CiTopologyMode.MULTI_AGENT_PARALLEL
+        topology.lanes.map(CiExecutionLane::id) shouldBe listOf(
+            "documentation",
+            "supplemental-verification",
+            "gradle-verification",
+            "ci-gate"
+        )
+        topology.lane("supplemental-verification").needs shouldBe listOf("documentation")
+        topology.lane("gradle-verification").needs shouldBe listOf("documentation")
+        topology.lane("ci-gate").needs shouldBe listOf(
+            "documentation",
+            "supplemental-verification",
+            "gradle-verification"
+        )
+        topology.authoritativeStatusPublisherLaneId shouldBe "ci-gate"
+    }
+
+    test("three agents separate repository tooling and Gradle lanes without losing work") {
+        val plan = plan(
+            ".teamcity/settings.kts",
+            "repo/figma-design-sync/tools/package.json",
+            "repo/dependency-catalog/versions.properties"
+        )
+
+        val topology = CiTopologyPlanner().create(plan, availableAgents = 3)
+
+        topology.lanes.map(CiExecutionLane::id) shouldBe listOf(
+            "documentation",
+            "repository-verification",
+            "tooling-verification",
+            "gradle-verification",
+            "ci-gate"
+        )
+        topology.lane("repository-verification").verificationUnits shouldBe
+            listOf(VerificationUnitId.TEAMCITY_DSL)
+        topology.lane("tooling-verification").verificationUnits shouldBe listOf(
+            VerificationUnitId.FIGMA_TOOLING,
+            VerificationUnitId.DEPENDENCY_CATALOG
+        )
+        topology.lanes.flatMap(CiExecutionLane::verificationUnits) shouldBe plan.requiredUnitIds()
+        topology.lanes.count(CiExecutionLane::publishesAuthoritativeStatus) shouldBe 1
+    }
+
+    test("empty future lanes are omitted for documentation-only work") {
+        val topology = CiTopologyPlanner().create(plan("docs/README.md"), availableAgents = 3)
+
+        topology.lanes.map(CiExecutionLane::id) shouldBe listOf(
+            "documentation",
+            "repository-verification",
+            "ci-gate"
+        )
+        topology.lane("repository-verification").verificationUnits shouldBe
+            listOf(VerificationUnitId.REPOSITORY_DIFF)
+    }
+
+    test("zero available agents is rejected") {
+        shouldThrow<IllegalArgumentException> {
+            CiTopologyPlanner().create(plan("docs/README.md"), availableAgents = 0)
+        }.message shouldBe "CI topology requires at least one available agent."
+    }
+}) {
+    companion object {
+        private fun plan(vararg paths: String): CiPlan = CiPlanFactory().create(
+            changeSet = RepositoryChangeSet(
+                comparisonBase = "base-sha",
+                head = "head-sha",
+                changedFiles = paths.toList()
+            ),
+            moduleGraph = testModuleGraph()
+        )
+
+        private fun CiPlan.requiredUnitIds() =
+            verificationUnits.filter { unit -> unit.required }.map { unit -> unit.id }
+
+        private fun com.marmatsan.ci.domain.model.CiExecutionTopology.lane(id: String) =
+            lanes.single { lane -> lane.id == id }
+    }
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral Kotlin topology planner for one, two, and three-plus CI agents
- expose a preview-only Gradle task and versioned JSON contract without changing active TeamCity jobs
- preserve one authoritative status publisher and document the activation boundary

## Verification

- `./gradlew.bat :ci:check generateCiTopologyPreview -PciAvailableAgents=3`
- `./gradlew.bat check`
- `pwsh -NoProfile -File .teamcity/scripts/validate-documentation.ps1`
- `git diff --check`

## Operational scope

The active TeamCity topology remains one sequential `Verify` job. This PR only
makes the future multi-agent topology executable and reviewable.
