### PR TITLE
docs(git): codify trunk-based workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,12 @@
 
 ## Branching
 
-- Use trunk-based development as the branching strategy.
-- Treat `main` as the trunk and keep it stable, tested, and releasable.
-- Create short-lived branches from `main` using `feature/<short-description>`, `fix/<short-description>`, or `chore/<short-description>`.
-- Keep branches small and merge them back into `main` quickly through pull requests.
-- Prefer feature flags or hidden entry points for incomplete work instead of long-running branches.
-- Delete short-lived branches after they have been merged into `main`.
-- Use version tags such as `v1.4.0` to mark releases.
-- Create temporary `release/<version>` stabilization branches only when a release needs focused QA or last-mile fixes.
-- Create `hotfix/<short-description>` branches from `main` only for urgent production fixes, then merge the fix back into `main` and tag the patch release.
+- Follow `docs/standards/git-workflow.md` as the canonical Git workflow.
+- Treat `main` as the only permanent branch and keep it stable, tested, and releasable.
+- Create short-lived `feature/*`, `fix/*`, or `chore/*` branches from current `main`.
+- Merge through a pull request using squash after `TeamCity CI` passes and all review conversations are resolved.
+- Use feature flags or hidden entry points for incomplete work, and delete short-lived branches after merge or abandonment.
+- Use immutable `vX.Y.Z` tags for releases. Create `release/<x.y.z>` only for exceptional stabilization and `hotfix/*` only for urgent production fixes.
 
 ## Commits
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Project structure](docs/reference/project-structure.md)
 - [Engineering standards](docs/standards/README.md)
 - [Development guides](docs/guides/README.md)
+- [Git workflow](docs/standards/git-workflow.md)
 - [Main branch protection](docs/ci/main-branch-protection.md)
 - [TeamCity HTTPS and webhook operations](docs/runbooks/teamcity-cloudflare-access.md)
 
@@ -15,3 +16,4 @@
 - [Run executable BDD scenarios](docs/guides/run-bdd-tests.md)
 - [Add a product feature](docs/guides/add-feature.md)
 - [Add a product module](docs/guides/add-module.md)
+- [Work with short-lived Git branches](docs/guides/work-with-short-lived-branches.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ them.
 ## Architecture Decisions
 
 - [ADR-0001: Adopt a Typed Documentation System](decisions/adr-0001-documentation-system.md)
+- [ADR-0007: Use Trunk-Based Development](decisions/adr-0007-use-trunk-based-development.md)
 - [ADR-0005: Name the Portable Infrastructure Figma Documentation Sync](decisions/adr-0005-name-figma-documentation-sync.md)
 - [ADR-0003: Keep the Figma Runtime Boundary in TypeScript](decisions/adr-0003-keep-figma-runtime-boundary-in-typescript.md)
 - [ADR-0004: Use JSON for Figma Writer Project Configuration](decisions/adr-0004-use-json-for-figma-writer-project-configuration.md)
@@ -28,3 +29,11 @@ them.
 ## CI References
 
 - [CI Verification Plan](reference/ci-verification-plan.md)
+
+## Git Workflow
+
+- [Git Workflow Standard](standards/git-workflow.md)
+- [Work With Short-Lived Git Branches](guides/work-with-short-lived-branches.md)
+- [Create A Release](runbooks/create-release.md)
+- [Ship A Production Hotfix](runbooks/ship-hotfix.md)
+- [Main Branch Protection](ci/main-branch-protection.md)

--- a/docs/ci/main-branch-protection.md
+++ b/docs/ci/main-branch-protection.md
@@ -1,5 +1,9 @@
 # Main Branch Protection
 
+This CI reference records the exact GitHub and TeamCity protection applied to
+`main`. The normative branch and merge rules live in the
+[Git workflow standard](../standards/git-workflow.md).
+
 `main` is the trunk branch. It must stay stable, tested, and releasable.
 
 ## Required Flow
@@ -34,7 +38,7 @@ It enforces:
 - non-fast-forward updates are blocked;
 - linear history is required;
 - changes must be merged through a pull request;
-- allowed pull request merge methods are squash and rebase;
+- the only allowed pull request merge method is squash;
 - review conversations must be resolved before merge;
 - `TeamCity CI` must pass before merge;
 - required status checks must be strict, so the pull request branch must be up
@@ -54,6 +58,10 @@ showing `All checks have passed` for `TeamCity CI`.
 Do not require `Figma Sync` in the GitHub ruleset. `Figma Sync` runs after
 changes reach `main`. It may still appear on `main` commits as the optional
 `TeamCity Figma Sync` status.
+
+Repository merge settings enable squash, automatic branch updates, automatic
+merge, and deletion of merged branches. Merge commits and rebase merge are
+disabled.
 
 ## TeamCity CI
 
@@ -116,3 +124,7 @@ fix/<short-description> -> pull request -> TeamCity CI -> merge
 ```
 
 Do not bypass the ruleset or push directly to `main` to repair the failure.
+
+Use the [hotfix runbook](../runbooks/ship-hotfix.md) only for urgent production
+corrections. Use the [release runbook](../runbooks/create-release.md) to create
+immutable version tags from verified `main` commits.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,3 +12,4 @@ ADRs explain durable project decisions and their tradeoffs. Use
 | [ADR-0004](adr-0004-use-json-for-figma-writer-project-configuration.md) | Superseded | Use Kotlin-generated JSON as the only writer project-configuration input. |
 | [ADR-0005](adr-0005-name-figma-documentation-sync.md) | Accepted | Publish the retained architecture as Figma Documentation Sync. |
 | [ADR-0006](adr-0006-use-gradle-owned-verification.md) | Accepted | Use Gradle tasks as the canonical repository verification API. |
+| [ADR-0007](adr-0007-use-trunk-based-development.md) | Accepted | Use one protected trunk with short-lived branches and squash integration. |

--- a/docs/decisions/adr-0007-use-trunk-based-development.md
+++ b/docs/decisions/adr-0007-use-trunk-based-development.md
@@ -1,0 +1,73 @@
+---
+title: Use trunk-based development
+type: adr
+scope: repository
+owner: repository-tooling
+status: accepted
+last-reviewed: 2026-07-20
+review-cycle-days: 365
+sources:
+  - AGENTS.md
+  - docs/ci/main-branch-protection.md
+  - .teamcity/settings.kts
+---
+
+# ADR-0007: Use Trunk-Based Development
+
+## Context
+
+The repository already treats `main` as its stable and releasable branch, uses
+short-lived pull request branches, and requires `TeamCity CI` before merge.
+Those rules were split between agent instructions and CI documentation, while
+the daily branch lifecycle, release stabilization, and hotfix recovery were not
+owned by one canonical engineering standard.
+
+The project currently has one maintainer, one protected trunk, and a CI pipeline
+that validates branches and pull requests before running separate post-merge
+Figma documentation verification. The branching model must keep that feedback
+loop short without introducing permanent integration or environment branches.
+
+## Decision
+
+Use trunk-based development with `main` as the only permanent branch. Changes
+enter `main` through short-lived `feature/*`, `fix/*`, or `chore/*` branches and
+are integrated by squash merge after required verification succeeds.
+
+Keep `fix/*` as a semantic distinction for ordinary defect correction even
+though trunk-based development does not require type-specific branch prefixes.
+Use temporary `release/<x.y.z>` branches only when focused stabilization is
+necessary and `hotfix/*` branches only for urgent production corrections.
+
+Mark releases with immutable semantic-version tags in the form `vX.Y.Z` on
+verified `main` commits. Use feature flags or hidden entry points when incomplete
+work cannot be delivered safely in one short-lived branch.
+
+## Consequences
+
+- `main` remains the only integration and release line.
+- Pull requests stay small and are expected to merge within three working days.
+- Squash merge makes the Conventional Commit pull request title the single
+  reviewed commit that reaches `main`.
+- Release and hotfix branches are exceptional and are deleted after merge.
+- No `develop`, environment, personal, or permanent release branches are used.
+- Zero approving reviews are acceptable while the repository has one
+  maintainer; at least one approval becomes mandatory when another maintainer
+  can review changes.
+- Branch naming and lifecycle rules become candidates for executable
+  verification rather than remaining prose-only conventions.
+
+## Alternatives
+
+- GitFlow with permanent `develop` and release branches. Rejected because it
+  delays integration and duplicates the role of the protected trunk.
+- Direct pushes to `main`. Rejected because they bypass the required CI and
+  review evidence.
+- One generic `change/*` prefix. Rejected because `feature/*`, `fix/*`, and
+  `chore/*` communicate intent and align with the repository's Conventional
+  Commit history at little operational cost.
+- Rebase merge as an additional merge method. Rejected because squash gives
+  every pull request one predictable, reviewed commit on `main`.
+
+## Supersession
+
+None.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,3 +10,4 @@ that govern them.
 | [Add an API endpoint](add-api-endpoint.md) | Add transport and domain behavior without leaking client types. |
 | [Add a Compose screen](add-compose-screen.md) | Build a state-driven, accessible screen using the design system. |
 | [Run BDD tests](run-bdd-tests.md) | Execute and filter the Cucumber business scenarios. |
+| [Work with short-lived Git branches](work-with-short-lived-branches.md) | Create, verify, merge, and clean up one focused branch. |

--- a/docs/guides/work-with-short-lived-branches.md
+++ b/docs/guides/work-with-short-lived-branches.md
@@ -1,0 +1,105 @@
+---
+title: Work with short-lived Git branches
+type: guide
+scope: repository
+owner: repository-tooling
+status: active
+last-reviewed: 2026-07-20
+review-cycle-days: 180
+sources:
+  - docs/standards/git-workflow.md
+  - AGENTS.md
+---
+
+# Work With Short-Lived Git Branches
+
+## Outcome
+
+Create one focused branch from the latest `main`, verify it, merge it through a
+pull request, and remove its local and remote references.
+
+## Applicable Standards
+
+Follow the [Git workflow standard](../standards/git-workflow.md) and use the
+commit structure in [`AGENTS.md`](../../AGENTS.md).
+
+## Steps
+
+1. Start from a clean, current trunk:
+
+   ```powershell
+   git switch main
+   git pull --ff-only
+   git status --short --branch
+   ```
+
+2. Choose the branch type by outcome and create it. For example:
+
+   ```powershell
+   git switch -c feature/plant-reminders
+   ```
+
+   Use `fix/*` for an ordinary defect and `chore/*` for documentation, CI,
+   dependencies, or maintenance.
+
+3. Keep the branch focused. Commit coherent checkpoints with Conventional
+   Commit messages:
+
+   ```powershell
+   git add <paths>
+   git commit -m "feat(reminders): add scheduled watering notifications"
+   ```
+
+4. Run the checks proportional to the change. The exhaustive default is:
+
+   ```powershell
+   .\gradlew.bat check
+   ```
+
+   Documentation changes additionally run:
+
+   ```powershell
+   .\gradlew.bat checkDocumentation
+   ```
+
+5. Publish the branch and open a pull request to `main`:
+
+   ```powershell
+   git push --set-upstream origin feature/plant-reminders
+   ```
+
+   Use a Conventional Commit pull request title because squash merge promotes
+   that title to the reviewed commit on `main`.
+
+6. If `main` advances before merge, update the branch and rerun verification:
+
+   ```powershell
+   git fetch origin
+   git rebase origin/main
+   git push --force-with-lease
+   ```
+
+7. Merge only after `TeamCity CI` passes and all review conversations are
+   resolved. Use squash merge.
+
+8. Refresh the local checkout and remove stale references:
+
+   ```powershell
+   git switch main
+   git pull --ff-only
+   git branch -d feature/plant-reminders
+   git fetch --prune
+   ```
+
+## Verification
+
+- `git status --short --branch` shows clean `main` aligned with `origin/main`.
+- The pull request appears as one Conventional Commit on `main`.
+- GitHub no longer contains the merged short-lived branch.
+- Required local checks and `TeamCity CI` succeeded.
+
+## Related Documentation
+
+- [Main branch protection](../ci/main-branch-protection.md)
+- [Create a release](../runbooks/create-release.md)
+- [Ship a hotfix](../runbooks/ship-hotfix.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -7,3 +7,5 @@ remain under that module's `docs/runbooks/` directory.
 |---------|-----------|
 | [TeamCity Cloudflare Access](teamcity-cloudflare-access.md) | Operate TeamCity HTTPS access, service authentication, webhooks, and Windows runtime recovery. |
 | [TeamCity Backup And Recovery](teamcity-backup-recovery.md) | Back up TeamCity server state and artifacts, verify off-host copies, and run isolated restore drills. |
+| [Create A Release](create-release.md) | Tag a verified `main` commit and run exceptional release stabilization. |
+| [Ship A Production Hotfix](ship-hotfix.md) | Deliver an urgent correction through the protected trunk and publish a patch tag. |

--- a/docs/runbooks/create-release.md
+++ b/docs/runbooks/create-release.md
@@ -1,0 +1,93 @@
+---
+title: Create a release
+type: runbook
+scope: repository
+owner: repository-tooling
+status: active
+last-reviewed: 2026-07-20
+review-cycle-days: 90
+sources:
+  - docs/standards/git-workflow.md
+  - docs/ci/main-branch-protection.md
+---
+
+# Create A Release
+
+## Purpose
+
+Create an immutable semantic-version tag from a verified `main` commit. Use a
+temporary release branch only when focused QA or last-mile stabilization is
+required.
+
+## Prerequisites
+
+- Maintainer permission to create and push tags.
+- A chosen semantic version `X.Y.Z` that has not been published previously.
+- A clean local checkout with access to `origin`.
+- Successful `TeamCity CI` on the `main` commit to release.
+- Completed required Figma documentation publication for that commit.
+
+## Procedure
+
+1. Refresh `main` and verify the intended commit:
+
+   ```powershell
+   git switch main
+   git pull --ff-only
+   git status --short --branch
+   git log -1 --oneline
+   .\gradlew.bat check
+   ```
+
+2. For a normal release, create and push an annotated tag:
+
+   ```powershell
+   git tag -a v1.4.0 -m "Release v1.4.0"
+   git push origin v1.4.0
+   ```
+
+3. When stabilization is required, create the exceptional branch before the
+   final tag:
+
+   ```powershell
+   git switch -c release/1.4.0
+   git push --set-upstream origin release/1.4.0
+   ```
+
+4. Apply only release-blocking changes, verify them, and open a pull request
+   from `release/1.4.0` to `main` with a Conventional Commit title.
+
+5. Squash merge the release pull request after `TeamCity CI` succeeds. Return to
+   the updated `main`, rerun step 1, and create the version tag there.
+
+## Verification
+
+```powershell
+git show --no-patch --decorate v1.4.0
+git ls-remote --tags origin refs/tags/v1.4.0
+```
+
+The tag resolves to the intended verified `main` commit, and any temporary
+release branch has been removed after merge.
+
+## Recovery
+
+- If an incorrect tag has not been pushed, delete it locally with
+  `git tag -d v1.4.0` and recreate it correctly.
+- Do not move or reuse a published tag. Correct a published release with a new
+  patch version such as `v1.4.1`.
+- If release verification fails, do not tag. Fix the failure through a normal
+  pull request or abandon the temporary release branch.
+
+## Prohibited Actions
+
+- Do not tag an unverified branch or detached local commit.
+- Do not tag the release-branch tip before its changes reach `main`.
+- Do not force-push, move, or reuse a published version tag.
+- Do not use a release branch as a permanent integration branch.
+
+## Sources
+
+- [Git workflow standard](../standards/git-workflow.md)
+- [Main branch protection](../ci/main-branch-protection.md)
+- [Hotfix runbook](ship-hotfix.md)

--- a/docs/runbooks/ship-hotfix.md
+++ b/docs/runbooks/ship-hotfix.md
@@ -1,0 +1,93 @@
+---
+title: Ship a production hotfix
+type: runbook
+scope: repository
+owner: repository-tooling
+status: active
+last-reviewed: 2026-07-20
+review-cycle-days: 90
+sources:
+  - docs/standards/git-workflow.md
+  - docs/ci/main-branch-protection.md
+---
+
+# Ship A Production Hotfix
+
+## Purpose
+
+Deliver an urgent production correction without bypassing the protected trunk,
+required CI, or immutable release history.
+
+## Prerequisites
+
+- A confirmed production defect requiring priority over ordinary work.
+- The current released version and the next unused patch version.
+- Maintainer permission to merge pull requests and push version tags.
+- A clean checkout of the latest `main`.
+
+## Procedure
+
+1. Create the hotfix from current `main`:
+
+   ```powershell
+   git switch main
+   git pull --ff-only
+   git switch -c hotfix/reminder-crash
+   ```
+
+2. Implement the smallest safe correction and add regression coverage.
+
+3. Run focused tests and the exhaustive repository check:
+
+   ```powershell
+   .\gradlew.bat check
+   git diff --check
+   ```
+
+4. Commit and publish the branch:
+
+   ```powershell
+   git add <paths>
+   git commit -m "fix(reminders): prevent production notification crash"
+   git push --set-upstream origin hotfix/reminder-crash
+   ```
+
+5. Open a pull request to `main`, resolve every review conversation, and wait
+   for strict `TeamCity CI` success.
+
+6. Squash merge the pull request. Refresh `main` and create the next patch tag:
+
+   ```powershell
+   git switch main
+   git pull --ff-only
+   git tag -a v1.4.1 -m "Release v1.4.1"
+   git push origin v1.4.1
+   git fetch --prune
+   ```
+
+## Verification
+
+- The regression test fails without the hotfix and passes with it.
+- `TeamCity CI` succeeds on the pull request and the resulting `main` commit.
+- The patch tag resolves to the squash commit on `main`.
+- GitHub no longer contains the hotfix branch.
+
+## Recovery
+
+- If CI fails, keep the branch unmerged and correct it normally.
+- If the merged hotfix causes another defect, revert or correct it through a new
+  `hotfix/*` pull request and publish a new patch version.
+- Never repair a published release by moving its existing tag.
+
+## Prohibited Actions
+
+- Do not push directly to `main`.
+- Do not bypass required status checks or unresolved review conversations.
+- Do not reduce regression coverage merely to shorten hotfix delivery.
+- Do not force-update or reuse a published version tag.
+
+## Sources
+
+- [Git workflow standard](../standards/git-workflow.md)
+- [Main branch protection](../ci/main-branch-protection.md)
+- [Release runbook](create-release.md)

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -12,3 +12,4 @@ review-blocking; `SHOULD` rules require a documented reason when not followed.
 | [API client](api-client.md) | Transport boundaries, DTOs, errors, and security. |
 | [Testing](testing.md) | Unit, BDD, integration, and UI test responsibilities. |
 | [Accessibility](accessibility.md) | Semantics, interaction, text, and visual accessibility. |
+| [Git workflow](git-workflow.md) | Trunk, short-lived branches, pull requests, merges, and release tags. |

--- a/docs/standards/git-workflow.md
+++ b/docs/standards/git-workflow.md
@@ -1,0 +1,104 @@
+---
+title: Git workflow standard
+type: standard
+scope: repository
+owner: repository-tooling
+status: active
+last-reviewed: 2026-07-20
+review-cycle-days: 180
+sources:
+  - docs/decisions/adr-0007-use-trunk-based-development.md
+  - AGENTS.md
+  - docs/ci/main-branch-protection.md
+---
+
+# Git Workflow Standard
+
+## Purpose
+
+This standard defines the repository-wide branch, pull request, merge, and
+release-tag contract. It is the normative source for Git workflow rules;
+provider-specific protection and CI details remain in
+[`../ci/main-branch-protection.md`](../ci/main-branch-protection.md).
+
+## Rules
+
+### Trunk
+
+- `main` MUST be the only permanent branch.
+- `main` MUST remain stable, tested, and releasable.
+- Changes MUST enter `main` through a pull request and MUST NOT be pushed
+  directly.
+- A pull request MUST pass the strict `TeamCity CI` status and resolve all
+  review conversations before merge.
+- Pull requests MUST use squash merge. Merge commits and rebase merges into
+  `main` are prohibited.
+
+### Short-Lived Branches
+
+| Branch | Purpose | Example |
+|--------|---------|---------|
+| `feature/<short-description>` | New user or system capability. | `feature/plant-reminders` |
+| `fix/<short-description>` | Ordinary defect correction. | `fix/watering-date-calculation` |
+| `chore/<short-description>` | Documentation, CI, dependencies, or maintenance. | `chore/git-branching-strategy` |
+| `release/<x.y.z>` | Exceptional stabilization for one release. | `release/1.4.0` |
+| `hotfix/<short-description>` | Urgent production correction. | `hotfix/reminder-crash` |
+
+- Branches MUST start from the current `main`.
+- Descriptions MUST use lowercase English `kebab-case` containing letters,
+  digits, and single hyphens.
+- Short-lived branches SHOULD merge or be abandoned within three working days.
+  Work that exceeds that target SHOULD be split into smaller deliverable slices.
+- Incomplete behavior MUST remain safe through a feature flag, hidden entry
+  point, or another explicit non-public boundary.
+- Branches MUST be deleted after merge or abandonment.
+- `develop`, environment, personal, and permanent release branches MUST NOT be
+  created.
+
+### Pull Requests And Commits
+
+- A pull request MUST contain one coherent change and enough verification
+  evidence for that change.
+- The pull request title MUST follow `<type>(<scope>): <summary>` so the squash
+  commit on `main` is a Conventional Commit.
+- The title summary MUST describe the concrete resulting change, not an
+  activity such as "update files".
+- The branch MUST be up to date with `main` before the strict required status
+  can permit merge.
+- Zero approving reviews MAY be used while the repository has one maintainer.
+  Once another maintainer is available, at least one approval MUST be required.
+
+### Releases And Hotfixes
+
+- A normal release MUST be tagged from a verified `main` commit as `vX.Y.Z`.
+- A `release/<x.y.z>` branch MAY be created only when focused QA or last-mile
+  stabilization cannot be completed directly through ordinary short-lived
+  branches.
+- Stabilization changes MUST return to `main` through a pull request before the
+  release tag is created.
+- A production emergency MUST use `hotfix/<short-description>`, pass the normal
+  pull request and CI gates, merge to `main`, and create a new patch tag.
+- Published version tags MUST NOT be moved or reused.
+
+## Exceptions
+
+An exception requires a documented reason in the pull request and explicit
+maintainer approval. GitHub protection and required CI MUST NOT be bypassed.
+Operational urgency changes prioritization, not the integrity of `main`.
+
+## Verification
+
+- GitHub protects `main` with strict `TeamCity CI`, linear history, pull request
+  integration, and resolved review conversations.
+- Repository settings allow squash merge and delete merged branches.
+- `checkGitWorkflow` validates branch names when it is available in the
+  verification platform.
+- `checkDocumentation` validates this standard and its linked documents.
+
+## Sources
+
+- [ADR-0007](../decisions/adr-0007-use-trunk-based-development.md)
+- [Main branch protection](../ci/main-branch-protection.md)
+- [Short-lived branch guide](../guides/work-with-short-lived-branches.md)
+- [Release runbook](../runbooks/create-release.md)
+- [Hotfix runbook](../runbooks/ship-hotfix.md)


### PR DESCRIPTION
## Resumen

- registra trunk-based development como ADR aceptado
- añade el estándar canónico de ramas, pull requests, squash y tags
- documenta el flujo diario de ramas cortas
- añade runbooks separados para releases y hotfixes
- convierte la protección de `main` en la referencia exacta de GitHub y TeamCity

## Por qué

La estrategia estaba repartida entre `AGENTS.md` y documentación de CI. Faltaba una fuente normativa única y procedimientos ejecutables para el ciclo diario, la estabilización excepcional y las correcciones urgentes.

## Impacto

- `main` queda definido como la única rama permanente
- `feature/*`, `fix/*` y `chore/*` son las ramas ordinarias
- `release/*` y `hotfix/*` quedan limitadas a operaciones excepcionales
- el título Conventional Commit del PR se convierte en el commit squash de `main`

## Verificación

- `.\gradlew.bat checkDocumentation`
- `git diff --cached --check`