### PR TITLE
feat(verification): enforce Git branch workflow

### DIFF
--- a/.teamcity/README.md
+++ b/.teamcity/README.md
@@ -77,11 +77,17 @@ The GitHub ruleset for `main` is documented in
 The pipeline:
 
 - monitors all branches;
+- passes TeamCity's server-resolved logical branch name to the Gradle-owned
+  `checkGitWorkflow` task, which validates developer branches and recognizes
+  provider-managed pull request refs without creating an implicit agent
+  requirement for a VCS-root-specific parameter;
 - discovers and validates the Windows agent toolchain and Android SDK before
   running repository verification, then exports the discovered SDK path only
   to later steps in the same TeamCity build;
 - generates the enforced `build/reports/ci/ci-plan.json` contract and exports
   only its allow-listed TeamCity parameters to subsequent steps;
+- validates the trunk-based branch contract before typed documentation and
+  change coverage through Kotlin Gradle tasks;
 - validates typed documentation and change coverage through the Kotlin
   `checkDocumentation` Gradle task: canonical placement, frontmatter, review
   dates, runbook and ADR sections, canonical sources, and local Markdown links;
@@ -89,12 +95,13 @@ The pipeline:
   Figma-sync implementation, dependency-catalog model, or CI topology must
   update their mapped canonical documentation in
   [`.teamcity/documentation-coverage.json`](documentation-coverage.json);
-- exposes repository diff, TeamCity DSL, documentation, and module verification
-  as Gradle tasks selected by the Kotlin plan;
+- exposes Git workflow, repository diff, TeamCity DSL, documentation, and
+  module verification as Gradle tasks selected by the Kotlin plan;
 - uses the allow-listed `ci.plan.gradleTasks` parameter emitted by
-  `prepareTeamCityCiPlan` in one Gradle invocation: documentation-only changes
-  select `checkDocumentation` and `checkRepositoryDiff`, `.teamcity` changes
-  additionally select `checkTeamCityDsl`, and every non-documentation change
+  `prepareTeamCityCiPlan` in one Gradle invocation: every change first selects
+  `checkGitWorkflow`; documentation-only changes also select
+  `checkDocumentation` and `checkRepositoryDiff`; `.teamcity` changes
+  additionally select `checkTeamCityDsl`; and every non-documentation change
   retains targeted module checks or root `check`;
 - coalesces Figma-tooling and dependency-catalog units into that single heavy
   Gradle invocation while only one agent is available;

--- a/.teamcity/documentation-coverage.json
+++ b/.teamcity/documentation-coverage.json
@@ -114,6 +114,21 @@
         "docs/ci/windows-runtime-validation.md",
         "docs/ci/visual-model-contract.md"
       ]
+    },
+    {
+      "id": "git-workflow",
+      "sourcePaths": [
+        "repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/model/GitBranchValidation.kt",
+        "repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidator.kt",
+        "repo/verification-platform/data/src/main/kotlin/com/marmatsan/verificationPlatform/data/git/GitCurrentBranchSource.kt",
+        "repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/CheckGitWorkflowTask.kt"
+      ],
+      "documentationPaths": [
+        "docs/standards/git-workflow.md",
+        "repo/verification-platform/README.md",
+        "repo/verification-platform/docs/bdd/README.md",
+        ".teamcity/README.md"
+      ]
     }
   ]
 }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -80,6 +80,7 @@ object WaterMyPlantsCi : Pipeline({
         }
 
         params {
+            param("env.GIT_WORKFLOW_BRANCH", "%teamcity.build.branch%")
             param("ci.plan.comparisonBase", "")
             param("ci.plan.gradleTasks", "check")
         }

--- a/docs/guides/work-with-short-lived-branches.md
+++ b/docs/guides/work-with-short-lived-branches.md
@@ -53,6 +53,7 @@ commit structure in [`AGENTS.md`](../../AGENTS.md).
 4. Run the checks proportional to the change. The exhaustive default is:
 
    ```powershell
+   .\gradlew.bat checkGitWorkflow
    .\gradlew.bat check
    ```
 

--- a/docs/reference/ci-verification-plan.md
+++ b/docs/reference/ci-verification-plan.md
@@ -4,7 +4,7 @@ type: reference
 scope: repository
 owner: repository-tooling
 status: active
-last-reviewed: 2026-07-19
+last-reviewed: 2026-07-20
 review-cycle-days: 180
 sources:
   - repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/model/CiPlan.kt
@@ -12,6 +12,7 @@ sources:
   - repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/CiPlanFactory.kt
   - repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/CiTopologyPlanner.kt
   - repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/ModuleImpactAnalyzer.kt
+  - repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidator.kt
 ---
 
 # CI Verification Plan
@@ -25,7 +26,7 @@ parallel without changing this contract.
 
 ## Contract
 
-`generateCiPlan` writes schema version `2` to
+`generateCiPlan` writes schema version `3` to
 `build/reports/ci/ci-plan.json` with:
 
 | Field | Meaning |
@@ -42,13 +43,16 @@ parallel without changing this contract.
 | `fullVerification` | Whether root `check` remains required. |
 | `fallbackReason` | Fail-closed explanation when targeted classification is unsafe. |
 
-Stable verification unit identifiers are `documentation`, `repository-diff`,
-`teamcity-dsl`, `figma-tooling`, `dependency-catalog`,
+Stable verification unit identifiers are `git-workflow`, `documentation`,
+`repository-diff`, `teamcity-dsl`, `figma-tooling`, `dependency-catalog`,
 `gradle-verification`, and `publish-reports`.
 
 ## Invariants
 
 - Unknown or empty change sets require full verification.
+- Git workflow validation is always required before other repository checks.
+- Plan generation is untracked and always reads the current committed `HEAD`;
+  Gradle must not reuse a plan produced for an earlier revision.
 - Plan output contains no executable shell commands.
 - Every executable verification unit maps to reviewed Gradle task names.
 - CI adapters validate and flatten those tasks without reimplementing policy.
@@ -76,6 +80,7 @@ rules:
 
 | Plan unit | TeamCity execution |
 |-----------|--------------------|
+| `git-workflow` | Always select `checkGitWorkflow` using TeamCity's server-resolved logical branch name. |
 | `documentation` | Always select `checkDocumentation`. |
 | `repository-diff` | Select `checkRepositoryDiff` for documentation-only changes. |
 | `teamcity-dsl` | Select `checkTeamCityDsl` when `.teamcity` changes; the task owns Maven-wrapper execution. |

--- a/docs/standards/git-workflow.md
+++ b/docs/standards/git-workflow.md
@@ -10,6 +10,8 @@ sources:
   - docs/decisions/adr-0007-use-trunk-based-development.md
   - AGENTS.md
   - docs/ci/main-branch-protection.md
+  - repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidator.kt
+  - repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/CheckGitWorkflowTask.kt
 ---
 
 # Git Workflow Standard
@@ -91,8 +93,7 @@ Operational urgency changes prioritization, not the integrity of `main`.
 - GitHub protects `main` with strict `TeamCity CI`, linear history, pull request
   integration, and resolved review conversations.
 - Repository settings allow squash merge and delete merged branches.
-- `checkGitWorkflow` validates branch names when it is available in the
-  verification platform.
+- `checkGitWorkflow` validates branch names locally and in TeamCity.
 - `checkDocumentation` validates this standard and its linked documents.
 
 ## Sources

--- a/repo/verification-platform/README.md
+++ b/repo/verification-platform/README.md
@@ -23,7 +23,8 @@ aggregator so existing consumers do not need to know its internal projects.
 
 - Domain models and classification do not depend on TeamCity, GitHub Actions,
   Gradle APIs, PowerShell, or Figma Documentation Sync.
-- The Git adapter resolves the committed diff against `origin/main`.
+- Git adapters resolve the current branch and committed diff against
+  `origin/main` without depending on a CI provider.
 - The Gradle adapter snapshots executable root-project modules and declared
   project dependencies after project evaluation. The domain computes changed
   modules and transitive reverse dependents without Gradle APIs.
@@ -31,7 +32,7 @@ aggregator so existing consumers do not need to know its internal projects.
   parameters and validates every emitted Gradle task name; it does not add
   provider concerns to the domain model.
 - The Gradle plugin is the current composition root and registers
-  `generateCiPlan`, `checkDocumentation`, `checkRepositoryDiff`,
+  `generateCiPlan`, `checkGitWorkflow`, `checkDocumentation`, `checkRepositoryDiff`,
   `checkTeamCityDsl`, `generateCiTopologyPreview`, `prepareTeamCityCiPlan`, and
   `runTeamCityInfrastructureHealth` in the Water My Plants root build.
 - CI providers consume allow-listed unit identifiers and Gradle task names;
@@ -63,6 +64,7 @@ therefore add or update KDoc in the same change.
 ```powershell
 .\gradlew.bat :verification-platform:domain:check :verification-platform:data:check :verification-platform:plugin:check
 .\gradlew.bat :verification-platform:dokkaGenerate
+.\gradlew.bat checkGitWorkflow
 .\gradlew.bat checkDocumentation
 .\gradlew.bat checkRepositoryDiff
 .\gradlew.bat checkTeamCityDsl
@@ -71,7 +73,11 @@ therefore add or update KDoc in the same change.
 .\gradlew.bat prepareTeamCityCiPlan
 ```
 
-`generateCiPlan` writes the provider-neutral JSON contract.
+`checkGitWorkflow` validates local symbolic `HEAD` or the complete CI VCS ref
+against the trunk-based branch contract. Provider-managed pull request refs are
+accepted because TeamCity also validates the corresponding source branch build.
+`generateCiPlan` is deliberately untracked and always writes the
+provider-neutral JSON contract from the current committed `HEAD`.
 `generateCiTopologyPreview` projects its required units into agent lanes under
 `build/reports/ci/ci-topology-preview.json`. The output is explicitly
 `preview-only`: no TeamCity setting consumes it. One agent produces the current

--- a/repo/verification-platform/data/src/main/kotlin/com/marmatsan/verificationPlatform/data/git/GitCurrentBranchSource.kt
+++ b/repo/verification-platform/data/src/main/kotlin/com/marmatsan/verificationPlatform/data/git/GitCurrentBranchSource.kt
@@ -1,0 +1,40 @@
+package com.marmatsan.verificationPlatform.data.git
+
+import java.io.File
+
+/** Reads the current developer-owned Git branch from a repository checkout. */
+class GitCurrentBranchSource {
+    /**
+     * Returns [branchOverride] when provided, otherwise resolves symbolic
+     * `HEAD` in [repositoryRoot].
+     *
+     * CI adapters provide the server-resolved logical branch name so detached
+     * pull request checkouts can still be classified without provider knowledge
+     * in domain.
+     *
+     * @throws IllegalStateException when neither input can identify a branch.
+     */
+    fun read(repositoryRoot: File, branchOverride: String? = null): String {
+        branchOverride?.trim()?.takeIf(String::isNotEmpty)?.let { branch ->
+            return branch
+        }
+
+        val root = repositoryRoot.canonicalFile
+        return gitOrNull(root, "symbolic-ref", "--quiet", "--short", "HEAD")
+            ?.takeIf(String::isNotBlank)
+            ?: error(
+                "Cannot resolve the Git branch from detached HEAD. " +
+                    "Provide gitWorkflowBranch or GIT_WORKFLOW_BRANCH."
+            )
+    }
+
+    private fun gitOrNull(root: File, vararg arguments: String): String? {
+        val safeDirectory = root.absolutePath.replace('\\', '/')
+        val process = ProcessBuilder(listOf("git", "-c", "safe.directory=$safeDirectory") + arguments)
+            .directory(root)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { reader -> reader.readText() }
+        return if (process.waitFor() == 0) output.trim() else null
+    }
+}

--- a/repo/verification-platform/data/src/main/kotlin/com/marmatsan/verificationPlatform/data/teamcity/TeamCityCiPlanParameters.kt
+++ b/repo/verification-platform/data/src/main/kotlin/com/marmatsan/verificationPlatform/data/teamcity/TeamCityCiPlanParameters.kt
@@ -48,6 +48,7 @@ class TeamCityCiPlanParameters {
     }
 
     private fun VerificationUnitId.externalName(): String = when (this) {
+        VerificationUnitId.GIT_WORKFLOW -> "git-workflow"
         VerificationUnitId.DOCUMENTATION -> "documentation"
         VerificationUnitId.REPOSITORY_DIFF -> "repository-diff"
         VerificationUnitId.TEAMCITY_DSL -> "teamcity-dsl"

--- a/repo/verification-platform/data/src/test/kotlin/com/marmatsan/verificationPlatform/data/git/GitCurrentBranchSourceTest.kt
+++ b/repo/verification-platform/data/src/test/kotlin/com/marmatsan/verificationPlatform/data/git/GitCurrentBranchSourceTest.kt
@@ -1,0 +1,43 @@
+package com.marmatsan.verificationPlatform.data.git
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Files
+
+class GitCurrentBranchSourceTest : FunSpec({
+    test("reads the symbolic branch from a local checkout") {
+        val root = Files.createTempDirectory("git-current-branch").toFile()
+        try {
+            git(root, "init")
+            git(root, "switch", "-c", "feature/plant-reminders")
+
+            GitCurrentBranchSource().read(root) shouldBe "feature/plant-reminders"
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    test("uses a CI branch override for detached provider checkouts") {
+        val root = Files.createTempDirectory("git-current-branch-override").toFile()
+        try {
+            GitCurrentBranchSource().read(root, "refs/pull/96/head") shouldBe
+                "refs/pull/96/head"
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+}) {
+    companion object {
+        private fun git(root: File, vararg arguments: String) {
+            val process = ProcessBuilder(listOf("git") + arguments)
+                .directory(root)
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().use { reader -> reader.readText() }
+            check(process.waitFor() == 0) {
+                "Git command failed: git ${arguments.joinToString(" ")}\n${output.trim()}"
+            }
+        }
+    }
+}

--- a/repo/verification-platform/data/src/test/kotlin/com/marmatsan/verificationPlatform/data/teamcity/TeamCityCiPlanParametersTest.kt
+++ b/repo/verification-platform/data/src/test/kotlin/com/marmatsan/verificationPlatform/data/teamcity/TeamCityCiPlanParametersTest.kt
@@ -20,7 +20,7 @@ class TeamCityCiPlanParametersTest : FunSpec({
         )
 
         TeamCityCiPlanParameters().create(plan) shouldBe linkedMapOf(
-            "ci.plan.schemaVersion" to "2",
+            "ci.plan.schemaVersion" to "3",
             "ci.plan.mode" to "enforced",
             "ci.plan.scope" to "teamcity",
             "ci.plan.comparisonBase" to "base-sha",
@@ -29,7 +29,8 @@ class TeamCityCiPlanParametersTest : FunSpec({
             "ci.plan.fallbackReason" to "",
             "ci.plan.changedModules" to "",
             "ci.plan.affectedModules" to "",
-            "ci.plan.gradleTasks" to "checkDocumentation checkTeamCityDsl check",
+            "ci.plan.gradleTasks" to "checkGitWorkflow checkDocumentation checkTeamCityDsl check",
+            "ci.unit.git-workflow.required" to "true",
             "ci.unit.documentation.required" to "true",
             "ci.unit.repository-diff.required" to "false",
             "ci.unit.teamcity-dsl.required" to "true",
@@ -55,7 +56,8 @@ class TeamCityCiPlanParametersTest : FunSpec({
         parameters["ci.plan.changedModules"] shouldBe ":core:ui"
         parameters["ci.plan.affectedModules"] shouldBe ":app,:core:ui,:onboarding:ui"
         parameters["ci.plan.gradleTasks"] shouldBe
-            "checkDocumentation :app:check :core:ui:check :onboarding:ui:check checkFigmaCatalogUsage"
+            "checkGitWorkflow checkDocumentation :app:check :core:ui:check " +
+            ":onboarding:ui:check checkFigmaCatalogUsage"
     }
 
     test("rejects Gradle task values that could inject shell content") {

--- a/repo/verification-platform/docs/README.md
+++ b/repo/verification-platform/docs/README.md
@@ -34,6 +34,7 @@ details must not leak into domain contracts.
 
 - [Architecture standard](../../../docs/standards/architecture.md)
 - [Testing, BDD, TDD, and KDoc standard](../../../docs/standards/testing.md)
+- [Git workflow standard](../../../docs/standards/git-workflow.md)
 - [Canonical documentation standard](../../../docs/documentation.md)
 
 ## Verification

--- a/repo/verification-platform/docs/bdd/README.md
+++ b/repo/verification-platform/docs/bdd/README.md
@@ -13,6 +13,7 @@ must explain technical usage without copying the scenarios.
 
 | Behavior contract | Feature | Primary Kotlin API |
 |---|---|---|
+| Trunk-based branch naming | `../../domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/git-workflow.feature` | `GitBranchNameValidator` |
 | Verification selection and fail-closed behavior | `../../domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/ci-verification-plan.feature` | `CiPlanFactory` |
 | Single-agent and future multi-agent topology | `../../domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/ci-execution-topology.feature` | `CiTopologyPlanner` |
 

--- a/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/model/GitBranchValidation.kt
+++ b/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/model/GitBranchValidation.kt
@@ -1,0 +1,17 @@
+package com.marmatsan.verificationPlatform.domain.model
+
+/**
+ * Result of validating one Git branch against the repository workflow.
+ *
+ * @property branch normalized branch name used for validation.
+ * @property valid whether the branch satisfies the repository policy.
+ * @property providerManaged whether the ref is a synthetic pull request ref
+ * created by the CI provider rather than a developer-owned branch.
+ * @property message validation failure detail, or `null` when valid.
+ */
+data class GitBranchValidation(
+    val branch: String,
+    val valid: Boolean,
+    val providerManaged: Boolean,
+    val message: String?
+)

--- a/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/model/VerificationUnitId.kt
+++ b/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/model/VerificationUnitId.kt
@@ -6,6 +6,10 @@ import kotlinx.serialization.Serializable
 /** Stable identifiers for work that reviewed CI adapters may execute. */
 @Serializable
 enum class VerificationUnitId {
+    /** Validate the current branch against the trunk-based Git workflow. */
+    @SerialName("git-workflow")
+    GIT_WORKFLOW,
+
     /** Validate documentation structure, metadata, links, and coverage. */
     @SerialName("documentation")
     DOCUMENTATION,

--- a/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/CiPlanFactory.kt
+++ b/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/CiPlanFactory.kt
@@ -85,8 +85,16 @@ class CiPlanFactory {
         fallbackReason: String?
     ): List<VerificationUnit> = listOf(
         unit(
+            id = VerificationUnitId.GIT_WORKFLOW,
+            required = true,
+            capabilities = listOf("git"),
+            gradleTasks = listOf(CHECK_GIT_WORKFLOW),
+            reasons = listOf("Every checkout must satisfy the trunk-based branch contract.")
+        ),
+        unit(
             id = VerificationUnitId.DOCUMENTATION,
             required = true,
+            needs = listOf(VerificationUnitId.GIT_WORKFLOW),
             capabilities = listOf("java", "android-sdk", "git"),
             gradleTasks = listOf(CHECK_DOCUMENTATION),
             reasons = listOf("Documentation structure and coverage are repository-wide invariants.")
@@ -148,6 +156,7 @@ class CiPlanFactory {
             id = VerificationUnitId.PUBLISH_REPORTS,
             required = true,
             needs = listOf(
+                VerificationUnitId.GIT_WORKFLOW,
                 VerificationUnitId.DOCUMENTATION,
                 VerificationUnitId.REPOSITORY_DIFF,
                 VerificationUnitId.TEAMCITY_DSL,
@@ -243,7 +252,8 @@ class CiPlanFactory {
     }
 
     private companion object {
-        const val SCHEMA_VERSION = 2
+        const val SCHEMA_VERSION = 3
+        const val CHECK_GIT_WORKFLOW = "checkGitWorkflow"
         const val CHECK_DOCUMENTATION = "checkDocumentation"
         const val CHECK_REPOSITORY_DIFF = "checkRepositoryDiff"
         const val CHECK_TEAMCITY_DSL = "checkTeamCityDsl"

--- a/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/CiTopologyPlanner.kt
+++ b/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/CiTopologyPlanner.kt
@@ -94,6 +94,7 @@ class CiTopologyPlanner {
     private fun multiAgentLaneId(id: VerificationUnitId, availableAgents: Int): String =
         if (availableAgents == 2) {
             when (id) {
+                VerificationUnitId.GIT_WORKFLOW,
                 VerificationUnitId.DOCUMENTATION -> DOCUMENTATION_LANE
                 VerificationUnitId.GRADLE_VERIFICATION -> GRADLE_LANE
                 VerificationUnitId.PUBLISH_REPORTS -> GATE_LANE
@@ -104,6 +105,7 @@ class CiTopologyPlanner {
             }
         } else {
             when (id) {
+                VerificationUnitId.GIT_WORKFLOW,
                 VerificationUnitId.DOCUMENTATION -> DOCUMENTATION_LANE
                 VerificationUnitId.REPOSITORY_DIFF,
                 VerificationUnitId.TEAMCITY_DSL -> REPOSITORY_LANE

--- a/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidator.kt
+++ b/repo/verification-platform/domain/src/main/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidator.kt
@@ -1,0 +1,60 @@
+package com.marmatsan.verificationPlatform.domain.service
+
+import com.marmatsan.verificationPlatform.domain.model.GitBranchValidation
+
+/** Validates provider-neutral Git branch names for the trunk-based workflow. */
+class GitBranchNameValidator {
+    /**
+     * Validates [branchRef] after removing supported local and remote prefixes.
+     *
+     * Synthetic `refs/pull/<number>/head` refs are accepted because TeamCity
+     * also validates the source `refs/heads/<branch>` build for the same commit.
+     *
+     * @param branchRef branch name or full Git ref supplied by a local checkout
+     * or CI provider.
+     * @return normalized validation result with a stable failure explanation.
+     */
+    fun validate(branchRef: String): GitBranchValidation {
+        val branch = normalize(branchRef)
+        val providerManaged = PULL_REQUEST_REF.matches(branch)
+        val valid = branch == MAIN_BRANCH ||
+            providerManaged ||
+            SHORT_LIVED_BRANCH.matches(branch) ||
+            RELEASE_BRANCH.matches(branch)
+
+        return GitBranchValidation(
+            branch = branch,
+            valid = valid,
+            providerManaged = providerManaged,
+            message = if (valid) {
+                null
+            } else {
+                "Branch '${branch.ifEmpty { "<blank>" }}' violates the Git workflow. " +
+                    "Expected main, feature/<kebab-case>, fix/<kebab-case>, " +
+                    "chore/<kebab-case>, release/<x.y.z>, or hotfix/<kebab-case>."
+            }
+        )
+    }
+
+    private fun normalize(branchRef: String): String {
+        val trimmed = branchRef.trim().replace('\\', '/')
+        return when {
+            trimmed.startsWith("refs/remotes/origin/") -> trimmed.removePrefix("refs/remotes/origin/")
+            trimmed.startsWith("refs/heads/") -> trimmed.removePrefix("refs/heads/")
+            trimmed.startsWith("origin/") -> trimmed.removePrefix("origin/")
+            trimmed.startsWith("refs/pull/") -> trimmed.removePrefix("refs/")
+            else -> trimmed
+        }
+    }
+
+    private companion object {
+        const val MAIN_BRANCH = "main"
+        val SHORT_LIVED_BRANCH = Regex(
+            "(?:feature|fix|chore|hotfix)/[a-z0-9]+(?:-[a-z0-9]+)*"
+        )
+        val RELEASE_BRANCH = Regex(
+            "release/(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)\\.(?:0|[1-9][0-9]*)"
+        )
+        val PULL_REQUEST_REF = Regex("pull/[1-9][0-9]{0,}/head")
+    }
+}

--- a/repo/verification-platform/domain/src/test/kotlin/com/marmatsan/verificationPlatform/domain/bdd/GitWorkflowSteps.kt
+++ b/repo/verification-platform/domain/src/test/kotlin/com/marmatsan/verificationPlatform/domain/bdd/GitWorkflowSteps.kt
@@ -1,0 +1,29 @@
+package com.marmatsan.verificationPlatform.domain.bdd
+
+import com.marmatsan.verificationPlatform.domain.model.GitBranchValidation
+import com.marmatsan.verificationPlatform.domain.service.GitBranchNameValidator
+import io.cucumber.java8.En
+import io.kotest.matchers.shouldBe
+
+class GitWorkflowSteps : En {
+    private lateinit var branch: String
+    private lateinit var validation: GitBranchValidation
+
+    init {
+        Given("the Git branch is {string}") { value: String ->
+            branch = value
+        }
+        When("the Git branch name is validated") {
+            validation = GitBranchNameValidator().validate(branch)
+        }
+        Then("the Git branch is accepted") {
+            validation.valid shouldBe true
+        }
+        Then("the Git branch is rejected") {
+            validation.valid shouldBe false
+        }
+        Then("the Git branch is provider-managed") {
+            validation.providerManaged shouldBe true
+        }
+    }
+}

--- a/repo/verification-platform/domain/src/test/kotlin/com/marmatsan/verificationPlatform/domain/service/CiPlanFactoryTest.kt
+++ b/repo/verification-platform/domain/src/test/kotlin/com/marmatsan/verificationPlatform/domain/service/CiPlanFactoryTest.kt
@@ -17,7 +17,8 @@ class CiPlanFactoryTest : FunSpec({
         plan.scope shouldBe CiScope.TEAMCITY
         plan.fullVerification shouldBe true
         plan.requiredUnitIds() shouldContain VerificationUnitId.TEAMCITY_DSL
-        plan.gradleTasks() shouldBe listOf("checkDocumentation", "checkTeamCityDsl", "check")
+        plan.gradleTasks() shouldBe
+            listOf("checkGitWorkflow", "checkDocumentation", "checkTeamCityDsl", "check")
     }
 
     test("mixed changes keep all matching units") {
@@ -52,7 +53,8 @@ class CiPlanFactoryTest : FunSpec({
         plan.changedModules shouldBe listOf(":app")
         plan.affectedModules shouldBe listOf(":app")
         plan.fullVerification shouldBe false
-        plan.gradleTasks() shouldBe listOf("checkDocumentation", ":app:check", "checkFigmaCatalogUsage")
+        plan.gradleTasks() shouldBe
+            listOf("checkGitWorkflow", "checkDocumentation", ":app:check", "checkFigmaCatalogUsage")
     }
 
     test("unresolved module graph dependencies fail closed to root check") {
@@ -71,7 +73,7 @@ class CiPlanFactoryTest : FunSpec({
         plan.changedModules shouldBe emptyList()
         plan.affectedModules shouldBe emptyList()
         plan.fullVerification shouldBe true
-        plan.gradleTasks() shouldBe listOf("checkDocumentation", "check")
+        plan.gradleTasks() shouldBe listOf("checkGitWorkflow", "checkDocumentation", "check")
         plan.fallbackReason shouldBe
             "The Gradle module graph contains an unresolved dependency: :app -> :missing."
     }

--- a/repo/verification-platform/domain/src/test/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidatorTest.kt
+++ b/repo/verification-platform/domain/src/test/kotlin/com/marmatsan/verificationPlatform/domain/service/GitBranchNameValidatorTest.kt
@@ -1,0 +1,33 @@
+package com.marmatsan.verificationPlatform.domain.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class GitBranchNameValidatorTest : FunSpec({
+    val validator = GitBranchNameValidator()
+
+    test("normalizes supported local and remote Git prefixes") {
+        validator.validate("refs/heads/feature/plant-reminders").branch shouldBe
+            "feature/plant-reminders"
+        validator.validate("refs/remotes/origin/fix/watering-date").branch shouldBe
+            "fix/watering-date"
+        validator.validate("origin/chore/update-gradle").branch shouldBe
+            "chore/update-gradle"
+    }
+
+    test("rejects release versions with leading zeroes") {
+        validator.validate("release/01.4.0").valid shouldBe false
+        validator.validate("release/1.04.0").valid shouldBe false
+        validator.validate("release/1.4.00").valid shouldBe false
+    }
+
+    test("reports the allowed branch contract for invalid input") {
+        val result = validator.validate("feature/")
+
+        result.valid shouldBe false
+        result.message shouldBe
+            "Branch 'feature/' violates the Git workflow. Expected main, " +
+            "feature/<kebab-case>, fix/<kebab-case>, chore/<kebab-case>, " +
+            "release/<x.y.z>, or hotfix/<kebab-case>."
+    }
+})

--- a/repo/verification-platform/domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/ci-verification-plan.feature
+++ b/repo/verification-platform/domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/ci-verification-plan.feature
@@ -13,6 +13,7 @@ Feature: Select repository verification
     Then the plan scope is DOCUMENTATION_ONLY
     And full Gradle verification is not required
     And the selected Gradle tasks are:
+      | checkGitWorkflow    |
       | checkDocumentation  |
       | checkRepositoryDiff |
 
@@ -24,6 +25,7 @@ Feature: Select repository verification
     Then the plan scope is TEAMCITY
     And full Gradle verification is required
     And the selected Gradle tasks are:
+      | checkGitWorkflow  |
       | checkDocumentation |
       | checkTeamCityDsl   |
       | check              |
@@ -38,6 +40,7 @@ Feature: Select repository verification
       | :core:ui       |
       | :onboarding:ui |
     And the selected Gradle tasks are:
+      | checkGitWorkflow        |
       | checkDocumentation     |
       | :app:check             |
       | :core:ui:check         |
@@ -52,6 +55,7 @@ Feature: Select repository verification
     Then the plan scope is UNKNOWN
     And full Gradle verification is required
     And the selected Gradle tasks are:
+      | checkGitWorkflow  |
       | checkDocumentation |
       | check |
     And the plan explains that the change has no targeted verification policy

--- a/repo/verification-platform/domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/git-workflow.feature
+++ b/repo/verification-platform/domain/src/test/resources/com/marmatsan/verificationPlatform/domain/bdd/git-workflow.feature
@@ -1,0 +1,41 @@
+@git-workflow
+Feature: Enforce the trunk-based Git branch contract
+
+  Repository branches communicate intent and remain compatible with the
+  protected trunk, release, and hotfix workflows.
+
+  @domain
+  Scenario Outline: Supported repository branches are accepted
+    Given the Git branch is "<branch>"
+    When the Git branch name is validated
+    Then the Git branch is accepted
+
+    Examples:
+      | branch                          |
+      | main                            |
+      | feature/plant-reminders         |
+      | fix/watering-date-calculation   |
+      | chore/git-branching-strategy    |
+      | release/1.4.0                   |
+      | hotfix/reminder-crash           |
+
+  @domain
+  Scenario Outline: Unsupported repository branches are rejected
+    Given the Git branch is "<branch>"
+    When the Git branch name is validated
+    Then the Git branch is rejected
+
+    Examples:
+      | branch                       |
+      | develop                      |
+      | feature/Plant_Reminders      |
+      | feature/plant--reminders     |
+      | release/v1.4.0               |
+      | personal/marmatsan           |
+
+  @domain
+  Scenario: Provider-managed pull request refs do not block required CI
+    Given the Git branch is "refs/pull/96/head"
+    When the Git branch name is validated
+    Then the Git branch is accepted
+    And the Git branch is provider-managed

--- a/repo/verification-platform/plugin/docs/dokka/README.md
+++ b/repo/verification-platform/plugin/docs/dokka/README.md
@@ -9,11 +9,12 @@ orchestration belongs here rather than in `verification-platform-domain`.
 Read this module from its public Gradle entry points:
 
 1. `VerificationPlatformPlugin` registers the CI planning and infrastructure tasks.
-2. `GenerateCiPlanTask` writes the provider-neutral verification plan.
-3. `GenerateCiTopologyPreviewTask` writes a non-authoritative agent topology
+2. `CheckGitWorkflowTask` validates the branch contract.
+3. `GenerateCiPlanTask` writes the provider-neutral verification plan.
+4. `GenerateCiTopologyPreviewTask` writes a non-authoritative agent topology
    preview.
-4. `PrepareTeamCityCiPlanTask` exports allow-listed TeamCity parameters.
-5. `RunTeamCityInfrastructureHealthTask` queues the infrastructure-health run.
+5. `PrepareTeamCityCiPlanTask` exports allow-listed TeamCity parameters.
+6. `RunTeamCityInfrastructureHealthTask` queues the infrastructure-health run.
 
 # Package com.marmatsan.verificationPlatform.plugin
 

--- a/repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/CheckGitWorkflowTask.kt
+++ b/repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/CheckGitWorkflowTask.kt
@@ -1,0 +1,39 @@
+package com.marmatsan.verificationPlatform.plugin
+
+import com.marmatsan.verificationPlatform.data.git.GitCurrentBranchSource
+import com.marmatsan.verificationPlatform.domain.service.GitBranchNameValidator
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/** Validates the current branch against the repository Git workflow. */
+@DisableCachingByDefault(because = "Git branch validation depends on checkout state")
+abstract class CheckGitWorkflowTask : DefaultTask() {
+    /** Repository checkout whose branch is validated. */
+    @get:Internal
+    abstract val repositoryRoot: DirectoryProperty
+
+    /** Optional full branch ref supplied by a CI provider for detached HEAD. */
+    @get:Input
+    @get:Optional
+    abstract val branchOverride: Property<String>
+
+    /** Resolves and validates the current branch name. */
+    @TaskAction
+    fun checkGitWorkflow() {
+        val branch = GitCurrentBranchSource().read(
+            repositoryRoot = repositoryRoot.get().asFile,
+            branchOverride = branchOverride.orNull
+        )
+        val validation = GitBranchNameValidator().validate(branch)
+        check(validation.valid) { validation.message ?: "Git workflow validation failed." }
+
+        val source = if (validation.providerManaged) "provider-managed ref" else "repository branch"
+        logger.lifecycle("Git workflow validation passed for {} '{}'.", source, validation.branch)
+    }
+}

--- a/repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/GenerateCiPlanTask.kt
+++ b/repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/GenerateCiPlanTask.kt
@@ -17,10 +17,10 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.gradle.work.DisableCachingByDefault
+import org.gradle.api.tasks.UntrackedTask
 
 /** Writes the provider-neutral CI plan for the committed repository change. */
-@DisableCachingByDefault(because = "The plan depends on Git revision state outside Gradle inputs")
+@UntrackedTask(because = "The plan depends on Git revision state outside Gradle inputs")
 abstract class GenerateCiPlanTask : DefaultTask() {
     /** Repository checkout whose committed Git state is classified. */
     @get:Internal

--- a/repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/VerificationPlatformPlugin.kt
+++ b/repo/verification-platform/plugin/src/main/kotlin/com/marmatsan/verificationPlatform/plugin/VerificationPlatformPlugin.kt
@@ -39,12 +39,26 @@ class VerificationPlatformPlugin : Plugin<Project> {
             }
         }
 
+        val checkGitWorkflow = project.tasks.register(
+            "checkGitWorkflow",
+            CheckGitWorkflowTask::class.java
+        ) { task ->
+            task.group = "verification"
+            task.description = "Validates the current branch against the trunk-based Git workflow."
+            task.repositoryRoot.set(project.layout.projectDirectory)
+            task.branchOverride.convention(
+                project.providers.gradleProperty("gitWorkflowBranch")
+                    .orElse(project.providers.environmentVariable("GIT_WORKFLOW_BRANCH"))
+            )
+        }
+
         val checkDocumentation = project.tasks.register(
             "checkDocumentation",
             CheckDocumentationTask::class.java
         ) { task ->
             task.group = "verification"
             task.description = "Validates typed documentation, links, sources, and committed change coverage."
+            task.dependsOn(checkGitWorkflow)
             task.dependsOn(generateCiPlan)
             task.repositoryRoot.set(project.layout.projectDirectory)
             task.coverageManifest.set(project.layout.projectDirectory.file(".teamcity/documentation-coverage.json"))


### PR DESCRIPTION
## Resumen

- añade el contrato BDD de nomenclatura trunk-based
- implementa `GitBranchNameValidator` en dominio y la lectura de refs en el adaptador Git
- expone `checkGitWorkflow` como tarea Gradle local y de TeamCity
- añade `git-workflow` como primera unidad obligatoria del plan CI schema 3
- pasa la ref VCS completa desde TeamCity para admitir checkouts PR desacoplados
- fuerza `generateCiPlan` a leer siempre el `HEAD` actual

## Por qué

La nomenclatura estaba documentada pero no era ejecutable. Además, `generateCiPlan` podía quedar `UP-TO-DATE` después de cambiar `HEAD`, porque el estado Git no era un input Gradle, y reutilizar evidencia de una revisión anterior debilitaría cualquier gate basado en el plan.

## Impacto

- `main`, `feature/*`, `fix/*`, `chore/*`, `release/<x.y.z>` y `hotfix/*` son aceptados
- ramas como `develop` se rechazan con un mensaje contractual
- refs sintéticas `refs/pull/<n>/head` no bloquean el CI requerido; la rama fuente también se valida en su build
- el plan CI se regenera para cada revisión comprometida

## Verificación

- `.\gradlew.bat :verification-platform:domain:test :verification-platform:data:test :verification-platform:plugin:compileKotlin`
- `.\gradlew.bat checkGitWorkflow checkDocumentation checkTeamCityDsl`
- `.\gradlew.bat check`
- rechazo focal de `develop`
- aceptación focal de `refs/pull/96/head`
- plan schema 3 regenerado para `34c38c5`