### PR TITLE
fix(figma-documentation-sync): validate the CI outcome container

### DIFF
--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -123,9 +123,10 @@ The visual model uses four composable components:
 
 The semantic composition is `.ci node` -> `.ci phase` -> `.ci step`, with
 `.ci outcome` as a sibling result under `.ci node`. The Figma layout places
-phases inside the node's transparent `execution plan` frame and steps inside
-the phase's transparent `steps` frame. These frames add layout structure, not
-execution levels. Outcomes are not steps because they describe externally
+phases inside the node's transparent `execution plan` frame, steps inside the
+phase's transparent `steps` frame, and outcomes inside the node's transparent
+`outcome` frame. These frames add layout structure, not execution levels.
+Outcomes are not steps because they describe externally
 observable results rather than work executed inside a TeamCity phase.
 
 The Kotlin visual plan uses schema version `3`. Every node owns typed `phases`
@@ -141,7 +142,7 @@ The stable capacity is:
 |-------|----------------|---------------|----------|
 | `.ci node` | `execution plan` | `phase 01` through `phase 08` | 8 phases |
 | `.ci phase` | `steps` | `step 01` through `step 08` | 8 steps per phase |
-| `.ci node` | Node root | `outcome 01` through `outcome 04` | 4 outcomes |
+| `.ci node` | `outcome` | `outcome 01` through `outcome 04` | 4 outcomes |
 
 Every slot is visible in its master component so maintainers can inspect the
 complete composition. Generated instances reveal only populated slots and hide
@@ -160,7 +161,7 @@ empty `phases` and `outcomes` arrays. Only their matching nodes in `ci.jobTasks`
 receive and display executable detail. Do not duplicate the hierarchy across
 both reading layers.
 
-The node orders its content as summary, `execution plan`, outcomes, then
+The node orders its content as summary, `execution plan`, `outcome`, then
 optional runtime and source details. `execution plan heading` supplies the
 visible `Execution plan` label and `show execution plan` hides the complete
 frame when a node has no phases. The `show optional details` boolean collapses

--- a/repo/figma-documentation-sync/data/src/main/kotlin/com/marmatsan/figmaDocumentationSync/data/json/writer/FigmaWriterProjectConfigJson.kt
+++ b/repo/figma-documentation-sync/data/src/main/kotlin/com/marmatsan/figmaDocumentationSync/data/json/writer/FigmaWriterProjectConfigJson.kt
@@ -118,6 +118,10 @@ object FigmaWriterProjectConfigJson {
                 ciNodePhaseContainerName,
             )
             put(
+                "CI_NODE_OUTCOME_CONTAINER_NAME",
+                ciNodeOutcomeContainerName,
+            )
+            put(
                 "CI_PHASE_COMPONENT_ID",
                 ciPhaseComponentId,
             )

--- a/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
@@ -159,7 +159,7 @@ The reserved component hierarchy is:
 |-------|-----------------------|-----------|---------------|
 | `.ci node` | `execution plan` | `.ci phase` (`64668:2944`) | `phase 01` through `phase 08` |
 | `.ci phase` | `steps` | `.ci step` (`64665:2991`) | `step 01` through `step 08` |
-| `.ci node` | Node root | `.ci outcome` (`64669:3118`) | `outcome 01` through `outcome 04` |
+| `.ci node` | `outcome` | `.ci outcome` (`64669:3118`) | `outcome 01` through `outcome 04` |
 
 The corresponding limits are 8 phases per node, 8 steps per phase, and 4
 outcomes per node. Masters keep every slot visible; generated instances reveal
@@ -204,10 +204,11 @@ commands and arguments remain available through the node's `source` link to
 GitHub `main`.
 
 Every managed `.ci node group` contains only its top-level `.ci node` instance.
-The node orders summary first, the `execution plan` frame second, outcomes
-third, and optional runtime and source details last. The execution frame owns
-its heading and exposed phase slots; each phase's `steps` frame owns its exposed
-step slots. `show execution plan` collapses that complete frame when no phases
+The node orders summary first, the `execution plan` frame second, the `outcome`
+frame third, and optional runtime and source details last. The execution frame
+owns its heading and exposed phase slots, the `outcome` frame owns its exposed
+outcome slots, and each phase's `steps` frame owns its exposed step slots.
+`show execution plan` collapses that complete frame when no phases
 exist, while `show optional details` collapses the details container when
 neither child is visible. Action descriptions remain in the typed model but are
 hidden visually; phase, decision, group, and outcome descriptions remain

--- a/repo/figma-documentation-sync/docs/runbooks/canonical-artifact-visual-sync.md
+++ b/repo/figma-documentation-sync/docs/runbooks/canonical-artifact-visual-sync.md
@@ -239,7 +239,8 @@ without a second download. The explicit revision is mandatory in this mode:
 
 ```powershell
 .\gradlew.bat prepareTeamCityFigmaSyncHandoff `
-    -PfigmaArtifactDirectory=<downloaded-figma-sync-directory>
+    -PfigmaArtifactDirectory=<downloaded-figma-sync-directory> `
+    -PfigmaExpectedGitSha=<exact-main-git-sha>
 
 .\gradlew.bat uploadCanonicalFigmaPayload `
     -PfigmaArtifactDirectory=<downloaded-figma-sync-directory> `

--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -223,13 +223,15 @@ still exists before calling `remove()` explicitly.
 
 ## Invalid CI Hierarchy Slots
 
-The CI writer depends on public direct-child contracts at each hierarchy
-boundary, not on nested sublayer IDs:
+The CI writer depends on public direct-child contracts inside named transparent
+layout frames, not on nested sublayer IDs:
 
-- `.ci node` contains `phase 01` through `phase 08`, each backed by `.ci phase`;
-- `.ci phase` contains `step 01` through `step 08`, each backed by `.ci step`;
-- `.ci node` contains `outcome 01` through `outcome 04`, each backed by
-  `.ci outcome`.
+- `.ci node` owns an `execution plan` frame containing `phase 01` through
+  `phase 08`, each backed by `.ci phase`;
+- `.ci phase` owns a `steps` frame containing `step 01` through `step 08`, each
+  backed by `.ci step`;
+- `.ci node` owns an `outcome` frame containing `outcome 01` through
+  `outcome 04`, each backed by `.ci outcome`.
 
 Every slot must be visible in its master and exposed to the containing
 component. Generated instances hide only unused slots.
@@ -239,8 +241,9 @@ slots:
 
 1. Edit the owning main component, not a published instance or nested sublayer
    URL.
-2. Restore the exact numeric direct children for that owner; do not wrap them
-   in an intermediate frame.
+2. Restore the configured transparent frame as a direct child of its owner and
+   the exact numeric slots as direct children of that frame. Do not add another
+   intermediate frame.
 3. Use an instance of the configured child component for every slot, mark it as
    exposed, and keep it visible in the master.
 4. Run the visual preflight again before retrying the CI visual target.
@@ -250,6 +253,17 @@ or create ad hoc sibling steps to bypass a broken component. When a visual plan
 legitimately exceeds 8 phases, 8 steps in one phase, or 4 outcomes, split the
 documentation boundary and regenerate the Kotlin plan. Keep final sync metadata
 unchanged until preflight and the affected visual target both succeed.
+
+## TeamCity Artifact Handoff Returns HTML
+
+If `prepareTeamCityFigmaSyncHandoff` fails while decoding the TeamCity response
+with `invalid character '<' looking for beginning of value`, the protected
+artifact request returned HTML instead of the expected JSON. Verify the CLI
+authentication and endpoint first. If the artifact was already downloaded by
+another authorized route, use the documented artifact-directory fallback with
+both `-PfigmaArtifactDirectory` and the exact
+`-PfigmaExpectedGitSha`. The explicit revision check is mandatory; never accept
+an unverified local artifact or weaken the handoff validation.
 
 ## Usage Blocks Hidden Despite Model Data
 

--- a/repo/figma-documentation-sync/domain/src/main/kotlin/com/marmatsan/figmaDocumentationSync/domain/model/writer/FigmaWriterProjectConfig.kt
+++ b/repo/figma-documentation-sync/domain/src/main/kotlin/com/marmatsan/figmaDocumentationSync/domain/model/writer/FigmaWriterProjectConfig.kt
@@ -21,6 +21,7 @@ data class FigmaWriterProjectConfig(
     val ciConnectorTemplateSectionId: String,
     val ciNodeProps: Map<String, String>,
     val ciNodePhaseContainerName: String,
+    val ciNodeOutcomeContainerName: String,
     val ciPhaseComponentId: String,
     val ciPhaseSlotNamePrefix: String,
     val ciPhaseSlotCount: Int,

--- a/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
+++ b/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
@@ -69,6 +69,7 @@ internal object WaterMyPlantsFigmaWriterProjectConfig {
                     "showOptionalDetails" to "show optional details",
                 ),
             ciNodePhaseContainerName = "execution plan",
+            ciNodeOutcomeContainerName = "outcome",
             ciPhaseComponentId = "64668:2944",
             ciPhaseSlotNamePrefix = "phase",
             ciPhaseSlotCount = 8,

--- a/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
+++ b/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
@@ -27,6 +27,7 @@ internal class FigmaWriterProjectConfigJsonTest :
                 root.getValue("PROJECT_VERSION_COMPONENT_ID").jsonPrimitive.content shouldBe "63075:591"
                 root.getValue("CI_CONFIGURATION_MODEL_NAME").jsonPrimitive.content shouldBe "teamCity"
                 root.getValue("CI_NODE_PHASE_CONTAINER_NAME").jsonPrimitive.content shouldBe "execution plan"
+                root.getValue("CI_NODE_OUTCOME_CONTAINER_NAME").jsonPrimitive.content shouldBe "outcome"
                 root.getValue("CI_PHASE_STEP_CONTAINER_NAME").jsonPrimitive.content shouldBe "steps"
                 root
                     .getValue("CI_NODE_PROPS")
@@ -133,6 +134,7 @@ internal class FigmaWriterProjectConfigJsonTest :
                 "CI_CONNECTOR_TEMPLATE_SECTION_ID",
                 "CI_NODE_PROPS",
                 "CI_NODE_PHASE_CONTAINER_NAME",
+                "CI_NODE_OUTCOME_CONTAINER_NAME",
                 "CI_PHASE_COMPONENT_ID",
                 "CI_PHASE_SLOT_NAME_PREFIX",
                 "CI_PHASE_SLOT_COUNT",

--- a/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -11,6 +11,7 @@ import {
   CI_ICON_ENVIRONMENTS,
   CI_ICON_INSTANCE_NAME,
   CI_NODE_COMPONENT_ID,
+  CI_NODE_OUTCOME_CONTAINER_NAME,
   CI_NODE_PHASE_CONTAINER_NAME,
   CI_NODE_PROPS,
   CI_OUTCOME_COMPONENT_SET_ID,
@@ -222,7 +223,11 @@ async function checkCiDocumentationContract(
     expectedComponentLabel: `component '${phaseComponent.id}'`,
   });
   await requireExactReservedSlots({
-    owner: component,
+    owner: requireDirectFrame(
+      component,
+      CI_NODE_OUTCOME_CONTAINER_NAME,
+      ".ci node"
+    ),
     expectedNames: ciOutcomeSlotNames(),
     hasNamePrefix: hasCiOutcomeSlotNamePrefix,
     label: "CI outcome",

--- a/repo/figma-documentation-sync/tools/src/project-config.d.ts
+++ b/repo/figma-documentation-sync/tools/src/project-config.d.ts
@@ -20,6 +20,7 @@ declare module "@figma-documentation-sync/project-config" {
   export const CI_CONNECTOR_TEMPLATE_SECTION_ID: any;
   export const CI_NODE_PROPS: any;
   export const CI_NODE_PHASE_CONTAINER_NAME: any;
+  export const CI_NODE_OUTCOME_CONTAINER_NAME: any;
   export const CI_PHASE_COMPONENT_ID: any;
   export const CI_PHASE_SLOT_NAME_PREFIX: any;
   export const CI_PHASE_SLOT_COUNT: any;


### PR DESCRIPTION
## Summary
- model the transparent .ci node outcome frame in the Kotlin writer configuration
- validate reserved outcome slots inside that named frame during Figma preflight
- document the hierarchy failure and SHA-verified TeamCity artifact fallback

## Verification
- .\\gradlew.bat -p repo\\figma-documentation-sync check --stacktrace
- .\\gradlew.bat testFigmaDocumentationSyncTools buildFigmaDocumentationSyncTools checkDocumentation --stacktrace
- git diff --check