### PR TITLE
fix(figma-documentation-sync): collapse empty CI phase steps

### DIFF
--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -149,6 +149,13 @@ complete composition. Generated instances reveal only populated slots and hide
 the remainder. Plans that exceed a capacity fail before Figma is mutated; split
 the job or phase into a clearer visual boundary instead of dropping work.
 
+The `.ci phase` master exposes `show steps=true` and binds it to the visibility
+of its direct `steps` frame. Generated instances set it from the typed
+`phase.steps` array: `true` when the phase has executable detail and `false`
+when the array is empty. Hiding only the reserved step instances is not enough;
+an empty visible Auto Layout frame can retain its master height and create a
+large blank region in the generated job node.
+
 Every property-backed field and optional section is also visible by default in
 each master component and every master variant. Master visibility booleans use
 `true` so the component surface documents its complete public contract. Only
@@ -166,7 +173,9 @@ optional runtime and source details. `execution plan heading` supplies the
 visible `Execution plan` label and `show execution plan` hides the complete
 frame when a node has no phases. The `show optional details` boolean collapses
 the final details container when both kinds of context are hidden. The
-component does not expose the obsolete `steps` or `show steps` properties.
+`.ci node` does not expose the obsolete `steps` or `show steps` properties;
+`show steps` belongs only to `.ci phase`, where it controls the phase-owned
+step container.
 
 Use the step variants consistently:
 

--- a/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
@@ -168,19 +168,26 @@ instances, while preflight requires each slot to be a direct child of its named
 container. Neither path creates ad hoc siblings or depends on unstable nested
 sublayer IDs.
 
+The `.ci phase` master exposes `show steps=true`, and its direct `steps` frame
+binds `visible` to that BOOLEAN property. The writer derives the instance value
+from `phase.steps.length > 0`. This container-level visibility is required in
+addition to hiding unused slots because a visible Auto Layout frame with no
+visible children can retain its master height instead of collapsing.
+
 Masters also keep every property-backed field and optional section visible in
 every variant. Their visibility booleans default to `true` so the component
 documents its complete public surface. The writer sets visibility explicitly on
 generated instances from model data; it must not rely on hidden master defaults.
 
 `.ci phase` requires `order`, `title`, `technical id`, `description`,
-`show technical id`, and `show description`. `.ci step` requires the same text
-and visibility properties plus `condition`, `show condition`, and exact `role`
-variants `action`, `decision`, and `group`. `.ci outcome` uses the step-shaped
-display properties with exact `kind` variants `artifact` and `check`. There is
-no `level` property: hierarchy is encoded by component ownership. Preflight
-validates all properties, variants, slot names, exposure flags, and main
-component identities before mutation.
+`show technical id`, `show description`, and `show steps`. `.ci step` requires
+the same text and field visibility properties plus `condition`, `show
+condition`, and exact `role` variants `action`, `decision`, and `group`. `.ci
+outcome` uses the step-shaped display properties with exact `kind` variants
+`artifact` and `check`. There is no `level` property: hierarchy is encoded by
+component ownership. Preflight validates all properties, visibility bindings,
+variants, slot names, exposure flags, and main component identities before
+mutation.
 
 The three `.ci step` variants use compact horizontal Auto Layout, a leading
 order badge, the Gradle icon, one flexible content column, and no outer stroke.

--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -236,6 +236,13 @@ layout frames, not on nested sublayer IDs:
 Every slot must be visible in its master and exposed to the containing
 component. Generated instances hide only unused slots.
 
+The `.ci phase` master must also expose `show steps` as a BOOLEAN with default
+`true`, and its direct `steps` frame must bind `visible` to that property. The
+writer sets `show steps=false` when `phase.steps` is empty. If all step slots
+are hidden but the phase still contains a large blank region, inspect this
+container binding first: resizing the parent only fits the already oversized
+child and does not correct the missing collapse contract.
+
 If preflight reports missing, duplicated, unexpected, unexposed, or foreign CI
 slots:
 

--- a/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
+++ b/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
@@ -81,6 +81,7 @@ internal object WaterMyPlantsFigmaWriterProjectConfig {
                     "description" to "description",
                     "showTechnicalId" to "show technical id",
                     "showDescription" to "show description",
+                    "showSteps" to "show steps",
                 ),
             ciPhaseStepContainerName = "steps",
             ciStepComponentSetId = "64665:2991",

--- a/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
+++ b/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
@@ -55,6 +55,24 @@ internal class FigmaWriterProjectConfigJsonTest :
                             .getValue("showExecutionPlan")
                             .jsonPrimitive.content shouldBe "show execution plan"
                     }
+                root
+                    .getValue("CI_PHASE_PROPS")
+                    .jsonObject
+                    .also { properties ->
+                        properties.keys shouldBe
+                            setOf(
+                                "order",
+                                "title",
+                                "technicalId",
+                                "description",
+                                "showTechnicalId",
+                                "showDescription",
+                                "showSteps",
+                            )
+                        properties
+                            .getValue("showSteps")
+                            .jsonPrimitive.content shouldBe "show steps"
+                    }
                 root.getValue("CI_STEP_SLOT_NAME_PREFIX").jsonPrimitive.content shouldBe "step"
                 root.getValue("CI_STEP_SLOT_COUNT").jsonPrimitive.content shouldBe "8"
                 root.getValue("CI_PHASE_SLOT_COUNT").jsonPrimitive.content shouldBe "8"

--- a/repo/figma-documentation-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -670,6 +670,7 @@ function syncCiPhase({
   const properties = ciPhasePropertyValues(phase);
   setComponentBooleanProperty(instance, CI_PHASE_PROPS.showTechnicalId, properties.showTechnicalId);
   setComponentBooleanProperty(instance, CI_PHASE_PROPS.showDescription, properties.showDescription);
+  setComponentBooleanProperty(instance, CI_PHASE_PROPS.showSteps, properties.showSteps);
   setComponentTextProperty(instance, CI_PHASE_PROPS.order, properties.order);
   setComponentTextProperty(instance, CI_PHASE_PROPS.title, properties.title);
   setComponentTextProperty(instance, CI_PHASE_PROPS.technicalId, properties.technicalId);
@@ -684,6 +685,7 @@ export function ciPhasePropertyValues(phase: CiVisualPhase) {
     description: phase.description || "",
     showTechnicalId: Boolean(phase.technicalId),
     showDescription: Boolean(phase.description),
+    showSteps: phase.steps.length > 0,
   };
 }
 

--- a/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -177,6 +177,18 @@ async function checkCiDocumentationContract(
   requireComponentProperty(phaseComponent, CI_PHASE_PROPS.description, "TEXT");
   requireComponentProperty(phaseComponent, CI_PHASE_PROPS.showTechnicalId, "BOOLEAN");
   requireComponentProperty(phaseComponent, CI_PHASE_PROPS.showDescription, "BOOLEAN");
+  requireComponentProperty(phaseComponent, CI_PHASE_PROPS.showSteps, "BOOLEAN");
+  const phaseSteps = requireDirectFrame(
+    phaseComponent,
+    CI_PHASE_STEP_CONTAINER_NAME,
+    ".ci phase"
+  );
+  requireComponentPropertyReference(
+    phaseSteps,
+    "visible",
+    CI_PHASE_PROPS.showSteps,
+    ".ci phase steps"
+  );
   checkedComponents.push(`${phaseComponent.name}:${phaseComponent.id}`);
 
   const stepSet = await requireComponentSet(CI_STEP_COMPONENT_SET_ID);
@@ -234,11 +246,6 @@ async function checkCiDocumentationContract(
     matchesComponent: async (slot) => (await slot.getMainComponentAsync())?.parent?.id === outcomeSet.id,
     expectedComponentLabel: `component set '${outcomeSet.id}'`,
   });
-  const phaseSteps = requireDirectFrame(
-    phaseComponent,
-    CI_PHASE_STEP_CONTAINER_NAME,
-    ".ci phase"
-  );
   await requireExactReservedSlots({
     owner: phaseSteps,
     expectedNames: ciStepSlotNames(),

--- a/repo/figma-documentation-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/ci-visual-plan.test.ts
@@ -139,8 +139,24 @@ test("CI phase properties expose its executable identity", () => {
       description: "Runs the Gradle entry points owned by this TeamCity phase.",
       showTechnicalId: true,
       showDescription: true,
+      showSteps: false,
     }
   );
+});
+
+test("CI phase properties reveal its steps when executable detail exists", () => {
+  const properties = ciPhasePropertyValues({
+    order: "02",
+    title: "Run planned Gradle checks",
+    steps: [{
+      order: "02.1",
+      role: "action",
+      title: "Run repository task",
+      technicalId: "check",
+    }],
+  });
+
+  assert.equal(properties.showSteps, true);
 });
 
 test("CI step properties expose a decision with its executable condition", () => {


### PR DESCRIPTION
## What changed

- adds a public `show steps` BOOLEAN to `.ci phase` and binds it to the direct `steps` frame
- derives the instance value from the typed `phase.steps` array
- makes visual preflight enforce the property and visibility binding
- covers empty and populated phases and documents the reusable failure mode

## Why

A phase with no semantic steps hid all eight reserved `.ci step` instances, but its visible Auto Layout container retained the 1080 px master height. Parent resize then correctly fitted that oversized child, leaving a large blank area in the generated Job Tasks section.

## Impact

Empty TeamCity phases now render only their header. Phases with Gradle detail retain the existing step layout, colors, spacing, and capacity.

## Validation

- `./gradlew.bat testFigmaDocumentationSyncTools buildFigmaDocumentationSyncTools checkDocumentation --stacktrace`
- `./gradlew.bat -p repo/figma-documentation-sync :project-config:test --rerun-tasks --stacktrace`
- `git diff --check`
- Figma component instance validation: `show steps=false` collapsed `.ci phase` from 1184 px to 96 px