### PR TITLE
fix(figma-documentation-sync): render CI group tasks as lists

### DIFF
--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -185,16 +185,24 @@ Use the step variants consistently:
 | `role` | `decision` | A runtime selection or branch in the verification plan. |
 | `role` | `group` | A compact family of tasks selected by the same impact rule. |
 
+`role=group` keeps the exact identifiers in the typed `technicalId` field but
+projects them through the component's public `tasks` property. The value is one
+left-aligned `TextNode` containing one literal `• ` bullet per line. Literal
+bullets are part of the property value because a Figma `TEXT` override replaces
+range formatting; relying on native list styling would lose the bullets in
+generated instances. The master shows at least two lines so this multiline
+contract remains visible to component maintainers.
+
 `.ci outcome` has the independent `kind` variants `artifact` and `check`.
 There is no `level` variant: component composition owns hierarchy. Do not nest
 another `.ci step` inside a step. Split the phase when a third execution level
 would otherwise be needed.
 
 Every `.ci step` renders as a compact horizontal Gradle row with the order badge
-first, the Gradle icon, and one flexible content column. It identifies the
-executable entry point with `TASK`. `.ci phase` supplies the TeamCity context;
-`.ci outcome` supplies the result context without pretending either is a Gradle
-task.
+first, the Gradle icon, and one flexible content column. Actions and decisions
+identify one executable entry point with `TASK`; groups use `TASKS` followed by
+their multiline list. `.ci phase` supplies the TeamCity context; `.ci outcome`
+supplies the result context without pretending either is a Gradle task.
 
 The environment icon in the `.ci node` header describes the owner of the whole
 node. A TeamCity job therefore remains `environment=teamcity` even when its

--- a/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
@@ -181,7 +181,7 @@ generated instances from model data; it must not rely on hidden master defaults.
 
 `.ci phase` requires `order`, `title`, `technical id`, `description`,
 `show technical id`, `show description`, and `show steps`. `.ci step` requires
-the same text and field visibility properties plus `condition`, `show
+the same text and field visibility properties plus `tasks`, `condition`, `show
 condition`, and exact `role` variants `action`, `decision`, and `group`. `.ci
 outcome` uses the step-shaped display properties with exact `kind` variants
 `artifact` and `check`. There is no `level` property: hierarchy is encoded by
@@ -194,6 +194,14 @@ order badge, the Gradle icon, one flexible content column, and no outer stroke.
 The condition row is borderless. A TeamCity build step maps to `.ci phase`;
 Gradle tasks and selection boundaries map to `.ci step`; published artifacts
 and checks map to `.ci outcome`.
+
+The `role=group` variant owns exactly one `tasks` text layer bound to the public
+`tasks` property. It uses `LEFT` alignment and `HEIGHT` text resize. The writer
+splits the exact identifiers stored in `technicalId` at the documented middle
+dot separator and writes one literal `• ` bullet per line. The master default
+contains at least two bulleted lines. Do not replace those literal bullets with
+native Figma list range styling: overriding a component `TEXT` value resets the
+range formatting and removes the visual list from generated instances.
 
 `.ci phase` is a transparent section, not a filled card around its child rows.
 Its header uses `md/sys/color/primary-container` and 8 px padding. Its

--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -261,6 +261,13 @@ legitimately exceeds 8 phases, 8 steps in one phase, or 4 outcomes, split the
 documentation boundary and regenerate the Kotlin plan. Keep final sync metadata
 unchanged until preflight and the affected visual target both succeed.
 
+If every `role=group` instance shows the same placeholder tasks or loses its
+bullets after an override, inspect the `.ci step` contract. The component set
+must expose a `tasks` TEXT property, and the group variant must bind exactly one
+left-aligned `tasks` text layer to it. The writer supplies literal bullets in a
+multiline value. Native Figma list range styling is not a substitute because a
+component TEXT override resets that formatting.
+
 ## TeamCity Artifact Handoff Returns HTML
 
 If `prepareTeamCityFigmaSyncHandoff` fails while decoding the TeamCity response

--- a/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
+++ b/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
@@ -98,6 +98,7 @@ internal object WaterMyPlantsFigmaWriterProjectConfig {
                     "order" to "order",
                     "title" to "title",
                     "technicalId" to "technical id",
+                    "tasks" to "tasks",
                     "description" to "description",
                     "condition" to "condition",
                     "showTechnicalId" to "show technical id",

--- a/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
+++ b/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
@@ -73,6 +73,27 @@ internal class FigmaWriterProjectConfigJsonTest :
                             .getValue("showSteps")
                             .jsonPrimitive.content shouldBe "show steps"
                     }
+                root
+                    .getValue("CI_STEP_PROPS")
+                    .jsonObject
+                    .also { properties ->
+                        properties.keys shouldBe
+                            setOf(
+                                "order",
+                                "title",
+                                "technicalId",
+                                "tasks",
+                                "description",
+                                "condition",
+                                "showTechnicalId",
+                                "showDescription",
+                                "showCondition",
+                                "role",
+                            )
+                        properties
+                            .getValue("tasks")
+                            .jsonPrimitive.content shouldBe "tasks"
+                    }
                 root.getValue("CI_STEP_SLOT_NAME_PREFIX").jsonPrimitive.content shouldBe "step"
                 root.getValue("CI_STEP_SLOT_COUNT").jsonPrimitive.content shouldBe "8"
                 root.getValue("CI_PHASE_SLOT_COUNT").jsonPrimitive.content shouldBe "8"

--- a/repo/figma-documentation-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -704,6 +704,7 @@ function syncCiStep({
   setComponentTextProperty(instance, CI_STEP_PROPS.order, properties.order);
   setComponentTextProperty(instance, CI_STEP_PROPS.title, properties.title);
   setComponentTextProperty(instance, CI_STEP_PROPS.technicalId, properties.technicalId);
+  setComponentTextProperty(instance, CI_STEP_PROPS.tasks, properties.tasks);
   setComponentTextProperty(instance, CI_STEP_PROPS.description, properties.description);
   setComponentTextProperty(instance, CI_STEP_PROPS.condition, properties.condition);
 }
@@ -714,12 +715,23 @@ export function ciStepPropertyValues(step: CiVisualStep) {
     role: step.role,
     title: step.title,
     technicalId: step.technicalId || "",
+    tasks: ciGroupTasksValue(step),
     description: step.description || "",
     condition: step.condition || "",
     showTechnicalId: Boolean(step.technicalId),
     showDescription: Boolean(step.description) && step.role !== "action",
     showCondition: Boolean(step.condition),
   };
+}
+
+function ciGroupTasksValue(step: CiVisualStep): string {
+  if (step.role !== "group" || !step.technicalId) return "";
+  return step.technicalId
+    .split(/\s*·\s*|\r?\n/)
+    .map((task) => task.replace(/^•\s*/, "").trim())
+    .filter(Boolean)
+    .map((task) => `• ${task}`)
+    .join("\n");
 }
 
 function syncCiOutcome({

--- a/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -195,6 +195,7 @@ async function checkCiDocumentationContract(
   requireComponentProperty(stepSet, CI_STEP_PROPS.order, "TEXT");
   requireComponentProperty(stepSet, CI_STEP_PROPS.title, "TEXT");
   requireComponentProperty(stepSet, CI_STEP_PROPS.technicalId, "TEXT");
+  const tasksDefinition = requireComponentProperty(stepSet, CI_STEP_PROPS.tasks, "TEXT");
   requireComponentProperty(stepSet, CI_STEP_PROPS.description, "TEXT");
   requireComponentProperty(stepSet, CI_STEP_PROPS.condition, "TEXT");
   requireComponentProperty(stepSet, CI_STEP_PROPS.showTechnicalId, "BOOLEAN");
@@ -205,6 +206,10 @@ async function checkCiDocumentationContract(
     propertyName: CI_STEP_PROPS.role,
     expectedOptions: CI_STEP_ROLES,
     label: "CI step roles",
+  });
+  requireCiGroupTasksContract({
+    stepSet,
+    tasksDefinition,
   });
   requireMissingComponentProperty(stepSet, "level");
   checkedComponents.push(`${stepSet.name}:${stepSet.id}`);
@@ -306,6 +311,51 @@ async function checkCiDocumentationContract(
   }
   checkedVariables.push(collection.name);
   checkedTargets.push(...requestedTargets);
+}
+
+function requireCiGroupTasksContract({
+  stepSet,
+  tasksDefinition,
+}: {
+  stepSet: ComponentSetNode;
+  tasksDefinition: any;
+}) {
+  const defaultLines = String(tasksDefinition.defaultValue || "")
+    .split(/\r?\n/)
+    .filter(Boolean);
+  if (defaultLines.length < 2 || defaultLines.some((line) => !line.startsWith("• "))) {
+    throw new Error(
+      `CI step component set '${stepSet.id}' must expose a multiline bullet-list default ` +
+        `for '${CI_STEP_PROPS.tasks}'.`
+    );
+  }
+
+  const groupVariant = stepSet.children.find((child) =>
+    child.type === "COMPONENT" && child.variantProperties?.[CI_STEP_PROPS.role] === "group"
+  );
+  if (!groupVariant || groupVariant.type !== "COMPONENT") {
+    throw new Error(`CI step component set '${stepSet.id}' is missing role=group.`);
+  }
+  const taskTexts = groupVariant.findAllWithCriteria({ types: ["TEXT"] })
+    .filter((text) => text.name === CI_STEP_PROPS.tasks);
+  if (taskTexts.length !== 1) {
+    throw new Error(
+      `CI step role=group '${groupVariant.id}' must contain exactly one ` +
+        `'${CI_STEP_PROPS.tasks}' text layer; found ${taskTexts.length}.`
+    );
+  }
+  const tasksText = taskTexts[0];
+  requireComponentPropertyReference(
+    tasksText,
+    "characters",
+    CI_STEP_PROPS.tasks,
+    "CI step role=group tasks"
+  );
+  if (tasksText.textAlignHorizontal !== "LEFT" || tasksText.textAutoResize !== "HEIGHT") {
+    throw new Error(
+      `CI step role=group tasks '${tasksText.id}' must be left-aligned with HEIGHT text resize.`
+    );
+  }
 }
 
 function requireDirectFrame(

--- a/repo/figma-documentation-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/ci-visual-plan.test.ts
@@ -174,8 +174,34 @@ test("CI step properties expose a decision with its executable condition", () =>
       role: "decision",
       title: "Select affected verification tasks",
       technicalId: "ci.plan.gradleTasks",
+      tasks: "",
       description: "Limits verification to the affected Gradle scopes.",
       condition: "Affected scopes are derived from the comparison base.",
+      showTechnicalId: true,
+      showDescription: true,
+      showCondition: true,
+    }
+  );
+});
+
+test("CI group properties render exact task identifiers as a multiline bullet list", () => {
+  assert.deepEqual(
+    ciStepPropertyValues({
+      order: "02.2",
+      role: "group",
+      title: "Always",
+      technicalId: "checkGitWorkflow · checkDocumentation",
+      description: "Runs the checks required for every change.",
+      condition: "Always",
+    }),
+    {
+      order: "02.2",
+      role: "group",
+      title: "Always",
+      technicalId: "checkGitWorkflow · checkDocumentation",
+      tasks: "• checkGitWorkflow\n• checkDocumentation",
+      description: "Runs the checks required for every change.",
+      condition: "Always",
       showTechnicalId: true,
       showDescription: true,
       showCondition: true,


### PR DESCRIPTION
## What changed

- adds the public `.ci step` `tasks` text property for `role=group`
- renders grouped Gradle identifiers as one literal bullet per line
- preserves `technical id` as the single-value field for action and decision variants
- makes preflight verify the group text binding, multiline master value, left alignment, and height resize
- documents why native list range styling is unsafe for Figma component text overrides

## Why

The group variant represents several Gradle tasks, but the writer projected them through the scalar `technical id` property. Figma text-property overrides also reset range list formatting, so native bullets disappear when generated values replace the master text.

## Impact

Grouped CI tasks now remain compact, multiline, left-aligned, and readable without changing the typed visual-plan schema or the action and decision variants.

## Validation

- `./gradlew.bat testFigmaDocumentationSyncTools buildFigmaDocumentationSyncTools checkDocumentation --stacktrace`
- `./gradlew.bat -p repo/figma-documentation-sync :project-config:test --rerun-tasks --stacktrace`
- `git diff --check`
- live Figma validation with a temporary three-task `role=group` instance