### PR TITLE
fix(figma-documentation-sync): keep CI nodes compact after sync

### DIFF
--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -171,11 +171,19 @@ both reading layers.
 The node orders its content as summary, `execution plan`, `outcome`, then
 optional runtime and source details. `execution plan heading` supplies the
 visible `Execution plan` label and `show execution plan` hides the complete
-frame when a node has no phases. The `show optional details` boolean collapses
-the final details container when both kinds of context are hidden. The
-`.ci node` does not expose the obsolete `steps` or `show steps` properties;
-`show steps` belongs only to `.ci phase`, where it controls the phase-owned
-step container.
+frame when a node has no phases. `show outcome` hides the complete outcome
+frame when the node has no observable results. The `show optional details`
+boolean collapses the final details container when both kinds of context are
+hidden. The `.ci node` does not expose the obsolete `steps` or `show steps`
+properties; `show steps` belongs only to `.ci phase`, where it controls the
+phase-owned step container.
+
+The `summary` and outer `optional details` frames stretch to the current node
+width. This keeps the header and details boundary aligned with expanded task
+nodes while compact flow nodes remain narrow. `optional details` owns the
+full-width runtime divider and an inside-aligned 2 px stroke bound to
+`md/sys/color/outline`; its nested `details content` frame keeps runtime and
+source text at the compact reading width.
 
 Use the step variants consistently:
 

--- a/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
@@ -149,9 +149,10 @@ writer selects the matching mode from the `ci/cd` variable collection:
 `Gate`. The collection's `type_label` string supplies the visible type label
 for each mode. The writer binds the exposed `name`, `description`, `source`,
 and `execution plan heading` text properties. It controls `show execution plan`
-from the presence of typed phases and controls `show source` and `show runtime`
-from actual model content. The component does not expose `steps`, `show steps`,
-or any other compatibility-only execution property.
+from the presence of typed phases, `show outcome` from the presence of typed
+outcomes, and `show source` and `show runtime` from actual model content. The
+component does not expose `steps`, `show steps`, or any other
+compatibility-only execution property.
 
 The reserved component hierarchy is:
 
@@ -223,11 +224,16 @@ The node orders summary first, the `execution plan` frame second, the `outcome`
 frame third, and optional runtime and source details last. The execution frame
 owns its heading and exposed phase slots, the `outcome` frame owns its exposed
 outcome slots, and each phase's `steps` frame owns its exposed step slots.
-`show execution plan` collapses that complete frame when no phases
-exist, while `show optional details` collapses the details container when
-neither child is visible. Action descriptions remain in the typed model but are
-hidden visually; phase, decision, group, and outcome descriptions remain
-visible.
+`show execution plan` collapses that complete frame when no phases exist,
+`show outcome` collapses the complete result frame when no outcomes exist, and
+`show optional details` collapses the details container when neither child is
+visible. The summary and outer details frames stretch to the width established
+by the visible execution content, so compact nodes remain narrow and task nodes
+receive a matching full-width header. The outer details frame owns the runtime
+divider and the `md/sys/color/outline` 2 px inside stroke; the nested `details
+content` frame preserves the compact reading width. Action descriptions remain
+in the typed model but are hidden visually; phase, decision, group, and outcome
+descriptions remain visible.
 
 Native Figma connectors are cloned from the existing `simple-solid_arrow` template because
 the MCP runtime does not expose `figma.createConnector()`. The clones attach to

--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -243,6 +243,21 @@ are hidden but the phase still contains a large blank region, inspect this
 container binding first: resizing the parent only fits the already oversized
 child and does not correct the missing collapse contract.
 
+The `.ci node` master follows the same rule for `show outcome`: its direct
+`outcome` frame binds `visible` to that BOOLEAN, and the writer derives the
+instance value from whether the node has typed outcomes. Without the aggregate
+binding, hiding the reserved outcome slots leaves an empty full-width frame and
+expands otherwise compact nodes.
+
+Reparenting a layer inside a component can clear its
+`componentPropertyReferences`, even when the layer itself and the component
+properties survive. After moving optional CI layers, restore and validate the
+`visible` bindings explicitly. In particular, `runtime context` remains bound
+to `show runtime`, `source` remains bound to `show source`, and their outer
+container remains bound to `show optional details`. Validate at least one
+compact instance after the move; checking only the fully expanded master can
+hide a lost binding or a fixed-width child.
+
 If preflight reports missing, duplicated, unexpected, unexposed, or foreign CI
 slots:
 

--- a/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
+++ b/repo/figma-documentation-sync/project-config/src/main/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/WaterMyPlantsFigmaWriterProjectConfig.kt
@@ -64,6 +64,7 @@ internal object WaterMyPlantsFigmaWriterProjectConfig {
                     "runtimeStartup" to "runtime startup",
                     "runtimeIdentity" to "runtime identity",
                     "showExecutionPlan" to "show execution plan",
+                    "showOutcome" to "show outcome",
                     "showSource" to "show source",
                     "showRuntime" to "show runtime",
                     "showOptionalDetails" to "show optional details",

--- a/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
+++ b/repo/figma-documentation-sync/project-config/src/test/kotlin/com/marmatsan/figmaDocumentationSync/projectConfig/FigmaWriterProjectConfigJsonTest.kt
@@ -44,6 +44,7 @@ internal class FigmaWriterProjectConfigJsonTest :
                                 "runtimeStartup",
                                 "runtimeIdentity",
                                 "showExecutionPlan",
+                                "showOutcome",
                                 "showSource",
                                 "showRuntime",
                                 "showOptionalDetails",
@@ -54,6 +55,9 @@ internal class FigmaWriterProjectConfigJsonTest :
                         properties
                             .getValue("showExecutionPlan")
                             .jsonPrimitive.content shouldBe "show execution plan"
+                        properties
+                            .getValue("showOutcome")
+                            .jsonPrimitive.content shouldBe "show outcome"
                     }
                 root
                     .getValue("CI_PHASE_PROPS")

--- a/repo/figma-documentation-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-ci-documentation-sync-gateway.ts
@@ -422,6 +422,7 @@ async function syncCiNode(instance, nodePlan: CiVisualNode, modeCollection) {
     CI_NODE_PROPS.showExecutionPlan,
     properties.showExecutionPlan
   );
+  setComponentBooleanProperty(instance, CI_NODE_PROPS.showOutcome, properties.showOutcome);
   setComponentBooleanProperty(instance, CI_NODE_PROPS.showSource, properties.showSource);
   setComponentBooleanProperty(instance, CI_NODE_PROPS.showRuntime, properties.showRuntime);
   setComponentBooleanProperty(
@@ -462,6 +463,7 @@ export function ciNodePropertyValues(nodePlan: CiVisualNode) {
     runtimeStartup: nodePlan.runtime?.startup || "",
     runtimeIdentity: nodePlan.runtime?.identity || "",
     showExecutionPlan: nodePlan.phases.length > 0,
+    showOutcome: nodePlan.outcomes.length > 0,
     showSource,
     showRuntime,
     showOptionalDetails: showSource || showRuntime,

--- a/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -132,6 +132,7 @@ async function checkCiDocumentationContract(
   requireComponentProperty(component, CI_NODE_PROPS.runtimeStartup, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.runtimeIdentity, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.showExecutionPlan, "BOOLEAN");
+  requireComponentProperty(component, CI_NODE_PROPS.showOutcome, "BOOLEAN");
   requireComponentProperty(component, CI_NODE_PROPS.showSource, "BOOLEAN");
   requireComponentProperty(component, CI_NODE_PROPS.showRuntime, "BOOLEAN");
   requireComponentProperty(component, CI_NODE_PROPS.showOptionalDetails, "BOOLEAN");
@@ -149,6 +150,17 @@ async function checkCiDocumentationContract(
     "visible",
     CI_NODE_PROPS.showExecutionPlan,
     ".ci node execution plan"
+  );
+  const outcome = requireDirectFrame(
+    component,
+    CI_NODE_OUTCOME_CONTAINER_NAME,
+    ".ci node"
+  );
+  requireComponentPropertyReference(
+    outcome,
+    "visible",
+    CI_NODE_PROPS.showOutcome,
+    ".ci node outcome"
   );
   const executionPlanHeading = requireDirectFrame(
     executionPlan,
@@ -240,11 +252,7 @@ async function checkCiDocumentationContract(
     expectedComponentLabel: `component '${phaseComponent.id}'`,
   });
   await requireExactReservedSlots({
-    owner: requireDirectFrame(
-      component,
-      CI_NODE_OUTCOME_CONTAINER_NAME,
-      ".ci node"
-    ),
+    owner: outcome,
     expectedNames: ciOutcomeSlotNames(),
     hasNamePrefix: hasCiOutcomeSlotNamePrefix,
     label: "CI outcome",

--- a/repo/figma-documentation-sync/tools/tests/ci-visual-plan.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/ci-visual-plan.test.ts
@@ -62,6 +62,7 @@ test("CI node properties hide runtime when the visual node has no runtime data",
     runtimeStartup: "",
     runtimeIdentity: "",
     showExecutionPlan: false,
+    showOutcome: false,
     showSource: true,
     showRuntime: false,
     showOptionalDetails: true,
@@ -89,6 +90,7 @@ test("CI node properties expose complete runtime data", () => {
     runtimeStartup: "Automatic",
     runtimeIdentity: "NT SERVICE\\TeamCity",
     showExecutionPlan: false,
+    showOutcome: false,
     showSource: true,
     showRuntime: true,
     showOptionalDetails: true,
@@ -121,6 +123,19 @@ test("CI node properties reveal the execution plan when phases exist", () => {
   };
 
   assert.equal(ciNodePropertyValues(node).showExecutionPlan, true);
+});
+
+test("CI node properties reveal outcomes only when results exist", () => {
+  const node = {
+    ...visualNode(),
+    outcomes: [{
+      order: "01",
+      kind: "artifact" as const,
+      title: "Publish CI outcome",
+    }],
+  };
+
+  assert.equal(ciNodePropertyValues(node).showOutcome, true);
 });
 
 test("CI phase properties expose its executable identity", () => {


### PR DESCRIPTION
## What changed

- derive the `show outcome` component property from typed CI outcomes
- validate the outcome frame visibility binding during Figma preflight
- document responsive CI node headers, optional detail boundaries, and the reparenting binding failure mode
- update the Kotlin writer configuration and focused tests

## Why

The `.ci node` master exposes all optional sections by default. The writer already collapsed execution plans, but it did not set `show outcome`. A fresh sync could therefore leave an empty full-width outcome frame visible and expand otherwise compact flow nodes to 1088 px.

## Impact

Future CI documentation syncs keep flow nodes compact when they have no outcomes, while task nodes still expand and their headers follow the visible content width. The Figma master uses the outline token for the 2 px optional-details boundary.

## Validation

- `.\gradlew.bat :figma-documentation-sync:project-config:test --tests "*FigmaWriterProjectConfigJsonTest" testFigmaDocumentationSyncTools checkDocumentation`
- live Figma validation of all visibility bindings, responsive widths, stroke token, and section/header bounds
- `git diff --cached --check`