### PR TITLE
fix(figma-documentation-sync): validate CI node root outline

### DIFF
--- a/docs/ci/visual-model-contract.md
+++ b/docs/ci/visual-model-contract.md
@@ -178,12 +178,13 @@ hidden. The `.ci node` does not expose the obsolete `steps` or `show steps`
 properties; `show steps` belongs only to `.ci phase`, where it controls the
 phase-owned step container.
 
-The `summary` and outer `optional details` frames stretch to the current node
-width. This keeps the header and details boundary aligned with expanded task
-nodes while compact flow nodes remain narrow. `optional details` owns the
-full-width runtime divider and an inside-aligned 2 px stroke bound to
-`md/sys/color/outline`; its nested `details content` frame keeps runtime and
-source text at the compact reading width.
+The `.ci node` root owns exactly one visible, inside-aligned 2 px stroke bound
+to `md/sys/color/outline`. The `summary` and outer `optional details` frames
+stretch to the current node width. This keeps the header and details boundary
+aligned with expanded task nodes while compact flow nodes remain narrow.
+`optional details` owns the full-width runtime divider but no additional
+stroke; its nested `details content` frame keeps runtime and source text at the
+compact reading width.
 
 Use the step variants consistently:
 

--- a/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
@@ -227,10 +227,11 @@ outcome slots, and each phase's `steps` frame owns its exposed step slots.
 `show execution plan` collapses that complete frame when no phases exist,
 `show outcome` collapses the complete result frame when no outcomes exist, and
 `show optional details` collapses the details container when neither child is
-visible. The summary and outer details frames stretch to the width established
-by the visible execution content, so compact nodes remain narrow and task nodes
-receive a matching full-width header. The outer details frame owns the runtime
-divider and the `md/sys/color/outline` 2 px inside stroke; the nested `details
+visible. The `.ci node` root owns exactly one visible 2 px inside stroke bound
+to `md/sys/color/outline`. The summary and outer details frames stretch to the
+width established by the visible execution content, so compact nodes remain
+narrow and task nodes receive a matching full-width header. The outer details
+frame owns the runtime divider but no additional stroke; the nested `details
 content` frame preserves the compact reading width. Action descriptions remain
 in the typed model but are hidden visually; phase, decision, group, and outcome
 descriptions remain visible.

--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -258,6 +258,12 @@ container remains bound to `show optional details`. Validate at least one
 compact instance after the move; checking only the fully expanded master can
 hide a lost binding or a fixed-width child.
 
+If CI preflight reports a `.ci node` outline mismatch, keep exactly one visible
+solid stroke on the root component, bind it to `md/sys/color/outline`, align it
+`INSIDE`, and set its weight to `2`. Remove any stroke from `optional details`
+so expanded and compact instances have one boundary instead of a double
+outline.
+
 If preflight reports missing, duplicated, unexpected, unexposed, or foreign CI
 slots:
 

--- a/repo/figma-documentation-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-node-gateway.ts
@@ -156,13 +156,21 @@ export function sectionStrokeContractSatisfied(section, outlineVariableId) {
   if (hasDirectHeader(section)) {
     return Array.isArray(section.strokes) && section.strokes.length === 0;
   }
-  if (section.strokeAlign !== SECTION_STROKE_ALIGN || section.strokeWeight !== SECTION_STROKE_WEIGHT) {
+
+  return outlineStrokeContractSatisfied(section, outlineVariableId);
+}
+
+export function outlineStrokeContractSatisfied(node, outlineVariableId) {
+  if (node.strokeAlign !== SECTION_STROKE_ALIGN || node.strokeWeight !== SECTION_STROKE_WEIGHT) {
     return false;
   }
-  if (!Array.isArray(section.strokes) || section.strokes.length !== 1) return false;
+  if (!Array.isArray(node.strokes) || node.strokes.length !== 1) return false;
 
-  const stroke = section.strokes[0];
-  return stroke.type === "SOLID" && stroke.boundVariables?.color?.id === outlineVariableId;
+  const stroke = node.strokes[0];
+  return stroke.type === "SOLID" &&
+    stroke.visible !== false &&
+    (stroke.opacity ?? 1) === 1 &&
+    stroke.boundVariables?.color?.id === outlineVariableId;
 }
 
 function applySectionStrokeContract(section, outlineVariable, mutatedNodeIds) {

--- a/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -73,6 +73,7 @@ import {
   requireComponentSet,
   requireFrameOrSection,
   requireModeId,
+  outlineStrokeContractSatisfied,
   requireOutlineColorVariable,
   requirePage,
   requireSection,
@@ -123,6 +124,16 @@ async function checkCiDocumentationContract(
   checkedSections.push(`ciDocumentation:${page.id}`);
 
   const component = await requireComponent(CI_NODE_COMPONENT_ID);
+  const outlineVariable = await requireOutlineColorVariable();
+  if (!outlineStrokeContractSatisfied(component, outlineVariable.id)) {
+    throw new Error(
+      `CI node component '${component.id}' must have exactly one visible solid stroke ` +
+        `bound to '${outlineVariable.name}', aligned inside, with weight 2.`
+    );
+  }
+  if (!checkedVariables.includes(outlineVariable.name)) {
+    checkedVariables.push(outlineVariable.name);
+  }
   requireComponentProperty(component, CI_NODE_PROPS.name, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.description, "TEXT");
   requireComponentProperty(component, CI_NODE_PROPS.executionPlanHeading, "TEXT");

--- a/repo/figma-documentation-sync/tools/tests/version-sync-plan.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/version-sync-plan.test.ts
@@ -4,7 +4,10 @@ import {
   dependencyVersionGridPosition,
   planDependencyVersionInstanceSync,
 } from "../src/figma/figma-version-sync-gateway";
-import { sectionStrokeContractSatisfied } from "../src/figma/figma-node-gateway";
+import {
+  outlineStrokeContractSatisfied,
+  sectionStrokeContractSatisfied,
+} from "../src/figma/figma-node-gateway";
 
 test("version sync removes stale renamed dependency versions and exact duplicates", () => {
   const instances = [
@@ -59,6 +62,42 @@ test("section stroke contract requires the bound outline variable, inside alignm
   assert.equal(sectionStrokeContractSatisfied({ ...compliantSection, strokeWeight: 1 }, "outline-variable"), false);
   assert.equal(sectionStrokeContractSatisfied({ ...compliantSection, strokeAlign: "CENTER" }, "outline-variable"), false);
   assert.equal(sectionStrokeContractSatisfied(compliantSection, "another-variable"), false);
+});
+
+test("outline stroke contract rejects hidden, transparent, or duplicated boundaries", () => {
+  const compliantNode = {
+    strokeAlign: "INSIDE",
+    strokeWeight: 2,
+    strokes: [{
+      type: "SOLID",
+      opacity: 1,
+      visible: true,
+      boundVariables: { color: { id: "outline-variable" } },
+    }],
+  };
+
+  assert.equal(outlineStrokeContractSatisfied(compliantNode, "outline-variable"), true);
+  assert.equal(
+    outlineStrokeContractSatisfied({
+      ...compliantNode,
+      strokes: [{ ...compliantNode.strokes[0], visible: false }],
+    }, "outline-variable"),
+    false
+  );
+  assert.equal(
+    outlineStrokeContractSatisfied({
+      ...compliantNode,
+      strokes: [{ ...compliantNode.strokes[0], opacity: 0 }],
+    }, "outline-variable"),
+    false
+  );
+  assert.equal(
+    outlineStrokeContractSatisfied({
+      ...compliantNode,
+      strokes: [...compliantNode.strokes, ...compliantNode.strokes],
+    }, "outline-variable"),
+    false
+  );
 });
 
 test("parent sections with a direct Header satisfy the contract only without strokes", () => {


### PR DESCRIPTION
## What changed

- require the `.ci node` root to own exactly one visible 2 px inside stroke bound to `md/sys/color/outline`
- reuse the outline validator for managed Figma sections
- add regression coverage for hidden, transparent, and duplicated strokes
- align the CI visual contract and troubleshooting documentation with the component

## Why

The component outline was moved from `optional details` to the `.ci node` root in Figma. The repository contract still described the old ownership and preflight did not verify the new boundary, so a future sync could accept a missing or double outline.

## Impact

Preflight now fails before mutation when the root outline drifts. `optional details` remains responsible only for the runtime divider and compact detail content.

## Validation

- `./gradlew.bat testFigmaDocumentationSyncTools checkDocumentation`
- `./gradlew.bat check`
- `git diff --check`