### PR TITLE
fix(figma-documentation-sync): validate hidden artifact templates

### DIFF
--- a/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
+++ b/repo/figma-documentation-sync/docs/reference/visual-sync-contract.md
@@ -71,7 +71,11 @@ For library catalog items, preflight validates `.artifact`, `.artifacts bundle`,
 and `.tool artifact usage` templates from the target section when present,
 falling back to the base `.tree node` component only when the section has no
 template. This matches the writer behavior: new nodes clone compatible section
-instances before falling back to the base component variant.
+instances before falling back to the base component variant. When an instance
+property hides a required nested template from instance traversal, preflight
+validates that template through the instance's main component. This fallback is
+read-only and must not toggle component properties merely to expose hidden
+slots.
 
 Catalog runners may pass `catalogRootFilters` to sync only one or more
 top-level roots inside a catalog target, for example `androidx` in

--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -192,8 +192,10 @@ the model, the metadata, or the visual sync code.
 
 ## Component Instance Shape
 
-Figma component instances can contain hidden template internals that remain
-addressable through the plugin API. Do not treat exact child counts as a stable
+Figma component instances can contain hidden template internals. Some remain
+addressable through the instance API, while nested content hidden by a boolean
+instance property can disappear from `findAllWithCriteria` even though it is
+present in the main component. Do not treat exact child counts as a stable
 contract for reused instances.
 
 For example, library artifact text updates must allow extra hidden
@@ -212,6 +214,19 @@ inside `.artifacts bundle` and fail with a misleading slot count:
 ```text
 Tree node '...' expected at least 4 '.artifact' instances, found 1.
 ```
+
+Preflight can report a similar false negative when it selects an `.artifact`
+inside `.artifacts bundle` whose `Show configured as tool` property is false:
+
+```text
+Expected '...' to contain a '.tool artifact usage' template instance.
+```
+
+First inspect the `.artifact` main component. If it already contains the
+required `.tool artifact usage` slots and public text property, keep the
+component unchanged and make preflight validate the main component as a
+read-only fallback. Do not mutate the instance property during preflight and do
+not remove the component slots to match a hidden instance.
 
 When deriving a new component set from existing variants, cloning a variant
 preserves its layers but does not recreate the shared component-set property

--- a/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-visual-contract-check-gateway.ts
@@ -567,7 +567,10 @@ async function checkLibraryTemplatesForTarget(section, expectedNodes, checkedCom
     const artifact = await findLibraryTemplateInstance(section, ARTIFACT_INSTANCE_NAME);
     checkArtifactTemplate(artifact, checkedComponents);
     if (requiresToolArtifactUsage) {
-      const toolArtifactUsage = requireNestedInstance(artifact, TOOL_ARTIFACT_USAGE_INSTANCE_NAME);
+      const toolArtifactUsage = await requireNestedTemplateInstance(
+        artifact,
+        TOOL_ARTIFACT_USAGE_INSTANCE_NAME
+      );
       requireComponentProperty(toolArtifactUsage, TOOL_ARTIFACT_USAGE_PROPS.target, "TEXT");
       checkedComponents.push(`${TOOL_ARTIFACT_USAGE_INSTANCE_NAME}:${toolArtifactUsage.id}`);
     }
@@ -658,6 +661,41 @@ function requireNestedInstance(root: any, instanceName: string) {
     throw new Error(`Expected '${root.id}' to contain a '${instanceName}' template instance.`);
   }
   return instance;
+}
+
+export async function requireNestedTemplateInstance(
+  root: any,
+  instanceName: string
+) {
+  const instance = findNestedInstance(
+    root,
+    instanceName
+  );
+  if (instance) return instance;
+
+  const mainComponent = root.type === "INSTANCE"
+    ? await root.getMainComponentAsync()
+    : null;
+  const componentTemplate = mainComponent
+    ? findNestedInstance(
+        mainComponent,
+        instanceName
+      )
+    : null;
+  if (componentTemplate) return componentTemplate;
+
+  throw new Error(
+    `Expected '${root.id}' or its main component to contain a ` +
+      `'${instanceName}' template instance.`
+  );
+}
+
+function findNestedInstance(
+  root: any,
+  instanceName: string
+) {
+  return root.findAllWithCriteria({ types: ["INSTANCE"] })
+    .find((candidate) => candidate.name === instanceName);
 }
 
 function requireComponentProperty(node: any, propertyName: string, propertyType: string) {

--- a/repo/figma-documentation-sync/tools/tests/library-catalog-entries.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/library-catalog-entries.test.ts
@@ -4,6 +4,28 @@ import {
   libraryArtifacts,
   libraryBundles,
 } from "../src/domain/catalog/library-catalog-entries";
+import { requireNestedTemplateInstance } from "../src/figma/figma-visual-contract-check-gateway";
+
+test("preflight validates hidden templates through an instance main component", async () => {
+  const expected = { id: "tool-usage", name: ".tool artifact usage" };
+  const mainComponent = {
+    findAllWithCriteria: () => [expected],
+  };
+  const hiddenArtifactInstance = {
+    id: "artifact-instance",
+    type: "INSTANCE",
+    findAllWithCriteria: () => [],
+    getMainComponentAsync: async () => mainComponent,
+  };
+
+  assert.equal(
+    await requireNestedTemplateInstance(
+      hiddenArtifactInstance,
+      ".tool artifact usage"
+    ),
+    expected
+  );
+});
 
 test("bundle entries keep artifacts inside the bundle instead of exposing direct artifacts", () => {
   const entries = [


### PR DESCRIPTION
## What changed

- make visual preflight resolve required nested template slots through an artifact instance's main component when instance properties hide them from traversal
- keep the direct instance path as the first choice
- add an executable regression test for a hidden bundled artifact
- document the read-only fallback and its troubleshooting signature

## Why

The canonical visual preflight selected an `.artifact` nested inside `.artifacts bundle`. Its `Show configured as tool=false` override caused Figma to omit hidden `.tool artifact usage` descendants from `findAllWithCriteria`, even though the correct slots exist in the `.artifact` main component.

The preflight therefore failed with a false missing-template error. The component itself is valid and did not need mutation.

## Impact

Preflight remains non-mutating and now validates the reusable component contract rather than toggling instance visibility. Genuine missing slots still fail before visual targets or metadata.

## Verification

- `.\gradlew.bat testFigmaDocumentationSyncTools buildFigmaDocumentationSyncTools checkDocumentation --stacktrace`
- `.\gradlew.bat check --stacktrace`
- live Figma inspection confirmed component `63069:700` owns the required `.tool artifact usage` slots