### PR TITLE
fix(figma-documentation-sync): refresh tree instances before nested writes

### DIFF
--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -228,6 +228,19 @@ component unchanged and make preflight validate the main component as a
 read-only fallback. Do not mutate the instance property during preflight and do
 not remove the component slots to match a hidden instance.
 
+A catalog write can instead fail immediately after updating the parent
+`.tree node` properties, even though a separate read of the same bundle finds
+all expected artifacts:
+
+```text
+Bundle '...' expected at least 4 '.artifact' instances, found 0.
+```
+
+This indicates a stale Plugin API instance reference, not a missing component
+slot. Reacquire the `.tree node` by ID after `setProperties` and only then walk
+or mutate its nested `.artifact` and `.artifacts bundle` instances. Do not add
+component properties or retry the same canonical runner to mask this failure.
+
 When deriving a new component set from existing variants, cloning a variant
 preserves its layers but does not recreate the shared component-set property
 contract reliably. Create the shared properties on the new set, wire every

--- a/repo/figma-documentation-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-node-gateway.ts
@@ -74,6 +74,17 @@ export async function requireConnector(nodeId) {
   return node;
 }
 
+export async function requireFreshInstance(
+  instance,
+  resolveNode = (nodeId) => figma.getNodeByIdAsync(nodeId)
+) {
+  const node = await resolveNode(instance.id);
+  if (!node || node.type !== "INSTANCE") {
+    throw new Error(`Expected '${instance.id}' to remain an INSTANCE after updating its component properties.`);
+  }
+  return node;
+}
+
 export async function requireFrame(nodeId) {
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node || node.type !== "FRAME") {

--- a/repo/figma-documentation-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -4,7 +4,11 @@ import {
 } from "@figma-documentation-sync/project-config";
 import { updateLibraryArtifactConsumerModules, updateLibraryBundleConsumerModules, updatePluginUsageBlocks } from "./figma-consumer-modules-gateway";
 import type { FlattenedCatalogNode } from "../domain/design-model";
-import { getComponentPropertyValue, requireTreeNodeComponent } from "./figma-node-gateway";
+import {
+  getComponentPropertyValue,
+  requireFreshInstance,
+  requireTreeNodeComponent,
+} from "./figma-node-gateway";
 import {
   libraryArtifacts,
   libraryBundles,
@@ -88,15 +92,17 @@ export async function updateLibraryTreeNode(instance, node, mutatedNodeIds) {
   });
   mutatedNodeIds.push(instance.id);
 
-  await updateNamedTextNodes(instance, "Library group", [node.label], mutatedNodeIds);
-  await updateLibraryArtifactConsumerModules(instance, artifacts, mutatedNodeIds);
-  await updateLibraryBundleConsumerModules(instance, bundles, mutatedNodeIds);
+  const refreshedInstance = await requireFreshInstance(instance);
+
+  await updateNamedTextNodes(refreshedInstance, "Library group", [node.label], mutatedNodeIds);
+  await updateLibraryArtifactConsumerModules(refreshedInstance, artifacts, mutatedNodeIds);
+  await updateLibraryBundleConsumerModules(refreshedInstance, bundles, mutatedNodeIds);
 
   if (!hasVisibleCatalogItems && requiredByModules.length === 0 && !hasCatalogEntries) {
-    resizeBareTreeNodeToFitLabel(instance, "Library group", mutatedNodeIds);
+    resizeBareTreeNodeToFitLabel(refreshedInstance, "Library group", mutatedNodeIds);
   }
 
-  restoreTreeNodeHorizontalCenter(instance, horizontalCenter, mutatedNodeIds);
+  restoreTreeNodeHorizontalCenter(refreshedInstance, horizontalCenter, mutatedNodeIds);
 }
 
 export async function updatePluginTreeNode(instance, node, mutatedNodeIds, target?) {
@@ -125,8 +131,10 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
   });
   mutatedNodeIds.push(instance.id);
 
+  const refreshedInstance = await requireFreshInstance(instance);
+
   await updatePluginUsageBlocks(
-    instance,
+    refreshedInstance,
     effectiveAppliedToModules,
     providedByConventionPlugins,
     showUnusedPluginWarning,
@@ -139,10 +147,10 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     !showGradlePluginBadge &&
     !hasVisiblePluginVersion(node)
   ) {
-    resizeBareTreeNodeToFitLabel(instance, "Plugin ID", mutatedNodeIds);
+    resizeBareTreeNodeToFitLabel(refreshedInstance, "Plugin ID", mutatedNodeIds);
   }
 
-  restoreTreeNodeHorizontalCenter(instance, horizontalCenter, mutatedNodeIds);
+  restoreTreeNodeHorizontalCenter(refreshedInstance, horizontalCenter, mutatedNodeIds);
 }
 
 function hasVisiblePluginVersion(node: FlattenedCatalogNode) {

--- a/repo/figma-documentation-sync/tools/tests/library-catalog-entries.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/library-catalog-entries.test.ts
@@ -5,6 +5,30 @@ import {
   libraryBundles,
 } from "../src/domain/catalog/library-catalog-entries";
 import { requireNestedTemplateInstance } from "../src/figma/figma-visual-contract-check-gateway";
+import { requireFreshInstance } from "../src/figma/figma-node-gateway";
+
+test("tree node writers reacquire instances after component property updates", async () => {
+  const staleInstance = {
+    id: "tree-node-instance",
+    type: "INSTANCE",
+    findAllWithCriteria: () => [],
+  };
+  const refreshedInstance = {
+    id: "tree-node-instance",
+    type: "INSTANCE",
+    findAllWithCriteria: () => [
+      { id: "bundle-artifact", name: ".artifact" },
+    ],
+  };
+
+  assert.equal(
+    await requireFreshInstance(
+      staleInstance,
+      async () => refreshedInstance
+    ),
+    refreshedInstance
+  );
+});
 
 test("preflight validates hidden templates through an instance main component", async () => {
   const expected = { id: "tool-usage", name: ".tool artifact usage" };


### PR DESCRIPTION
## Summary

- reacquire `.tree node` instances after component-property writes
- use refreshed instances for nested artifact, bundle, and plugin updates
- document the stale Plugin API reference failure and add regression coverage

## Verification

- `./gradlew.bat testFigmaDocumentationSyncTools buildFigmaDocumentationSyncTools checkDocumentation`
- `./gradlew.bat check`

This unblocks the canonical Figma sync that switches CI flows to `simple-line_arrow`.