### PR TITLE
fix(figma-documentation-sync): preserve bundled artifact rows

### DIFF
--- a/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
+++ b/repo/figma-documentation-sync/docs/runbooks/troubleshooting.md
@@ -228,18 +228,19 @@ component unchanged and make preflight validate the main component as a
 read-only fallback. Do not mutate the instance property during preflight and do
 not remove the component slots to match a hidden instance.
 
-A catalog write can instead fail immediately after updating the parent
-`.tree node` properties, even though a separate read of the same bundle finds
-all expected artifacts:
+A bundle-only catalog node can fail during its write even though a separate
+read of the same bundle finds all expected artifacts:
 
 ```text
 Bundle '...' expected at least 4 '.artifact' instances, found 0.
 ```
 
-This indicates a stale Plugin API instance reference, not a missing component
-slot. Reacquire the `.tree node` by ID after `setProperties` and only then walk
-or mutate its nested `.artifact` and `.artifacts bundle` instances. Do not add
-component properties or retry the same canonical runner to mask this failure.
+This happens when the direct-artifact fallback selects descendant `.artifact`
+rows owned by `.artifacts bundle` and hides them as unused before the bundle
+writer runs. Direct artifact selection must exclude every candidate with an
+`.artifacts bundle` ancestor inside the `.tree node`; the bundle writer remains
+responsible for those nested rows. Do not add component properties or retry the
+same canonical runner to mask this failure.
 
 When deriving a new component set from existing variants, cloning a variant
 preserves its layers but does not recreate the shared component-set property

--- a/repo/figma-documentation-sync/tools/src/figma/figma-consumer-modules-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-consumer-modules-gateway.ts
@@ -530,7 +530,7 @@ function childrenOf(node) {
   return "children" in node ? [...node.children] : [];
 }
 
-function directCatalogItemInstances(root, instanceName) {
+export function directCatalogItemInstances(root, instanceName) {
   const container = childrenOf(root)
     .find((child) => child.name === "artifacts" && "children" in child);
   const directInstances = childrenOf(container || root)
@@ -539,7 +539,11 @@ function directCatalogItemInstances(root, instanceName) {
   if (directInstances.length > 0) return directInstances;
 
   return root.findAllWithCriteria({ types: ["INSTANCE"] })
-    .filter((candidate) => candidate.name === instanceName);
+    .filter((candidate) => candidate.name === instanceName)
+    .filter((candidate) =>
+      instanceName !== ARTIFACT_INSTANCE_NAME ||
+      !hasAncestorInstanceNamed(candidate, ARTIFACTS_BUNDLE_INSTANCE_NAME, root)
+    );
 }
 
 function isExcludedByOptions(node, root, options: ConsumerModuleOptions = {}) {

--- a/repo/figma-documentation-sync/tools/src/figma/figma-node-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-node-gateway.ts
@@ -74,17 +74,6 @@ export async function requireConnector(nodeId) {
   return node;
 }
 
-export async function requireFreshInstance(
-  instance,
-  resolveNode = (nodeId) => figma.getNodeByIdAsync(nodeId)
-) {
-  const node = await resolveNode(instance.id);
-  if (!node || node.type !== "INSTANCE") {
-    throw new Error(`Expected '${instance.id}' to remain an INSTANCE after updating its component properties.`);
-  }
-  return node;
-}
-
 export async function requireFrame(nodeId) {
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node || node.type !== "FRAME") {

--- a/repo/figma-documentation-sync/tools/src/figma/figma-tree-node-gateway.ts
+++ b/repo/figma-documentation-sync/tools/src/figma/figma-tree-node-gateway.ts
@@ -4,11 +4,7 @@ import {
 } from "@figma-documentation-sync/project-config";
 import { updateLibraryArtifactConsumerModules, updateLibraryBundleConsumerModules, updatePluginUsageBlocks } from "./figma-consumer-modules-gateway";
 import type { FlattenedCatalogNode } from "../domain/design-model";
-import {
-  getComponentPropertyValue,
-  requireFreshInstance,
-  requireTreeNodeComponent,
-} from "./figma-node-gateway";
+import { getComponentPropertyValue, requireTreeNodeComponent } from "./figma-node-gateway";
 import {
   libraryArtifacts,
   libraryBundles,
@@ -92,17 +88,15 @@ export async function updateLibraryTreeNode(instance, node, mutatedNodeIds) {
   });
   mutatedNodeIds.push(instance.id);
 
-  const refreshedInstance = await requireFreshInstance(instance);
-
-  await updateNamedTextNodes(refreshedInstance, "Library group", [node.label], mutatedNodeIds);
-  await updateLibraryArtifactConsumerModules(refreshedInstance, artifacts, mutatedNodeIds);
-  await updateLibraryBundleConsumerModules(refreshedInstance, bundles, mutatedNodeIds);
+  await updateNamedTextNodes(instance, "Library group", [node.label], mutatedNodeIds);
+  await updateLibraryArtifactConsumerModules(instance, artifacts, mutatedNodeIds);
+  await updateLibraryBundleConsumerModules(instance, bundles, mutatedNodeIds);
 
   if (!hasVisibleCatalogItems && requiredByModules.length === 0 && !hasCatalogEntries) {
-    resizeBareTreeNodeToFitLabel(refreshedInstance, "Library group", mutatedNodeIds);
+    resizeBareTreeNodeToFitLabel(instance, "Library group", mutatedNodeIds);
   }
 
-  restoreTreeNodeHorizontalCenter(refreshedInstance, horizontalCenter, mutatedNodeIds);
+  restoreTreeNodeHorizontalCenter(instance, horizontalCenter, mutatedNodeIds);
 }
 
 export async function updatePluginTreeNode(instance, node, mutatedNodeIds, target?) {
@@ -131,10 +125,8 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
   });
   mutatedNodeIds.push(instance.id);
 
-  const refreshedInstance = await requireFreshInstance(instance);
-
   await updatePluginUsageBlocks(
-    refreshedInstance,
+    instance,
     effectiveAppliedToModules,
     providedByConventionPlugins,
     showUnusedPluginWarning,
@@ -147,10 +139,10 @@ export async function updatePluginTreeNode(instance, node, mutatedNodeIds, targe
     !showGradlePluginBadge &&
     !hasVisiblePluginVersion(node)
   ) {
-    resizeBareTreeNodeToFitLabel(refreshedInstance, "Plugin ID", mutatedNodeIds);
+    resizeBareTreeNodeToFitLabel(instance, "Plugin ID", mutatedNodeIds);
   }
 
-  restoreTreeNodeHorizontalCenter(refreshedInstance, horizontalCenter, mutatedNodeIds);
+  restoreTreeNodeHorizontalCenter(instance, horizontalCenter, mutatedNodeIds);
 }
 
 function hasVisiblePluginVersion(node: FlattenedCatalogNode) {

--- a/repo/figma-documentation-sync/tools/tests/library-catalog-entries.test.ts
+++ b/repo/figma-documentation-sync/tools/tests/library-catalog-entries.test.ts
@@ -4,29 +4,40 @@ import {
   libraryArtifacts,
   libraryBundles,
 } from "../src/domain/catalog/library-catalog-entries";
+import { directCatalogItemInstances } from "../src/figma/figma-consumer-modules-gateway";
 import { requireNestedTemplateInstance } from "../src/figma/figma-visual-contract-check-gateway";
-import { requireFreshInstance } from "../src/figma/figma-node-gateway";
 
-test("tree node writers reacquire instances after component property updates", async () => {
-  const staleInstance = {
-    id: "tree-node-instance",
-    type: "INSTANCE",
-    findAllWithCriteria: () => [],
-  };
-  const refreshedInstance = {
-    id: "tree-node-instance",
-    type: "INSTANCE",
-    findAllWithCriteria: () => [
-      { id: "bundle-artifact", name: ".artifact" },
+test("direct artifact selection excludes rows owned by an artifacts bundle", () => {
+  const root = {
+    id: "tree-node",
+    children: [
+      {
+        id: "artifacts-container",
+        name: "artifacts",
+        children: [],
+      },
     ],
   };
+  const bundle = {
+    id: "bundle",
+    type: "INSTANCE",
+    name: ".artifacts bundle",
+    parent: root,
+  };
+  const nestedArtifact = {
+    id: "bundle-artifact",
+    type: "INSTANCE",
+    name: ".artifact",
+    parent: bundle,
+  };
+  root.findAllWithCriteria = () => [bundle, nestedArtifact];
 
-  assert.equal(
-    await requireFreshInstance(
-      staleInstance,
-      async () => refreshedInstance
+  assert.deepEqual(
+    directCatalogItemInstances(
+      root,
+      ".artifact"
     ),
-    refreshedInstance
+    []
   );
 });
 


### PR DESCRIPTION
## Summary

- exclude `.artifact` rows owned by `.artifacts bundle` from direct tree-node fallback selection
- remove the disproven instance-refresh workaround
- document the verified bundle-only failure mechanism and add regression coverage

## Verification

- Figma clone POC: 0 direct artifacts selected, 4 bundle artifacts preserved, clone removed
- `./gradlew.bat testFigmaDocumentationSyncTools buildFigmaDocumentationSyncTools checkDocumentation`
- `./gradlew.bat check`

This unblocks the canonical visual sync for the `simple-line_arrow` CI connector migration.